### PR TITLE
fix(compare): handle whitespace normalization for RDF comments

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/services/compare/TripleChangeAnalyser.java
+++ b/backend/src/main/java/org/rdfarchitect/services/compare/TripleChangeAnalyser.java
@@ -222,7 +222,10 @@ public class TripleChangeAnalyser {
             var from = originalValues.get(predicate);
             var to = updatedValues.get(predicate);
 
-            if (!Objects.equals(from, to)) {
+            var normalizedFrom = normalizeValueForComparison(predicate, from);
+            var normalizedTo = normalizeValueForComparison(predicate, to);
+
+            if (!Objects.equals(normalizedFrom, normalizedTo)) {
                 var change = new TriplePropertyChange();
                 change.setPredicate(predicate.toString());
                 change.setFrom(from != null ? from.toString() : null);
@@ -260,6 +263,18 @@ public class TripleChangeAnalyser {
         }
 
         return propertyChanges;
+    }
+
+    private String normalizeValueForComparison(Node predicate, Node value) {
+        if (value == null) {
+            return null;
+        }
+        if (RDFS.comment.asNode().equals(predicate) && value.isLiteral()) {
+            var language = value.getLiteralLanguage() == null ? "" : value.getLiteralLanguage();
+            var datatype = value.getLiteralDatatypeURI() == null ? "" : value.getLiteralDatatypeURI();
+            return value.getLiteralLexicalForm().strip() + "|" + language + "|" + datatype;
+        }
+        return value.toString();
     }
 
     /**

--- a/backend/src/main/java/org/rdfarchitect/services/compare/TripleChangeAnalyser.java
+++ b/backend/src/main/java/org/rdfarchitect/services/compare/TripleChangeAnalyser.java
@@ -221,11 +221,14 @@ public class TripleChangeAnalyser {
 
             var from = originalValues.get(predicate);
             var to = updatedValues.get(predicate);
+            var valuesDiffer = !Objects.equals(from, to);
+            if (RDFS.comment.asNode().equals(predicate)) {
+                var normalizedFrom = normalizeCommentValue(from);
+                var normalizedTo = normalizeCommentValue(to);
+                valuesDiffer = !Objects.equals(normalizedFrom, normalizedTo);
+            }
 
-            var normalizedFrom = normalizeValueForComparison(predicate, from);
-            var normalizedTo = normalizeValueForComparison(predicate, to);
-
-            if (!Objects.equals(normalizedFrom, normalizedTo)) {
+            if (valuesDiffer) {
                 var change = new TriplePropertyChange();
                 change.setPredicate(predicate.toString());
                 change.setFrom(from != null ? from.toString() : null);
@@ -265,11 +268,11 @@ public class TripleChangeAnalyser {
         return propertyChanges;
     }
 
-    private String normalizeValueForComparison(Node predicate, Node value) {
+    private String normalizeCommentValue(Node value) {
         if (value == null) {
             return null;
         }
-        if (RDFS.comment.asNode().equals(predicate) && value.isLiteral()) {
+        if (value.isLiteral()) {
             var language = value.getLiteralLanguage() == null ? "" : value.getLiteralLanguage();
             var datatype = value.getLiteralDatatypeURI() == null ? "" : value.getLiteralDatatypeURI();
             return value.getLiteralLexicalForm().strip() + "|" + language + "|" + datatype;

--- a/backend/src/test/java/org/rdfarchitect/services/schemaComparison/SchemaComparisonServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/schemaComparison/SchemaComparisonServiceTest.java
@@ -332,6 +332,18 @@ class SchemaComparisonServiceTest {
     }
 
     @Test
+    void compareSchemas_changedCommentWhitespace_returnsEmptyList() {
+        // arrange
+        MultipartFile file = readMultipartFileFromFile(PATH, "changedCommentWhitespace.ttl");
+
+        // act
+        var result = service.compareSchemas(GRAPH_IDENTIFIER, file);
+
+        // assert
+        assertThat(result).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @Test
     void compareSchemas_changedTripleOrder_returnsEmptyList() {
         // arrange
         MultipartFile identicalFile = readMultipartFileFromFile(PATH, "changedOrder.ttl");
@@ -374,6 +386,19 @@ class SchemaComparisonServiceTest {
         // arrange
         var file1 = readMultipartFileFromFile(PATH, "inMemoryGraph.ttl");
         var file2 = readMultipartFileFromFile(PATH, "inMemoryGraph.ttl");
+
+        // act
+        var result = service.compareSchemas(file1, file2);
+
+        // assert
+        assertThat(result).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @Test
+    void compareSchemas_fileFile_changedCommentWhitespace_returnsEmptyList() {
+        // arrange
+        var file1 = readMultipartFileFromFile(PATH, "inMemoryGraph.ttl");
+        var file2 = readMultipartFileFromFile(PATH, "changedCommentWhitespace.ttl");
 
         // act
         var result = service.compareSchemas(file1, file2);

--- a/backend/src/test/java/org/rdfarchitect/services/schemaComparison/graphs/changedCommentWhitespace.ttl
+++ b/backend/src/test/java/org/rdfarchitect/services/schemaComparison/graphs/changedCommentWhitespace.ttl
@@ -1,0 +1,67 @@
+PREFIX cim:    <http://iec.ch/TC57/2013/CIM-schema-cim16#>
+PREFIX cims:   <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#>
+PREFIX entsoe: <http://entsoe.eu/CIM/SchemaExtension/3/1#>
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX ex:     <http://example.org#>
+
+ex:package
+    rdf:type                  cims:ClassCategory ;
+    rdfs:label                "package"@en .
+
+ex:class
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "class"@en ;
+    cims:belongsToCategory    ex:package ;
+    rdfs:comment              """
+        This is a comment
+    """ ;
+    <http://example.org#uuid> "43836908-c7f7-4749-bb8b-3ac9250de655" .
+
+ex:classToBeDeleted
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "classToBeDeleted"@en .
+
+ex:associatedClass
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "associatedClass"@en .
+
+ex:class.associatedClass
+    rdf:type             rdf:Property ;
+    rdfs:label           "associatedClass"@en ;
+    rdfs:domain          ex:class ;
+    rdfs:range           ex:associatedClass ;
+    cims:AssociationUsed "Yes" ;
+    cims:inverseRoleName ex:associatedClass.class ;
+    cims:multiplicity    cims:M:0..n .
+
+ex:associatedClass.class
+    rdf:type             rdf:Property ;
+    rdfs:label           "class"@en ;
+    rdfs:domain          ex:associatedClass ;
+    rdfs:range           ex:class ;
+    cims:AssociationUsed "Yes" ;
+    cims:inverseRoleName ex:class.associatedClass ;
+    cims:multiplicity    cims:M:0..n .
+
+ex:subClass
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "subClass"@en ;
+    rdfs:subClassOf           ex:class .
+
+ex:enum
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "enum"@en .
+
+ex:enum.enumEntry
+    rdf:type                  ex:enum ;
+    rdfs:label                "enumEntry"@en ;
+    cims:stereotype           "enum" .
+
+ex:class.attribute
+    rdf:type             rdf:Property ;
+    rdfs:label           "attribute"@en ;
+    rdfs:domain          ex:class ;
+    cims:stereotype      <http://iec.ch/TC57/NonStandard/UML#attribute> ;
+    rdfs:range           xsd:string .


### PR DESCRIPTION
## Description

Introduced `normalizeValueForComparison` to compare RDF comments, factoring in whitespace and metadata. Added tests to verify behavior using `changedCommentWhitespace.ttl`.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works