### PR TITLE
fix(dialog): Refactor shared dialogs to bits-ui modal primitives (RDFA-366)

### DIFF
--- a/frontend/src/lib/dialog/AlertDialog.svelte
+++ b/frontend/src/lib/dialog/AlertDialog.svelte
@@ -1,0 +1,41 @@
+<!--
+  -    Copyright (c) 2024-2026 SOPTIM AG
+  -
+  -    Licensed under the Apache License, Version 2.0 (the "License");
+  -    you may not use this file except in compliance with the License.
+  -    You may obtain a copy of the License at
+  -
+  -    http://www.apache.org/licenses/LICENSE-2.0
+  -
+  -    Unless required by applicable law or agreed to in writing, software
+  -    distributed under the License is distributed on an "AS IS" BASIS,
+  -    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -    See the License for the specific language governing permissions and
+  -    limitations under the License.
+  -->
+<script>
+    import { AlertDialog as BitsUiAlertDialog } from "bits-ui";
+
+    let {
+        showDialog = $bindable(),
+        size = "w-full max-w-md",
+        onkeydown,
+        children,
+        ...restProps
+    } = $props();
+</script>
+
+<BitsUiAlertDialog.Root bind:open={showDialog}>
+    <BitsUiAlertDialog.Portal>
+        <BitsUiAlertDialog.Overlay
+            class="bg-dialog-backlight fixed inset-0 z-40"
+        />
+        <BitsUiAlertDialog.Content
+            {...restProps}
+            class="border-border bg-window-background fixed top-1/2 left-1/2 z-40 -translate-x-1/2 -translate-y-1/2 rounded border border-solid p-2 shadow outline-none {size}"
+            {onkeydown}
+        >
+            {@render children?.()}
+        </BitsUiAlertDialog.Content>
+    </BitsUiAlertDialog.Portal>
+</BitsUiAlertDialog.Root>

--- a/frontend/src/lib/dialog/Dialog.svelte
+++ b/frontend/src/lib/dialog/Dialog.svelte
@@ -15,6 +15,7 @@
   -
   -->
 <script>
+    import { Dialog as BitsUiDialog } from "bits-ui";
     import { onDestroy } from "svelte";
     import { untrack } from "svelte";
 
@@ -29,15 +30,18 @@
         children,
     } = $props();
 
-    let dialogElement = $state();
+    let dialogWasOpen = false;
 
     $effect(() => {
         if (showDialog) {
-            eventStack.addEvent(closeDialog);
-            untrack(onOpen);
-            dialogElement?.focus();
-        } else {
+            if (!dialogWasOpen) {
+                eventStack.addEvent(closeDialog);
+                untrack(onOpen);
+                dialogWasOpen = true;
+            }
+        } else if (dialogWasOpen) {
             eventStack.removeEvent(closeDialog);
+            dialogWasOpen = false;
         }
     });
 
@@ -53,23 +57,28 @@
             showDialog = !onCloseReturn;
         }
     }
+
+    function handleEscapeKeydown(event) {
+        event.preventDefault();
+        closeDialog();
+    }
+
+    function handleInteractOutside(event) {
+        event.preventDefault();
+        closeDialog();
+    }
 </script>
 
-{#if showDialog}
-    <div
-        bind:this={dialogElement}
-        class="bg-dialog-backlight fixed top-0 left-0 z-40 flex h-screen w-screen items-center justify-center"
-        role="dialog"
-        aria-modal="true"
-        tabindex="-1"
-        {onkeydown}
-    >
-        <div class="flex size-full items-center justify-center">
-            <div
-                class="border-border bg-window-background rounded border border-solid p-2 shadow {size}"
-            >
-                {@render children?.()}
-            </div>
-        </div>
-    </div>
-{/if}
+<BitsUiDialog.Root bind:open={showDialog}>
+    <BitsUiDialog.Portal>
+        <BitsUiDialog.Overlay class="bg-dialog-backlight fixed inset-0 z-40" />
+        <BitsUiDialog.Content
+            class="border-border bg-window-background fixed top-1/2 left-1/2 z-40 -translate-x-1/2 -translate-y-1/2 rounded border border-solid p-2 shadow outline-none {size}"
+            {onkeydown}
+            onEscapeKeydown={handleEscapeKeydown}
+            onInteractOutside={handleInteractOutside}
+        >
+            {@render children?.()}
+        </BitsUiDialog.Content>
+    </BitsUiDialog.Portal>
+</BitsUiDialog.Root>

--- a/frontend/src/lib/dialog/DiscardCancelConfirmDialog.svelte
+++ b/frontend/src/lib/dialog/DiscardCancelConfirmDialog.svelte
@@ -20,10 +20,10 @@
         faRotateLeft,
         faXmark,
     } from "@fortawesome/free-solid-svg-icons";
+    import { AlertDialog as BitsUiAlertDialog } from "bits-ui";
     import { Fa } from "svelte-fa";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
-    import Dialog from "$lib/dialog/Dialog.svelte";
 
     let {
         showDialog = $bindable(),
@@ -47,65 +47,75 @@
     }
 </script>
 
-<Dialog
-    bind:showDialog
-    onkeydown={handleKeyDown}
-    {...restProps}
-    size="w-full max-w-md"
->
-    <div class="flex items-start gap-3 p-2">
-        <div
-            class="bg-red flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white"
+<BitsUiAlertDialog.Root bind:open={showDialog}>
+    <BitsUiAlertDialog.Portal>
+        <BitsUiAlertDialog.Overlay
+            class="bg-dialog-backlight fixed inset-0 z-40"
+        />
+        <BitsUiAlertDialog.Content
+            {...restProps}
+            class="border-border bg-window-background fixed top-1/2 left-1/2 z-40 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded border border-solid p-2 shadow outline-none"
+            onkeydown={handleKeyDown}
         >
-            <Fa icon={faExclamation} />
-        </div>
+            <div class="flex items-start gap-3 p-2">
+                <div
+                    class="bg-red flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white"
+                >
+                    <Fa icon={faExclamation} />
+                </div>
 
-        <div class="min-w-0">
-            <h2 class="text-default-text text-lg leading-9 font-semibold">
-                Unsaved changes
-            </h2>
+                <div class="min-w-0">
+                    <BitsUiAlertDialog.Title
+                        class="text-default-text text-lg leading-9 font-semibold"
+                    >
+                        Unsaved changes
+                    </BitsUiAlertDialog.Title>
 
-            <div class="text-text-subtle space-y-1 pt-2 pb-1">
-                <p class="text-sm leading-relaxed">
-                    Unsaved changes will be lost.
-                </p>
-                <p class="text-sm leading-relaxed">
-                    {#if disableSave}
-                        Cannot save because the changes are invalid.
-                    {:else}
-                        Do you want to save before continuing?
-                    {/if}
-                </p>
+                    <BitsUiAlertDialog.Description
+                        class="text-text-subtle space-y-1 pt-2 pb-1"
+                    >
+                        <p class="text-sm leading-relaxed">
+                            Unsaved changes will be lost.
+                        </p>
+                        <p class="text-sm leading-relaxed">
+                            {#if disableSave}
+                                Cannot save because the changes are invalid.
+                            {:else}
+                                Do you want to save before continuing?
+                            {/if}
+                        </p>
+                    </BitsUiAlertDialog.Description>
+                </div>
             </div>
-        </div>
-    </div>
-    <div class="flex flex-row justify-end gap-2 px-2 pb-2">
-        <div>
-            <FaIconButton
-                callOnClick={() => closeDialog(onCancel)}
-                icon={faXmark}
-                text="Cancel"
-            />
-        </div>
+            <div class="flex flex-row justify-end gap-2 px-2 pb-2">
+                <div>
+                    <FaIconButton
+                        callOnClick={() => closeDialog(onCancel)}
+                        icon={faXmark}
+                        text="Cancel"
+                    />
+                </div>
 
-        <div>
-            <FaIconButton
-                callOnClick={() => closeDialog(onDiscard)}
-                icon={faRotateLeft}
-                variant="danger"
-                text="Discard"
-                title="Discard changes"
-            />
-        </div>
+                <div>
+                    <FaIconButton
+                        callOnClick={() => closeDialog(onDiscard)}
+                        icon={faRotateLeft}
+                        variant="danger"
+                        text="Discard"
+                        title="Discard changes"
+                    />
+                </div>
 
-        <div>
-            <FaIconButton
-                callOnClick={() => closeDialog(onSave)}
-                icon={faFloppyDisk}
-                disabled={disableSave}
-                text="Save"
-                title="Save changes"
-            />
-        </div>
-    </div>
-</Dialog>
+                <div>
+                    <FaIconButton
+                        callOnClick={() => closeDialog(onSave)}
+                        icon={faFloppyDisk}
+                        disabled={disableSave}
+                        text="Save"
+                        title="Save changes"
+                    />
+                </div>
+            </div>
+        </BitsUiAlertDialog.Content>
+    </BitsUiAlertDialog.Portal>
+</BitsUiAlertDialog.Root>

--- a/frontend/src/lib/dialog/DiscardCancelConfirmDialog.svelte
+++ b/frontend/src/lib/dialog/DiscardCancelConfirmDialog.svelte
@@ -24,6 +24,7 @@
     import { Fa } from "svelte-fa";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
+    import AlertDialog from "$lib/dialog/AlertDialog.svelte";
 
     let {
         showDialog = $bindable(),
@@ -47,75 +48,69 @@
     }
 </script>
 
-<BitsUiAlertDialog.Root bind:open={showDialog}>
-    <BitsUiAlertDialog.Portal>
-        <BitsUiAlertDialog.Overlay
-            class="bg-dialog-backlight fixed inset-0 z-40"
-        />
-        <BitsUiAlertDialog.Content
-            {...restProps}
-            class="border-border bg-window-background fixed top-1/2 left-1/2 z-40 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded border border-solid p-2 shadow outline-none"
-            onkeydown={handleKeyDown}
+<AlertDialog
+    bind:showDialog
+    {...restProps}
+    size="w-full max-w-md"
+    onkeydown={handleKeyDown}
+>
+    <div class="flex items-start gap-3 p-2">
+        <div
+            class="bg-red flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white"
         >
-            <div class="flex items-start gap-3 p-2">
-                <div
-                    class="bg-red flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white"
-                >
-                    <Fa icon={faExclamation} />
-                </div>
+            <Fa icon={faExclamation} />
+        </div>
 
-                <div class="min-w-0">
-                    <BitsUiAlertDialog.Title
-                        class="text-default-text text-lg leading-9 font-semibold"
-                    >
-                        Unsaved changes
-                    </BitsUiAlertDialog.Title>
+        <div class="min-w-0">
+            <BitsUiAlertDialog.Title
+                class="text-default-text text-lg leading-9 font-semibold"
+            >
+                Unsaved changes
+            </BitsUiAlertDialog.Title>
 
-                    <BitsUiAlertDialog.Description
-                        class="text-text-subtle space-y-1 pt-2 pb-1"
-                    >
-                        <p class="text-sm leading-relaxed">
-                            Unsaved changes will be lost.
-                        </p>
-                        <p class="text-sm leading-relaxed">
-                            {#if disableSave}
-                                Cannot save because the changes are invalid.
-                            {:else}
-                                Do you want to save before continuing?
-                            {/if}
-                        </p>
-                    </BitsUiAlertDialog.Description>
-                </div>
-            </div>
-            <div class="flex flex-row justify-end gap-2 px-2 pb-2">
-                <div>
-                    <FaIconButton
-                        callOnClick={() => closeDialog(onCancel)}
-                        icon={faXmark}
-                        text="Cancel"
-                    />
-                </div>
+            <BitsUiAlertDialog.Description
+                class="text-text-subtle space-y-1 pt-2 pb-1"
+            >
+                <p class="text-sm leading-relaxed">
+                    Unsaved changes will be lost.
+                </p>
+                <p class="text-sm leading-relaxed">
+                    {#if disableSave}
+                        Cannot save because the changes are invalid.
+                    {:else}
+                        Do you want to save before continuing?
+                    {/if}
+                </p>
+            </BitsUiAlertDialog.Description>
+        </div>
+    </div>
+    <div class="flex flex-row justify-end gap-2 px-2 pb-2">
+        <div>
+            <FaIconButton
+                callOnClick={() => closeDialog(onCancel)}
+                icon={faXmark}
+                text="Cancel"
+            />
+        </div>
 
-                <div>
-                    <FaIconButton
-                        callOnClick={() => closeDialog(onDiscard)}
-                        icon={faRotateLeft}
-                        variant="danger"
-                        text="Discard"
-                        title="Discard changes"
-                    />
-                </div>
+        <div>
+            <FaIconButton
+                callOnClick={() => closeDialog(onDiscard)}
+                icon={faRotateLeft}
+                variant="danger"
+                text="Discard"
+                title="Discard changes"
+            />
+        </div>
 
-                <div>
-                    <FaIconButton
-                        callOnClick={() => closeDialog(onSave)}
-                        icon={faFloppyDisk}
-                        disabled={disableSave}
-                        text="Save"
-                        title="Save changes"
-                    />
-                </div>
-            </div>
-        </BitsUiAlertDialog.Content>
-    </BitsUiAlertDialog.Portal>
-</BitsUiAlertDialog.Root>
+        <div>
+            <FaIconButton
+                callOnClick={() => closeDialog(onSave)}
+                icon={faFloppyDisk}
+                disabled={disableSave}
+                text="Save"
+                title="Save changes"
+            />
+        </div>
+    </div>
+</AlertDialog>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -120,6 +120,9 @@
 
     async function handleKeydown(event) {
         if (event.key === "Escape") {
+            if (event.defaultPrevented) {
+                return;
+            }
             eventStack.executeNewestEvent();
             return;
         }


### PR DESCRIPTION
## Description

Replaced the custom shared dialog implementation with `bits-ui` dialog and alert-dialog primitives. Standard dialogs now get built-in focus trapping/restoration and close on backdrop click.


## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
