### PR TITLE
feat: Export puts Ontology as the first resource (RDFA-350)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModel.java
+++ b/backend/src/main/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModel.java
@@ -341,7 +341,7 @@ public class CimSortedModel implements Model {
      *
      * @return negative if a comes first, positive if b comes first, 0 if equal
      */
-    private <T> int compareOntologyFirst(Predicate<T> isOntology, T a, T b) {
+    private <T> int compareWithOntologyPrioritized(Predicate<T> isOntology, T a, T b) {
         var aIsOntology = isOntology.test(a);
         var bIsOntology = isOntology.test(b);
         if (aIsOntology && !bIsOntology) {
@@ -354,18 +354,18 @@ public class CimSortedModel implements Model {
     }
 
     private int compareResources(Resource r1, Resource r2) {
-        return compareOntologyFirst(r -> r.hasProperty(RDF.type, OWL2.Ontology), r1, r2);
+        return compareWithOntologyPrioritized(r -> r.hasProperty(RDF.type, OWL2.Ontology), r1, r2);
     }
 
     private int compareStatements(Statement s1, Statement s2) {
-        return compareOntologyFirst(s -> s.getSubject().hasProperty(RDF.type, OWL2.Ontology), s1, s2);
+        return compareWithOntologyPrioritized(s -> s.getSubject().hasProperty(RDF.type, OWL2.Ontology), s1, s2);
     }
 
     private int compareNodes(RDFNode n1, RDFNode n2) {
-        return compareOntologyFirst(n -> n.isResource() && n.asResource().hasProperty(RDF.type, OWL2.Ontology), n1, n2);
+        return compareWithOntologyPrioritized(n -> n.isResource() && n.asResource().hasProperty(RDF.type, OWL2.Ontology), n1, n2);
     }
 
     private int compareTriples(Triple t1, Triple t2) {
-        return compareOntologyFirst(t -> model.wrapAsResource(t.getSubject()).hasProperty(RDF.type, OWL2.Ontology), t1, t2);
+        return compareWithOntologyPrioritized(t -> model.wrapAsResource(t.getSubject()).hasProperty(RDF.type, OWL2.Ontology), t1, t2);
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModel.java
+++ b/backend/src/main/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModel.java
@@ -27,8 +27,8 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.rdf.model.impl.NTripleWriter;
 import org.apache.jena.rdf.model.impl.NodeIteratorImpl;
 import org.apache.jena.rdf.model.impl.NsIteratorImpl;
 import org.apache.jena.rdf.model.impl.ResIteratorImpl;
@@ -37,46 +37,49 @@ import org.apache.jena.rdfxml.xmloutput.impl.RDFXML_Basic;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.vocabulary.OWL2;
+import org.apache.jena.vocabulary.RDF;
 import org.rdfarchitect.rdf.graph.wrapper.SortedGraph;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.io.Writer;
-import java.util.Comparator;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * A Model wrapper that ensures that all iterators return their elements in alphabetical order.
+ * A Model wrapper that ensures that all iterators return their elements in alphabetical order, except for the ontology resource which is always the first element.
  * Also, when writing the model to an output stream or writer, the statements are written in alphabetical order.
  * Supported formats are RDF/XML, N-Triples, Turtle, TriG and JSON-LD.
  * Other formats can still be written, although there is no guarantee that they will be sorted
  */
-public class AlphabeticallySortedModel implements Model {
+public class CimSortedModel implements Model {
 
     @Delegate
     private final Model model;
 
-    public AlphabeticallySortedModel() {
+    public CimSortedModel() {
         this(ModelFactory.createDefaultModel());
     }
 
-    public AlphabeticallySortedModel(Model model) {
-        this.model = ModelFactory.createModelForGraph(new SortedGraph(Comparator.comparing(Triple::toString), model.getGraph()));
+    public CimSortedModel(Model model) {
+        this.model = ModelFactory.createModelForGraph(new SortedGraph(this::compareTriples, model.getGraph()));
     }
 
     @Override
     public ResIterator listSubjects() {
         var list = this.model.listSubjects().toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public NsIterator listNameSpaces() {
         var list = this.model.listNameSpaces().toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(String::compareTo);
         return new NsIteratorImpl(list.iterator(), null);
     }
 
@@ -96,7 +99,7 @@ public class AlphabeticallySortedModel implements Model {
             this.write(out, lang, base);
             writer.write(out.toString());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
         return this;
     }
@@ -129,189 +132,189 @@ public class AlphabeticallySortedModel implements Model {
     @Override
     public StmtIterator listLiteralStatements(Resource subject, Property predicate, boolean object) {
         var list = this.model.listLiteralStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listLiteralStatements(Resource subject, Property predicate, char object) {
         var list = this.model.listLiteralStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listLiteralStatements(Resource subject, Property predicate, long object) {
         var list = this.model.listLiteralStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listLiteralStatements(Resource subject, Property predicate, int object) {
         var list = this.model.listLiteralStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listLiteralStatements(Resource subject, Property predicate, float object) {
         var list = this.model.listLiteralStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listLiteralStatements(Resource subject, Property predicate, double object) {
         var list = this.model.listLiteralStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listStatements(Resource subject, Property predicate, String object) {
         var list = this.model.listStatements(subject, predicate, object).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listStatements(Resource subject, Property predicate, String object, String lang) {
         var list = this.model.listStatements(subject, predicate, object, lang).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listStatements(Resource subject, Property predicate, String object, String lang, String direction) {
         var list = this.model.listStatements(subject, predicate, object, lang, direction).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, boolean o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, long o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, char o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, float o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, double o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, Object o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listSubjectsWithProperty(Property p, String str) {
         var list = this.model.listSubjectsWithProperty(p, str).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listSubjectsWithProperty(Property p, String str, String lang) {
         var list = this.model.listSubjectsWithProperty(p, str, lang).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listSubjectsWithProperty(Property p, String str, String lang, String dir) {
         var list = this.model.listSubjectsWithProperty(p, str, lang, dir).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listSubjectsWithProperty(Property p) {
         var list = this.model.listSubjectsWithProperty(p).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p) {
         var list = this.model.listResourcesWithProperty(p).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listSubjectsWithProperty(Property p, RDFNode o) {
         var list = this.model.listSubjectsWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public ResIterator listResourcesWithProperty(Property p, RDFNode o) {
         var list = this.model.listResourcesWithProperty(p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareResources);
         return new ResIteratorImpl(list.iterator());
     }
 
     @Override
     public NodeIterator listObjects() {
         var list = this.model.listObjects().toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareNodes);
         return new NodeIteratorImpl(list.iterator(), null);
     }
 
     @Override
     public NodeIterator listObjectsOfProperty(Property p) {
         var list = this.model.listObjectsOfProperty(p).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareNodes);
         return new NodeIteratorImpl(list.iterator(), null);
     }
 
     @Override
     public NodeIterator listObjectsOfProperty(Resource s, Property p) {
         var list = this.model.listObjectsOfProperty(s, p).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareNodes);
         return new NodeIteratorImpl(list.iterator(), null);
     }
 
     @Override
     public StmtIterator listStatements() {
         var list = this.model.listStatements().toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
     @Override
     public StmtIterator listStatements(Resource s, Property p, RDFNode o) {
         var list = this.model.listStatements(s, p, o).toList();
-        list.sort(Comparator.comparing(Object::toString));
+        list.sort(this::compareStatements);
         return new StmtIteratorImpl(list.iterator());
     }
 
@@ -326,5 +329,43 @@ public class AlphabeticallySortedModel implements Model {
                             (e1, e2) -> e1,
                             java.util.LinkedHashMap::new
                                            ));
+    }
+
+    /**
+     * Generic comparison that places ontology resources first, then falls back to alphabetical order.
+     *
+     * @param isOntology extracts whether an element is (or belongs to) the ontology resource
+     * @param a          first element
+     * @param b          second element
+     * @param <T>        element type
+     *
+     * @return negative if a comes first, positive if b comes first, 0 if equal
+     */
+    private <T> int compareOntologyFirst(Predicate<T> isOntology, T a, T b) {
+        var aIsOntology = isOntology.test(a);
+        var bIsOntology = isOntology.test(b);
+        if (aIsOntology && !bIsOntology) {
+            return -1;
+        } else if (bIsOntology && !aIsOntology) {
+            return 1;
+        } else {
+            return a.toString().compareTo(b.toString());
+        }
+    }
+
+    private int compareResources(Resource r1, Resource r2) {
+        return compareOntologyFirst(r -> r.hasProperty(RDF.type, OWL2.Ontology), r1, r2);
+    }
+
+    private int compareStatements(Statement s1, Statement s2) {
+        return compareOntologyFirst(s -> s.getSubject().hasProperty(RDF.type, OWL2.Ontology), s1, s2);
+    }
+
+    private int compareNodes(RDFNode n1, RDFNode n2) {
+        return compareOntologyFirst(n -> n.isResource() && n.asResource().hasProperty(RDF.type, OWL2.Ontology), n1, n2);
+    }
+
+    private int compareTriples(Triple t1, Triple t2) {
+        return compareOntologyFirst(t -> model.wrapAsResource(t.getSubject()).hasProperty(RDF.type, OWL2.Ontology), t1, t2);
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/services/select/QueryGraphService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/select/QueryGraphService.java
@@ -48,11 +48,12 @@ import org.rdfarchitect.database.inmemory.InMemorySparqlExecutioner;
 import org.rdfarchitect.exception.database.DataAccessException;
 import org.rdfarchitect.rdf.graph.GraphUtils;
 import org.rdfarchitect.rdf.graph.wrapper.GraphRewindableWithUUIDs;
-import org.rdfarchitect.rdf.model.wrapper.AlphabeticallySortedModel;
+import org.rdfarchitect.rdf.model.wrapper.CimSortedModel;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -137,11 +138,11 @@ public class QueryGraphService implements GetClassListUseCase, ListDatatypesUseC
             var copiedGraph = GraphUtils.deepCopy(graph);
             copiedGraph.getPrefixMapping().setNsPrefixes(databasePort.getPrefixMapping(graphIdentifier.getDatasetName()));
             removeUUIDs(copiedGraph);
-            var sortedModel = new AlphabeticallySortedModel(ModelFactory.createModelForGraph(copiedGraph));
+            var sortedModel = new CimSortedModel(ModelFactory.createModelForGraph(copiedGraph));
             sortedModel.write(out, format.getLang().getName());
             return out;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         } finally {
             if (graph != null) {
                 graph.end();

--- a/backend/src/test/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModelTest.java
+++ b/backend/src/test/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModelTest.java
@@ -20,6 +20,8 @@ package org.rdfarchitect.rdf.model.wrapper;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.vocabulary.OWL2;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,7 +39,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class AlphabeticallySortedModelTest {
 
-    private AlphabeticallySortedModel createTestModel() {
+    private CimSortedModel createTestModel() {
         var m = ModelFactory.createDefaultModel();
         var s1 = m.createResource("http://example.org/A");
         var s2 = m.createResource("http://example.org/B");
@@ -49,29 +51,54 @@ class AlphabeticallySortedModelTest {
         m.setNsPrefix("z", "http://example.org/z");
         m.setNsPrefix("a", "http://example.org/a");
         m.setNsPrefix("m", "http://example.org/m");
-        return new AlphabeticallySortedModel(m);
+        return new CimSortedModel(m);
+    }
+
+    private CimSortedModel createTestModelWithOntology() {
+        var m = ModelFactory.createDefaultModel();
+        var ontology = m.createResource("http://example.org/MyOntology");
+        var s1 = m.createResource("http://example.org/A");
+        var s2 = m.createResource("http://example.org/B");
+        var p = m.createProperty("http://example.org/prop");
+        m.add(ontology, RDF.type, OWL2.Ontology);
+        m.add(ontology, p, "ontologyValue");
+        m.add(s1, p, "foo");
+        m.add(s2, p, "bar");
+        return new CimSortedModel(m);
+    }
+
+    private <T> List<String> toStringList(ClosableIterator<T> it) {
+        var result = new ArrayList<String>();
+        while (it.hasNext()) {
+            result.add(it.next().toString());
+        }
+        it.close();
+        return result;
     }
 
     @Nested
     class listTests {
-
-        private <T> List<Object> toSortedStringList(ClosableIterator<T> it) {
-            var result = new ArrayList<>();
-            while (it.hasNext()) {
-                result.add(it.next().toString());
-            }
-            it.close();
-            return result;
-        }
 
         @Test
         void listSubjects_givenUnsortedSubjects_returnsAlphabeticallySorted() {
             // Arrange
             var model = createTestModel();
             // Act
-            var subjects = toSortedStringList(model.listSubjects());
+            var subjects = toStringList(model.listSubjects());
             // Assert
             assertThat(subjects).isEqualTo(subjects.stream().sorted().toList());
+        }
+
+        @Test
+        void listSubjects_givenOntologyResource_returnsOntologyFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            // Act
+            var subjects = toStringList(model.listSubjects());
+            // Assert
+            assertThat(subjects.getFirst()).isEqualTo("http://example.org/MyOntology");
+            assertThat(subjects.subList(1, subjects.size()))
+                      .isEqualTo(subjects.subList(1, subjects.size()).stream().sorted().toList());
         }
 
         @Test
@@ -79,7 +106,7 @@ class AlphabeticallySortedModelTest {
             // Arrange
             var model = createTestModel();
             // Act
-            var ns = toSortedStringList(model.listNameSpaces());
+            var ns = toStringList(model.listNameSpaces());
             // Assert
             assertThat(ns).isEqualTo(ns.stream().sorted().toList());
         }
@@ -89,9 +116,25 @@ class AlphabeticallySortedModelTest {
             // Arrange
             var model = createTestModel();
             // Act
-            var objs = toSortedStringList(model.listObjects());
+            var objs = toStringList(model.listObjects());
             // Assert
             assertThat(objs).isEqualTo(objs.stream().sorted().toList());
+        }
+
+        @Test
+        void listObjects_givenOntologyResource_returnsOntologyFirst() {
+            // Arrange
+            var m = ModelFactory.createDefaultModel();
+            var ontology = m.createResource("http://example.org/ZZZOntology");
+            var p = m.createProperty("http://example.org/ref");
+            m.add(ontology, RDF.type, OWL2.Ontology);
+            m.add(m.createResource("http://example.org/A"), p, ontology);
+            m.add(m.createResource("http://example.org/B"), p, m.createResource("http://example.org/AAA"));
+            var model = new CimSortedModel(m);
+            // Act
+            var objs = toStringList(model.listObjectsOfProperty(p));
+            // Assert
+            assertThat(objs.getFirst()).isEqualTo("http://example.org/ZZZOntology");
         }
 
         @Test
@@ -100,7 +143,7 @@ class AlphabeticallySortedModelTest {
             var model = createTestModel();
             var p = model.getProperty("http://example.org/prop");
             // Act
-            var objs = toSortedStringList(model.listObjectsOfProperty(p));
+            var objs = toStringList(model.listObjectsOfProperty(p));
             // Assert
             assertThat(objs).isEqualTo(objs.stream().sorted().toList());
         }
@@ -112,7 +155,7 @@ class AlphabeticallySortedModelTest {
             var s = model.getResource("http://example.org/B");
             var p = model.getProperty("http://example.org/prop");
             // Act
-            var objs = toSortedStringList(model.listObjectsOfProperty(s, p));
+            var objs = toStringList(model.listObjectsOfProperty(s, p));
             // Assert
             assertThat(objs).isEqualTo(objs.stream().sorted().toList());
         }
@@ -122,9 +165,20 @@ class AlphabeticallySortedModelTest {
             // Arrange
             var model = createTestModel();
             // Act
-            var stmts = toSortedStringList(model.listStatements());
+            var stmts = toStringList(model.listStatements());
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
+        }
+
+        @Test
+        void listStatements_givenOntologyResource_returnsOntologyStatementsFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            // Act
+            var stmts = toStringList(model.listStatements());
+            // Assert
+            assertThat(stmts.getFirst()).contains("MyOntology");
+            assertThat(stmts.get(1)).contains("MyOntology");
         }
 
         @Test
@@ -135,7 +189,7 @@ class AlphabeticallySortedModelTest {
             var p = model.getProperty("http://example.org/prop");
             var o = model.createLiteral("foo");
             // Act
-            var stmts = toSortedStringList(model.listStatements(s, p, o));
+            var stmts = toStringList(model.listStatements(s, p, o));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -149,7 +203,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createTypedLiteral(true));
             model.add(s, p, model.createTypedLiteral(false));
             // Act
-            var stmts = toSortedStringList(model.listLiteralStatements(s, p, true));
+            var stmts = toStringList(model.listLiteralStatements(s, p, true));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -163,7 +217,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createTypedLiteral('a'));
             model.add(s, p, model.createTypedLiteral('b'));
             // Act
-            var stmts = toSortedStringList(model.listLiteralStatements(s, p, 'a'));
+            var stmts = toStringList(model.listLiteralStatements(s, p, 'a'));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -177,7 +231,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createTypedLiteral(1L));
             model.add(s, p, model.createTypedLiteral(2L));
             // Act
-            var stmts = toSortedStringList(model.listLiteralStatements(s, p, 1L));
+            var stmts = toStringList(model.listLiteralStatements(s, p, 1L));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -191,7 +245,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createTypedLiteral(3));
             model.add(s, p, model.createTypedLiteral(2));
             // Act
-            var stmts = toSortedStringList(model.listLiteralStatements(s, p, 2));
+            var stmts = toStringList(model.listLiteralStatements(s, p, 2));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -205,7 +259,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createTypedLiteral(1.1f));
             model.add(s, p, model.createTypedLiteral(2.2f));
             // Act
-            var stmts = toSortedStringList(model.listLiteralStatements(s, p, 1.1f));
+            var stmts = toStringList(model.listLiteralStatements(s, p, 1.1f));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -219,7 +273,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createTypedLiteral(1.1d));
             model.add(s, p, model.createTypedLiteral(2.2d));
             // Act
-            var stmts = toSortedStringList(model.listLiteralStatements(s, p, 1.1d));
+            var stmts = toStringList(model.listLiteralStatements(s, p, 1.1d));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -231,7 +285,7 @@ class AlphabeticallySortedModelTest {
             var s = model.getResource("http://example.org/A");
             var p = model.getProperty("http://example.org/prop");
             // Act
-            var stmts = toSortedStringList(model.listStatements(s, p, "baz"));
+            var stmts = toStringList(model.listStatements(s, p, "baz"));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -245,7 +299,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createLiteral("baz", "en"));
             model.add(s, p, model.createLiteral("baz", "de"));
             // Act
-            var stmts = toSortedStringList(model.listStatements(s, p, "baz", "en"));
+            var stmts = toStringList(model.listStatements(s, p, "baz", "en"));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -259,7 +313,7 @@ class AlphabeticallySortedModelTest {
             model.add(s, p, model.createLiteral("baz", "en", "ltr"));
             model.add(s, p, model.createLiteral("baz", "en", "rtl"));
             // Act
-            var stmts = toSortedStringList(model.listStatements(s, p, "baz", "en", "ltr"));
+            var stmts = toStringList(model.listStatements(s, p, "baz", "en", "ltr"));
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
         }
@@ -272,7 +326,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/J"), p, model.createTypedLiteral(true));
             model.add(model.createResource("http://example.org/K"), p, model.createTypedLiteral(false));
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, true));
+            var res = toStringList(model.listResourcesWithProperty(p, true));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -285,7 +339,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/L"), p, model.createTypedLiteral(1L));
             model.add(model.createResource("http://example.org/M"), p, model.createTypedLiteral(2L));
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, 1L));
+            var res = toStringList(model.listResourcesWithProperty(p, 1L));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -298,7 +352,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/N"), p, model.createTypedLiteral('a'));
             model.add(model.createResource("http://example.org/O"), p, model.createTypedLiteral('b'));
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, 'a'));
+            var res = toStringList(model.listResourcesWithProperty(p, 'a'));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -311,7 +365,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/P"), p, model.createTypedLiteral(1.1f));
             model.add(model.createResource("http://example.org/Q"), p, model.createTypedLiteral(2.2f));
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, 1.1f));
+            var res = toStringList(model.listResourcesWithProperty(p, 1.1f));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -324,7 +378,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/R"), p, model.createTypedLiteral(1.1d));
             model.add(model.createResource("http://example.org/S"), p, model.createTypedLiteral(2.2d));
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, 1.1d));
+            var res = toStringList(model.listResourcesWithProperty(p, 1.1d));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -338,9 +392,22 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/T"), p, o);
             model.add(model.createResource("http://example.org/U"), p, o);
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, o));
+            var res = toStringList(model.listResourcesWithProperty(p, o));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
+        }
+
+        @Test
+        void listResourcesWithProperty_givenOntologyResource_returnsOntologyFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            var p = model.getProperty("http://example.org/prop");
+            // Act
+            var res = toStringList(model.listResourcesWithProperty(p));
+            // Assert
+            assertThat(res.getFirst()).isEqualTo("http://example.org/MyOntology");
+            assertThat(res.subList(1, res.size()))
+                      .isEqualTo(res.subList(1, res.size()).stream().sorted().toList());
         }
 
         @Test
@@ -351,7 +418,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/V"), p, "foo");
             model.add(model.createResource("http://example.org/W"), p, "foo");
             // Act
-            var res = toSortedStringList(model.listSubjectsWithProperty(p, "foo"));
+            var res = toStringList(model.listSubjectsWithProperty(p, "foo"));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -364,7 +431,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/X"), p, model.createLiteral("foo", "en"));
             model.add(model.createResource("http://example.org/Y"), p, model.createLiteral("foo", "en"));
             // Act
-            var res = toSortedStringList(model.listSubjectsWithProperty(p, "foo", "en"));
+            var res = toStringList(model.listSubjectsWithProperty(p, "foo", "en"));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -377,7 +444,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/Z"), p, model.createLiteral("foo", "en", "ltr"));
             model.add(model.createResource("http://example.org/AA"), p, model.createLiteral("foo", "en", "ltr"));
             // Act
-            var res = toSortedStringList(model.listSubjectsWithProperty(p, "foo", "en", "ltr"));
+            var res = toStringList(model.listSubjectsWithProperty(p, "foo", "en", "ltr"));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -390,7 +457,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/AB"), p, "foo");
             model.add(model.createResource("http://example.org/AC"), p, "bar");
             // Act
-            var res = toSortedStringList(model.listSubjectsWithProperty(p));
+            var res = toStringList(model.listSubjectsWithProperty(p));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -403,7 +470,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/AD"), p, "foo");
             model.add(model.createResource("http://example.org/AE"), p, "bar");
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p));
+            var res = toStringList(model.listResourcesWithProperty(p));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -417,7 +484,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/AF"), p, o);
             model.add(model.createResource("http://example.org/AG"), p, o);
             // Act
-            var res = toSortedStringList(model.listSubjectsWithProperty(p, o));
+            var res = toStringList(model.listSubjectsWithProperty(p, o));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -431,7 +498,7 @@ class AlphabeticallySortedModelTest {
             model.add(model.createResource("http://example.org/AH"), p, o);
             model.add(model.createResource("http://example.org/AI"), p, o);
             // Act
-            var res = toSortedStringList(model.listResourcesWithProperty(p, o));
+            var res = toStringList(model.listResourcesWithProperty(p, o));
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
@@ -482,14 +549,141 @@ class AlphabeticallySortedModelTest {
     }
 
     @Nested
+    class ontologyFirstTests {
+
+        @Test
+        void listSubjectsWithProperty_givenOntologyAndRegularResources_returnsOntologyFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            var p = model.getProperty("http://example.org/prop");
+            // Act
+            var subjects = toStringList(model.listSubjectsWithProperty(p));
+            // Assert
+            assertThat(subjects.getFirst()).isEqualTo("http://example.org/MyOntology");
+            assertThat(subjects.subList(1, subjects.size()))
+                      .isEqualTo(subjects.subList(1, subjects.size()).stream().sorted().toList());
+        }
+
+        @Test
+        void listSubjectsWithPropertyRDFNode_givenOntologyAndRegularResources_returnsOntologyFirst() {
+            // Arrange
+            var m = ModelFactory.createDefaultModel();
+            var ontology = m.createResource("http://example.org/ZZZOntology");
+            var s1 = m.createResource("http://example.org/A");
+            var p = m.createProperty("http://example.org/prop");
+            RDFNode o = m.createLiteral("shared");
+            m.add(ontology, RDF.type, OWL2.Ontology);
+            m.add(ontology, p, o);
+            m.add(s1, p, o);
+            var model = new CimSortedModel(m);
+            // Act
+            var subjects = toStringList(model.listSubjectsWithProperty(p, o));
+            // Assert
+            assertThat(subjects.getFirst()).isEqualTo("http://example.org/ZZZOntology");
+        }
+
+        @Test
+        void listStatements_givenOntologyAndRegularResources_returnsOntologyStatementsFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            // Act
+            var stmts = toStringList(model.listStatements());
+            // Assert
+            assertThat(stmts.getFirst()).contains("MyOntology");
+            assertThat(stmts.get(1)).contains("MyOntology");
+        }
+
+        @Test
+        void listStatements_givenOntologyAndRegularResources_returnsRemainingStatementsSorted() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            // Act
+            var stmts = toStringList(model.listStatements());
+            // Assert
+            var nonOntologyStmts = stmts.stream()
+                                        .filter(s -> !s.contains("MyOntology"))
+                                        .toList();
+            assertThat(nonOntologyStmts)
+                      .isEqualTo(nonOntologyStmts.stream().sorted().toList());
+        }
+
+        @Test
+        void listStatementsWithFilter_givenOntologySubject_returnsOntologyStatementsFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            var p = model.getProperty("http://example.org/prop");
+            // Act
+            var stmts = toStringList(model.listStatements(null, p, (RDFNode) null));
+            // Assert
+            assertThat(stmts.getFirst()).contains("MyOntology");
+        }
+
+        @Test
+        void listObjects_givenOntologyAsObject_returnsOntologyFirst() {
+            // Arrange
+            var m = ModelFactory.createDefaultModel();
+            var ontology = m.createResource("http://example.org/ZZZOntology");
+            var p = m.createProperty("http://example.org/ref");
+            m.add(ontology, RDF.type, OWL2.Ontology);
+            m.add(m.createResource("http://example.org/A"), p, ontology);
+            m.add(m.createResource("http://example.org/B"), p, m.createResource("http://example.org/AAA"));
+            var model = new CimSortedModel(m);
+            // Act
+            var objs = toStringList(model.listObjects());
+            // Assert
+            var resourceObjs = objs.stream()
+                                   .filter(o -> !o.contains("Ontology") || o.contains("ZZZOntology"))
+                                   .filter(o -> o.startsWith("http://"))
+                                   .toList();
+            assertThat(resourceObjs.getFirst()).isEqualTo("http://example.org/ZZZOntology");
+        }
+
+        @Test
+        void write_ntriplesWithOntology_writesOntologyTriplesFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            var out = new ByteArrayOutputStream();
+            // Act
+            model.write(out, "N-TRIPLES");
+            var result = out.toString(StandardCharsets.UTF_8);
+            // Assert
+            var lines = result.lines()
+                              .filter(l -> !l.isBlank())
+                              .toList();
+            var firstOntologyLine = lines.stream()
+                                         .filter(l -> l.contains("MyOntology"))
+                                         .findFirst();
+            var firstNonOntologyLine = lines.stream()
+                                            .filter(l -> !l.contains("MyOntology"))
+                                            .findFirst();
+            assertThat(firstOntologyLine).isPresent();
+            assertThat(firstNonOntologyLine).isPresent();
+            assertThat(lines.indexOf(firstOntologyLine.get()))
+                      .isLessThan(lines.indexOf(firstNonOntologyLine.get()));
+        }
+
+        @Test
+        void getNsPrefixMap_returnsSortedByKey() {
+            // Arrange
+            var model = createTestModel();
+            // Act
+            var prefixMap = model.getNsPrefixMap();
+            // Assert
+            var keys = new ArrayList<>(prefixMap.keySet());
+            assertThat(keys).isEqualTo(keys.stream().sorted().toList());
+        }
+    }
+
+    @Nested
     class writeTests {
 
-        private AlphabeticallySortedModel model;
+        private CimSortedModel model;
         private ByteArrayOutputStream outputStream;
         private static final String BASE_URI = "http://example.org/";
 
         @BeforeEach
         void setUp() {
+            // Arrange
             model = createTestModel();
             outputStream = new ByteArrayOutputStream();
         }
@@ -498,16 +692,13 @@ class AlphabeticallySortedModelTest {
         void write_withRdfXmlLanguage_shouldSerializeAlphabetically() {
             // Arrange
             var language = "RDF/XML";
-
             // Act
-            var result = (AlphabeticallySortedModel) model.write(outputStream, language, BASE_URI);
+            var result = (CimSortedModel) model.write(outputStream, language, BASE_URI);
             var serializedOutput = outputStream.toString();
-
             // Assert
             assertThat(result).isSameAs(model);
             assertThat(serializedOutput).isNotEmpty();
 
-            // Find the first occurrence index of each subject URI in the string
             int indexA = serializedOutput.indexOf("rdf:about=\"A\"");
             int indexB = serializedOutput.indexOf("rdf:about=\"B\"");
             int indexC = serializedOutput.indexOf("rdf:about=\"C\"");
@@ -521,8 +712,6 @@ class AlphabeticallySortedModelTest {
             assertThat(indexC)
                       .as("Serialized output should contain resource C")
                       .isNotNegative();
-
-
             assertThat(indexA)
                       .as("Resource A should appear before resource B")
                       .isLessThan(indexB);
@@ -532,14 +721,29 @@ class AlphabeticallySortedModelTest {
         }
 
         @Test
+        void write_withRdfXmlAndOntology_shouldSerializeOntologyFirst() {
+            // Arrange
+            var ontologyModel = createTestModelWithOntology();
+            var out = new ByteArrayOutputStream();
+            var language = "RDF/XML";
+            // Act
+            ontologyModel.write(out, language, BASE_URI);
+            var serializedOutput = out.toString();
+            // Assert
+            int indexOntology = serializedOutput.indexOf("MyOntology");
+            int indexA = serializedOutput.indexOf("rdf:about=\"A\"");
+            assertThat(indexOntology)
+                      .as("Ontology resource should appear before resource A")
+                      .isLessThan(indexA);
+        }
+
+        @Test
         void write_withTurtleLanguage_shouldSerializeAlphabetically() {
             // Arrange
             var language = "TURTLE";
-
             // Act
-            var result = (AlphabeticallySortedModel) model.write(outputStream, language, BASE_URI);
+            var result = (CimSortedModel) model.write(outputStream, language, BASE_URI);
             var serializedOutput = outputStream.toString();
-
             // Assert
             assertThat(result).isSameAs(model);
             assertThat(serializedOutput).isNotEmpty()
@@ -571,16 +775,13 @@ class AlphabeticallySortedModelTest {
         void write_withNTriplesLanguage_shouldSerializeAlphabetically() {
             // Arrange
             var language = "N-TRIPLES";
-
             // Act
-            var result = (AlphabeticallySortedModel) model.write(outputStream, language, BASE_URI);
+            var result = (CimSortedModel) model.write(outputStream, language, BASE_URI);
             var serializedOutput = outputStream.toString();
-
             // Assert
             assertThat(result).isSameAs(model);
             assertThat(serializedOutput).isNotEmpty();
 
-            // N-Triples format: each line is a triple ending with " ."
             var tripleLines = Arrays.stream(serializedOutput.split("\n"))
                                     .map(String::trim)
                                     .filter(line -> line.endsWith(" ."))
@@ -588,13 +789,11 @@ class AlphabeticallySortedModelTest {
 
             assertThat(tripleLines).as("Triple lines should not be empty").isNotEmpty();
 
-            // Extract distinct subjects from each triple line
             var subjects = tripleLines.stream()
-                                      .map(line -> line.split(" ", 2)[0]) // subject is first term
+                                      .map(line -> line.split(" ", 2)[0])
                                       .distinct()
                                       .toList();
 
-            // Check alphabetical order by comparing to sorted version
             var sortedSubjects = new ArrayList<>(subjects);
             sortedSubjects.sort(Comparator.naturalOrder());
 
@@ -607,7 +806,6 @@ class AlphabeticallySortedModelTest {
         void write_withUnsupportedLanguage_shouldThrowIllegalArgumentException() {
             // Arrange
             var unsupportedLanguage = "UNSUPPORTED_FORMAT";
-
             // Act & Assert
             assertThatThrownBy(() -> model.write(outputStream, unsupportedLanguage, BASE_URI))
                       .isInstanceOf(IllegalArgumentException.class)
@@ -618,11 +816,9 @@ class AlphabeticallySortedModelTest {
         void write_withNullBaseUri_shouldSerializeSuccessfully() {
             // Arrange
             var language = "TURTLE";
-
             // Act
-            var result = (AlphabeticallySortedModel) model.write(outputStream, language, null);
+            var result = (CimSortedModel) model.write(outputStream, language, null);
             var serializedOutput = outputStream.toString();
-
             // Assert
             assertThat(result).isSameAs(model);
             assertThat(serializedOutput).isNotEmpty();
@@ -632,10 +828,8 @@ class AlphabeticallySortedModelTest {
         void write_shouldReturnSameModelInstance() {
             // Arrange
             var language = "TURTLE";
-
             // Act
-            AlphabeticallySortedModel result = (AlphabeticallySortedModel) model.write(outputStream, language, BASE_URI);
-
+            CimSortedModel result = (CimSortedModel) model.write(outputStream, language, BASE_URI);
             // Assert
             assertThat(result)
                       .as("Method should return the same model instance for method chaining")

--- a/backend/src/test/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModelTest.java
+++ b/backend/src/test/java/org/rdfarchitect/rdf/model/wrapper/CimSortedModelTest.java
@@ -37,7 +37,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-class AlphabeticallySortedModelTest {
+class CimSortedModelTest {
 
     private CimSortedModel createTestModel() {
         var m = ModelFactory.createDefaultModel();
@@ -90,18 +90,6 @@ class AlphabeticallySortedModelTest {
         }
 
         @Test
-        void listSubjects_givenOntologyResource_returnsOntologyFirst() {
-            // Arrange
-            var model = createTestModelWithOntology();
-            // Act
-            var subjects = toStringList(model.listSubjects());
-            // Assert
-            assertThat(subjects.getFirst()).isEqualTo("http://example.org/MyOntology");
-            assertThat(subjects.subList(1, subjects.size()))
-                      .isEqualTo(subjects.subList(1, subjects.size()).stream().sorted().toList());
-        }
-
-        @Test
         void listNameSpaces_givenUnsortedNamespaces_returnsAlphabeticallySorted() {
             // Arrange
             var model = createTestModel();
@@ -119,22 +107,6 @@ class AlphabeticallySortedModelTest {
             var objs = toStringList(model.listObjects());
             // Assert
             assertThat(objs).isEqualTo(objs.stream().sorted().toList());
-        }
-
-        @Test
-        void listObjects_givenOntologyResource_returnsOntologyFirst() {
-            // Arrange
-            var m = ModelFactory.createDefaultModel();
-            var ontology = m.createResource("http://example.org/ZZZOntology");
-            var p = m.createProperty("http://example.org/ref");
-            m.add(ontology, RDF.type, OWL2.Ontology);
-            m.add(m.createResource("http://example.org/A"), p, ontology);
-            m.add(m.createResource("http://example.org/B"), p, m.createResource("http://example.org/AAA"));
-            var model = new CimSortedModel(m);
-            // Act
-            var objs = toStringList(model.listObjectsOfProperty(p));
-            // Assert
-            assertThat(objs.getFirst()).isEqualTo("http://example.org/ZZZOntology");
         }
 
         @Test
@@ -168,17 +140,6 @@ class AlphabeticallySortedModelTest {
             var stmts = toStringList(model.listStatements());
             // Assert
             assertThat(stmts).isEqualTo(stmts.stream().sorted().toList());
-        }
-
-        @Test
-        void listStatements_givenOntologyResource_returnsOntologyStatementsFirst() {
-            // Arrange
-            var model = createTestModelWithOntology();
-            // Act
-            var stmts = toStringList(model.listStatements());
-            // Assert
-            assertThat(stmts.getFirst()).contains("MyOntology");
-            assertThat(stmts.get(1)).contains("MyOntology");
         }
 
         @Test
@@ -398,19 +359,6 @@ class AlphabeticallySortedModelTest {
         }
 
         @Test
-        void listResourcesWithProperty_givenOntologyResource_returnsOntologyFirst() {
-            // Arrange
-            var model = createTestModelWithOntology();
-            var p = model.getProperty("http://example.org/prop");
-            // Act
-            var res = toStringList(model.listResourcesWithProperty(p));
-            // Assert
-            assertThat(res.getFirst()).isEqualTo("http://example.org/MyOntology");
-            assertThat(res.subList(1, res.size()))
-                      .isEqualTo(res.subList(1, res.size()).stream().sorted().toList());
-        }
-
-        @Test
         void listSubjectsWithPropertyString_givenUnsortedSubjects_returnsAlphabeticallySorted() {
             // Arrange
             var model = createTestModel();
@@ -502,54 +450,62 @@ class AlphabeticallySortedModelTest {
             // Assert
             assertThat(res).isEqualTo(res.stream().sorted().toList());
         }
-
-        @Test
-        void write_rdfxmlFormat_writesValidRdfXml() {
-            // Arrange
-            var model = createTestModel();
-            var out = new ByteArrayOutputStream();
-            // Act
-            model.write(out, "RDF/XML");
-            var result = out.toString(StandardCharsets.UTF_8);
-            // Assert
-            assertThat(result).contains("rdf:RDF")
-                              .contains("http://example.org/A")
-                              .contains("http://example.org/B")
-                              .contains("http://example.org/C");
-        }
-
-        @Test
-        void write_turtleFormat_writesValidTurtle() {
-            // Arrange
-            var model = createTestModel();
-            var out = new ByteArrayOutputStream();
-            // Act
-            model.write(out, "TURTLE");
-            var result = out.toString(StandardCharsets.UTF_8);
-            // Assert
-            assertThat(result).contains("http://example.org/A")
-                              .contains("http://example.org/B")
-                              .contains("http://example.org/C")
-                              .contains("http://example.org/prop");
-        }
-
-        @Test
-        void write_ntriplesFormat_writesSortedNTriples() {
-            // Arrange
-            var model = createTestModel();
-            var out = new ByteArrayOutputStream();
-            // Act
-            model.write(out, "N-TRIPLES");
-            var result = out.toString(StandardCharsets.UTF_8);
-            // Assert
-            var lines = result.lines().filter(l -> l.contains("http://example.org/")).toList();
-            var sortedLines = lines.stream().sorted().toList();
-            assertThat(lines).isEqualTo(sortedLines);
-        }
     }
 
     @Nested
     class ontologyFirstTests {
+
+        @Test
+        void listStatements_givenOntologyResource_returnsOntologyStatementsFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            // Act
+            var stmts = toStringList(model.listStatements());
+            // Assert
+            assertThat(stmts.getFirst()).contains("MyOntology");
+            assertThat(stmts.get(1)).contains("MyOntology");
+        }
+
+        @Test
+        void listSubjects_givenOntologyResource_returnsOntologyFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            // Act
+            var subjects = toStringList(model.listSubjects());
+            // Assert
+            assertThat(subjects.getFirst()).isEqualTo("http://example.org/MyOntology");
+            assertThat(subjects.subList(1, subjects.size()))
+                      .isEqualTo(subjects.subList(1, subjects.size()).stream().sorted().toList());
+        }
+
+        @Test
+        void listObjects_givenOntologyResource_returnsOntologyFirst() {
+            // Arrange
+            var m = ModelFactory.createDefaultModel();
+            var ontology = m.createResource("http://example.org/ZZZOntology");
+            var p = m.createProperty("http://example.org/ref");
+            m.add(ontology, RDF.type, OWL2.Ontology);
+            m.add(m.createResource("http://example.org/A"), p, ontology);
+            m.add(m.createResource("http://example.org/B"), p, m.createResource("http://example.org/AAA"));
+            var model = new CimSortedModel(m);
+            // Act
+            var objs = toStringList(model.listObjectsOfProperty(p));
+            // Assert
+            assertThat(objs.getFirst()).isEqualTo("http://example.org/ZZZOntology");
+        }
+
+        @Test
+        void listResourcesWithProperty_givenOntologyResource_returnsOntologyFirst() {
+            // Arrange
+            var model = createTestModelWithOntology();
+            var p = model.getProperty("http://example.org/prop");
+            // Act
+            var res = toStringList(model.listResourcesWithProperty(p));
+            // Assert
+            assertThat(res.getFirst()).isEqualTo("http://example.org/MyOntology");
+            assertThat(res.subList(1, res.size()))
+                      .isEqualTo(res.subList(1, res.size()).stream().sorted().toList());
+        }
 
         @Test
         void listSubjectsWithProperty_givenOntologyAndRegularResources_returnsOntologyFirst() {
@@ -580,17 +536,6 @@ class AlphabeticallySortedModelTest {
             var subjects = toStringList(model.listSubjectsWithProperty(p, o));
             // Assert
             assertThat(subjects.getFirst()).isEqualTo("http://example.org/ZZZOntology");
-        }
-
-        @Test
-        void listStatements_givenOntologyAndRegularResources_returnsOntologyStatementsFirst() {
-            // Arrange
-            var model = createTestModelWithOntology();
-            // Act
-            var stmts = toStringList(model.listStatements());
-            // Assert
-            assertThat(stmts.getFirst()).contains("MyOntology");
-            assertThat(stmts.get(1)).contains("MyOntology");
         }
 
         @Test
@@ -834,6 +779,44 @@ class AlphabeticallySortedModelTest {
             assertThat(result)
                       .as("Method should return the same model instance for method chaining")
                       .isSameAs(model);
+        }
+
+        @Test
+        void write_rdfxmlFormat_writesValidRdfXml() {
+            // Arrange
+            // Act
+            model.write(outputStream, "RDF/XML");
+            var result = outputStream.toString(StandardCharsets.UTF_8);
+            // Assert
+            assertThat(result).contains("rdf:RDF")
+                              .contains("http://example.org/A")
+                              .contains("http://example.org/B")
+                              .contains("http://example.org/C");
+        }
+
+        @Test
+        void write_turtleFormat_writesValidTurtle() {
+            // Arrange
+            // Act
+            model.write(outputStream, "TURTLE");
+            var result = outputStream.toString(StandardCharsets.UTF_8);
+            // Assert
+            assertThat(result).contains("http://example.org/A")
+                              .contains("http://example.org/B")
+                              .contains("http://example.org/C")
+                              .contains("http://example.org/prop");
+        }
+
+        @Test
+        void write_ntriplesFormat_writesSortedNTriples() {
+            // Arrange
+            // Act
+            model.write(outputStream, "N-TRIPLES");
+            var result = outputStream.toString(StandardCharsets.UTF_8);
+            // Assert
+            var lines = result.lines().filter(l -> l.contains("http://example.org/")).toList();
+            var sortedLines = lines.stream().sorted().toList();
+            assertThat(lines).isEqualTo(sortedLines);
         }
     }
 }


### PR DESCRIPTION
## Description

On Export the ontology is always listed as the first resource.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works