### PR TITLE
RDFA-337: Clear reset for package editor

### DIFF
--- a/frontend/src/lib/models/reactive/mapper/map-reactive-object-to-dto.js
+++ b/frontend/src/lib/models/reactive/mapper/map-reactive-object-to-dto.js
@@ -19,6 +19,7 @@ import { ReactiveAttribute } from "$lib/models/reactive/reactive-attribute.svelt
 import { ReactiveClass } from "$lib/models/reactive/reactive-class.svelte.js";
 import { ReactiveEnumEntry } from "$lib/models/reactive/reactive-enum-entry.svelte.js";
 import { ReactiveNamespace } from "$lib/models/reactive/reactive-namespace.svelte.js";
+import { ReactivePackage } from "$lib/models/reactive/reactive-package.svelte.js";
 
 /**
  * Maps a ReactiveClass to a class DTO for API submission
@@ -264,6 +265,23 @@ export function mapReactiveNamespaceToNamespaceDto(namespace) {
     return {
         prefix: namespace.iri,
         substitutedPrefix: namespace.prefix,
+    };
+}
+
+/**
+ * Maps a ReactivePackage to a package DTO for API submission
+ * @param {ReactivePackage | Object} pkg - The reactive package instance or a plain object of it
+ * @returns {Object} The package DTO
+ */
+export function mapReactivePackageToPackageDto(pkg) {
+    if (pkg instanceof ReactivePackage) {
+        pkg = pkg.getPlainObject();
+    }
+    return {
+        uuid: pkg.uuid,
+        prefix: pkg.namespace,
+        label: pkg.label,
+        comment: pkg.comment ?? null,
     };
 }
 

--- a/frontend/src/lib/models/reactive/reactive-package.svelte.js
+++ b/frontend/src/lib/models/reactive/reactive-package.svelte.js
@@ -1,0 +1,136 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { ReactiveValueWrapper } from "$lib/models/reactive/reactive-wrappers/reactive-value-wrapper.svelte.js";
+import {
+    isInvalidLabel,
+    isInvalidNamespace,
+    isInvalidUuid,
+} from "$lib/models/reactive/validity-rules/validityFunctions.js";
+
+export class ReactivePackage {
+    constructor({
+        uuid = null,
+        label = "",
+        namespace = "",
+        comment = null,
+    } = {}) {
+        this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
+        this.label = new ReactiveValueWrapper(label, isInvalidLabel);
+        this.namespace = new ReactiveValueWrapper(
+            namespace,
+            isInvalidNamespace,
+        );
+        this.comment = new ReactiveValueWrapper(comment);
+    }
+
+    /**
+     * The unique identifier of this package
+     * @type {ReactiveValueWrapper<string | null>}
+     */
+    uuid;
+
+    /**
+     * The label/name of this package
+     * @type {ReactiveValueWrapper<string>}
+     */
+    label;
+
+    /**
+     * The namespace (URI prefix) of this package
+     * @type {ReactiveValueWrapper<string>}
+     */
+    namespace;
+
+    /**
+     * A comment describing this package
+     * @type {ReactiveValueWrapper<string | null>}
+     */
+    comment;
+
+    // noinspection JSUnresolvedFunction
+    /**
+     * Indicates whether this package has changes
+     * @type {boolean}
+     */
+    isModified = $derived(
+        this.uuid.isModified ||
+            this.label.isModified ||
+            this.namespace.isModified ||
+            this.comment.isModified,
+    );
+
+    // noinspection JSUnresolvedFunction
+    /**
+     * Indicates whether this package is valid
+     * @type {boolean}
+     */
+    isValid = $derived(
+        this.uuid.isValid &&
+            this.label.isValid &&
+            this.namespace.isValid &&
+            this.comment.isValid,
+    );
+
+    /**
+     * Resets this package to its initial values
+     */
+    reset() {
+        this.uuid.reset();
+        this.label.reset();
+        this.namespace.reset();
+        this.comment.reset();
+    }
+
+    /**
+     * Applies changes made to this package as the new baseline
+     */
+    save() {
+        this.uuid.save();
+        this.label.save();
+        this.namespace.save();
+        this.comment.save();
+    }
+
+    /**
+     * Checks if this package is equal to another package
+     * @param {ReactivePackage} other - The other package to compare to
+     * @returns {boolean} True if the packages are equal
+     */
+    equals(other) {
+        // not checking uuid as two different packages with same properties should be considered equal
+        return (
+            !!other &&
+            this.label.equals(other.label) &&
+            this.namespace.equals(other.namespace) &&
+            this.comment.equals(other.comment)
+        );
+    }
+
+    /**
+     * Converts this package to a plain object
+     * @returns {Object} Plain object representation of this package
+     */
+    getPlainObject() {
+        return {
+            uuid: this.uuid.getPlainObject(),
+            label: this.label.getPlainObject(),
+            namespace: this.namespace.getPlainObject(),
+            comment: this.comment.getPlainObject(),
+        };
+    }
+}

--- a/frontend/src/routes/layout/menu-bar/Edit.svelte
+++ b/frontend/src/routes/layout/menu-bar/Edit.svelte
@@ -70,6 +70,7 @@
     let packageDialogGraph = $state(null);
     let selectedPackageDetails = $state(null);
     let packageDetailsRequestId = 0;
+    let packages = $state([]);
 
     let ontology = $state();
 
@@ -101,7 +102,8 @@
         editorState.selectedDataset.subscribe();
         forceReloadTrigger.subscribe();
         ontology = await getOntology();
-        await refreshSelectedPackageDetails();
+        packages = await getPackages();
+        await refreshSelectedPackageDetails(packages);
     });
 
     async function getOntology() {
@@ -155,7 +157,30 @@
         showPackageDeleteDialog = true;
     }
 
-    async function refreshSelectedPackageDetails() {
+    async function getPackages() {
+        if (!hasGraphSelected) {
+            return [];
+        }
+        try {
+            const response = await bec.getPackages(
+                selectedDataset,
+                selectedGraph,
+            );
+            if (!response.ok) {
+                throw new Error("Failed to fetch packages");
+            }
+            const packagesJSON = await response.json();
+            return [
+                ...(packagesJSON.internalPackageList ?? []),
+                ...(packagesJSON.externalPackageList ?? []),
+            ];
+        } catch (error) {
+            console.error("Failed to fetch packages", error);
+            return [];
+        }
+    }
+
+    async function refreshSelectedPackageDetails(packages) {
         const datasetName = editorState.selectedDataset.getValue();
         const graphURI = editorState.selectedGraph.getValue();
         const packageId = editorState.selectedPackageUUID.getValue();
@@ -173,16 +198,7 @@
         const requestId = ++packageDetailsRequestId;
 
         try {
-            const response = await bec.getPackages(datasetName, graphURI);
-            if (!response.ok) {
-                throw new Error("Failed to fetch packages");
-            }
-            const packagesJSON = await response.json();
-            const candidates = [
-                ...(packagesJSON.internalPackageList ?? []),
-                ...(packagesJSON.externalPackageList ?? []),
-            ];
-            const match = candidates.find(pkg => pkg?.uuid === packageId);
+            const match = packages.find(pkg => pkg?.uuid === packageId);
             if (requestId === packageDetailsRequestId) {
                 selectedPackageDetails = match ?? null;
                 if (!match) {
@@ -355,6 +371,7 @@
         bind:showDialog={showPackageEditorDialog}
         datasetName={packageDialogDataset}
         graphUri={packageDialogGraph}
+        {packages}
         pack={packageDialogTarget}
         readonly={isDatasetReadOnly}
     />

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
@@ -150,7 +150,7 @@
             />
             <ViolationMessages violations={attribute.datatype.violations} />
 
-            <!--MULTIPLICITIY-->
+            <!--MULTIPLICITY-->
             <NumberInputControl
                 label="Multiplicity LowerBound:"
                 placeholder="multiplicity LowerBound..."

--- a/frontend/src/routes/mainpage/packageEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/packageEditorDialog.svelte
@@ -75,31 +75,20 @@
         }
 
         const apiPackage = mapReactivePackageToPackageDto(pkg);
+        const res = await bec.putPackage(datasetName, graphUri, apiPackage);
 
-        let saveCall;
-        if (isNewPackage) {
-            saveCall = bec.postPackage(datasetName, graphUri, apiPackage);
+        if (res.ok) {
+            console.log("Successfully saved package");
+            pkg.save();
+            editorState.selectedClassUUID.trigger();
+            editorState.selectedPackageUUID.trigger();
+            forceReloadTrigger.trigger();
         } else {
-            saveCall = bec.putPackage(datasetName, graphUri, apiPackage);
+            const errorText = await res.text();
+            console.error("Could not save package:", errorText);
         }
 
-        return saveCall
-            .then(async res => {
-                if (res.ok) {
-                    const packageUUID = await res.json();
-                    console.log("Successfully saved package:", packageUUID);
-                    pkg.save();
-                } else {
-                    const errorText = await res.text();
-                    console.error("Could not save package:", errorText);
-                }
-                return res;
-            })
-            .finally(() => {
-                editorState.selectedClassUUID.trigger();
-                editorState.selectedPackageUUID.trigger();
-                forceReloadTrigger.trigger();
-            });
+        return res;
     }
 </script>
 

--- a/frontend/src/routes/mainpage/packageEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/packageEditorDialog.svelte
@@ -34,6 +34,7 @@
 
     let {
         showDialog = $bindable(),
+        packages = [],
         pack,
         readonly = false,
         datasetName = null,
@@ -64,6 +65,16 @@
             isNewPackage = true;
             pkg = new ReactivePackage();
         }
+        pkg.label.violationChecks.push(value => {
+            if (
+                packages.some(
+                    p => p.label === value && p.uuid !== pkg.uuid.value,
+                )
+            ) {
+                return ["must be unique"];
+            }
+            return [];
+        });
         if (!readonly && datasetName) {
             namespaces = await getNamespaces(datasetName);
         }

--- a/frontend/src/routes/mainpage/packageEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/packageEditorDialog.svelte
@@ -14,15 +14,17 @@
   -    limitations under the License.
   -
   -->
-
 <script>
     import { BackendConnection } from "$lib/api/backend.js";
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import TextAreaControl from "$lib/components/TextAreaControl.svelte";
     import TextEditControl from "$lib/components/TextEditControl.svelte";
+    import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ModifyDataDialog from "$lib/dialog/ModifyDataDialog.svelte";
-    import { Package } from "$lib/models/dto";
+    import { mapReactivePackageToPackageDto } from "$lib/models/reactive/mapper/map-reactive-object-to-dto.js";
+    import { ReactivePackage } from "$lib/models/reactive/reactive-package.svelte.js";
+    import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
     import {
         editorState,
         forceReloadTrigger,
@@ -39,87 +41,31 @@
     } = $props();
 
     const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
-    // modeled after the PackageObject, because Classes are not reactive
-    let modifiedPackage = $state({
-        uuid: "",
-        prefix: "",
-        label: "",
-        comment: "",
-        external: false,
-    });
 
+    let pkg = $state(null);
+    let isNewPackage = $state(true);
     let namespaces = $state([]);
-    let resolvedPack = $state(null);
 
-    const originalPackage = $derived(
-        resolvedPack || pack ? new Package(resolvedPack ?? pack) : null,
-    );
-
-    let hasUnsavedChanges = $derived(
-        originalPackage
-            ? !new Package({
-                  ...originalPackage,
-                  comment: normalizeOptionalComment(originalPackage.comment),
-              }).equals(
-                  new Package({
-                      ...modifiedPackage,
-                      comment: normalizeOptionalComment(
-                          modifiedPackage.comment,
-                      ),
-                  }),
-              )
-            : false,
-    );
-    //disable if required properties are not set
-    let disableSubmit = $derived(
-        !modifiedPackage.label || !modifiedPackage.prefix,
-    );
-
-    function normalizeOptionalComment(value) {
-        return value === "" ? null : value;
+    function getSubstitutedNamespace(namespace) {
+        const namespaceObj = namespaces.find(n => n.prefix === namespace);
+        return namespaceObj ? namespaceObj.substitutedPrefix : namespace;
     }
 
     async function onOpen() {
-        if (!pack || !datasetName || !graphUri) {
-            return;
+        if (pack) {
+            isNewPackage = false;
+            pkg = new ReactivePackage({
+                uuid: pack.uuid,
+                label: pack.label,
+                namespace: pack.prefix,
+                comment: pack.comment,
+            });
+        } else {
+            isNewPackage = true;
+            pkg = new ReactivePackage();
         }
-        resolvedPack = null;
-        resolvedPack = await resolveCurrentPackage();
-        const packageToEdit = new Package(resolvedPack ?? pack);
-        modifiedPackage = {
-            uuid: packageToEdit.uuid,
-            prefix: packageToEdit.prefix,
-            label: packageToEdit.label,
-            comment: packageToEdit.comment,
-            external: packageToEdit.external,
-        };
-        if (!readonly) {
+        if (!readonly && datasetName) {
             namespaces = await getNamespaces(datasetName);
-        }
-    }
-
-    async function resolveCurrentPackage() {
-        if (!pack?.uuid) {
-            return pack;
-        }
-
-        if (!datasetName || !graphUri) {
-            return pack;
-        }
-
-        try {
-            const response = await bec.getPackages(datasetName, graphUri);
-            if (!response.ok) {
-                return pack;
-            }
-            const packageJson = await response.json();
-            const allPackages = [
-                ...(packageJson.internalPackageList ?? []),
-                ...(packageJson.externalPackageList ?? []),
-            ];
-            return allPackages.find(p => p?.uuid === pack.uuid) ?? pack;
-        } catch {
-            return pack;
         }
     }
 
@@ -127,62 +73,85 @@
         if (!datasetName || !graphUri) {
             return;
         }
-        const response = await bec.putPackage(datasetName, graphUri, {
-            ...modifiedPackage,
-            comment: normalizeOptionalComment(modifiedPackage.comment),
-        });
-        if (!response.ok) {
-            return;
+
+        const apiPackage = mapReactivePackageToPackageDto(pkg);
+
+        let saveCall;
+        if (isNewPackage) {
+            saveCall = bec.postPackage(datasetName, graphUri, apiPackage);
+        } else {
+            saveCall = bec.putPackage(datasetName, graphUri, apiPackage);
         }
-        editorState.selectedPackageUUID.trigger();
-        editorState.selectedClassUUID.trigger();
-        forceReloadTrigger.trigger();
-    }
 
-    function onClose() {
-        resolvedPack = null;
-    }
-
-    function getSubstitutedNamespace(namespace) {
-        const namespaceObj = namespaces.find(p => p.prefix === namespace);
-        return namespaceObj ? namespaceObj.substitutedPrefix : namespace;
+        return saveCall
+            .then(async res => {
+                if (res.ok) {
+                    const packageUUID = await res.json();
+                    console.log("Successfully saved package:", packageUUID);
+                    pkg.save();
+                } else {
+                    const errorText = await res.text();
+                    console.error("Could not save package:", errorText);
+                }
+                return res;
+            })
+            .finally(() => {
+                editorState.selectedClassUUID.trigger();
+                editorState.selectedPackageUUID.trigger();
+                forceReloadTrigger.trigger();
+            });
     }
 </script>
 
 <ModifyDataDialog
     bind:showDialog
     {onOpen}
-    {onClose}
     saveChanges={savePackage}
-    hasChanges={hasUnsavedChanges}
-    isValid={!disableSubmit}
+    discardChanges={() => pkg.reset()}
+    hasChanges={isNewPackage || pkg?.isModified}
+    isValid={pkg?.isValid}
     {readonly}
 >
-    {#if pack}
+    {#if pkg}
         <div class="mx-2 flex h-full flex-col">
             <span class="mb-2 text-lg">
-                {#if readonly}
-                    Viewing package <b>{originalPackage.label}</b>
+                {#if isNewPackage}
+                    Creating new package
+                {:else if readonly}
+                    Viewing package <b>{pkg.label.backup}</b>
                 {:else}
-                    Editing package <b>{originalPackage.label}</b>
+                    Editing package <b>{pkg.label.backup}</b>
                 {/if}
             </span>
 
             <span class="mb-1 font-semibold">UUID:</span>
-            <p class="mb-2 w-full">{originalPackage.uuid}</p>
+            <p class="mb-2 w-full">
+                {#if pkg.uuid.value}
+                    {pkg.uuid.value}
+                {:else}
+                    not yet assigned
+                {/if}
+            </p>
 
-            <!--LABEL-->
+            <!-- LABEL -->
             <TextEditControl
                 label="Label:"
-                bind:value={modifiedPackage.label}
                 placeholder="package label..."
+                bind:value={pkg.label.value}
+                highlight={pkg.label.isModified}
+                warn={!pkg.label.isValid}
                 {readonly}
+                buttons={getControlButtonsForReactiveObject(
+                    pkg.label,
+                    readonly,
+                )}
             />
+            <ViolationMessages violations={pkg.label.violations} />
 
-            <!--URI PREFIX-->
+            <!-- NAMESPACE -->
             <SearchableSelect
-                label="URI Prefix:"
-                value={getSubstitutedNamespace(modifiedPackage.prefix)}
+                label="Namespace:"
+                value={getSubstitutedNamespace(pkg.namespace.value)}
                 optionObjectList={namespaces}
                 accessDisplayData={namespace =>
                     getSubstitutedNamespace(namespace.prefix)}
@@ -192,19 +161,35 @@
                     namespace.prefix +
                     ") "}
                 callOnValidChange={newNamespace =>
-                    (modifiedPackage.prefix = newNamespace
+                    (pkg.namespace.value = newNamespace
                         ? newNamespace.prefix
                         : null)}
+                highlight={pkg.namespace.isModified}
+                warn={!pkg.namespace.isValid}
                 {readonly}
+                buttons={getControlButtonsForReactiveObject(
+                    pkg.namespace,
+                    readonly,
+                )}
+                tooltip={pkg.namespace.value}
             />
-            <!--COMMENT-->
+            <ViolationMessages violations={pkg.namespace.violations} />
+
+            <!-- COMMENT -->
             <label for="package-edit-dialog-comment-text-area">Comment:</label>
             <TextAreaControl
                 id="package-edit-dialog-comment-text-area"
-                bind:value={modifiedPackage.comment}
-                placeholder="package comment..."
+                placeholder="comment..."
+                bind:value={pkg.comment.value}
+                highlight={pkg.comment.isModified}
+                warn={!pkg.comment.isValid}
                 {readonly}
+                buttons={getControlButtonsForReactiveObject(
+                    pkg.comment,
+                    readonly,
+                )}
             />
+            <ViolationMessages violations={pkg.comment.violations} />
         </div>
     {/if}
 </ModifyDataDialog>

--- a/frontend/src/routes/mainpage/packageNavigation/GraphSection.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/GraphSection.svelte
@@ -542,6 +542,7 @@
                 <PackageButton
                     {dataset}
                     {graph}
+                    {packages}
                     {pack}
                     {prefixes}
                     classes={classesByPackage[getPackageId(pack)] ?? []}

--- a/frontend/src/routes/mainpage/packageNavigation/PackageButton.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/PackageButton.svelte
@@ -51,6 +51,7 @@
         dataset,
         graph,
         pack,
+        packages = [],
         classes = [],
         prefixes = [],
         onPackChange = () => {},
@@ -228,6 +229,7 @@
     bind:showDialog={showPackageEditorDialog}
     datasetName={dataset.label}
     graphUri={getUri(graph)}
+    {packages}
     {pack}
     {readOnly}
 />


### PR DESCRIPTION
## Description

created reactive package and refactored packageEditorDialog.svelte accordingly

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works