### PR TITLE
feat: Class Editor loading animation (RDFA-447)

### DIFF
--- a/frontend/src/lib/sharedState.svelte.js
+++ b/frontend/src/lib/sharedState.svelte.js
@@ -43,6 +43,7 @@ export const editorState = {
     selectedClassDataset: new StateValuePair(),
     selectedClassGraph: new StateValuePair(),
     selectedClassUUID: new StateValuePair(),
+    selectedContext: new StateValuePair(),
 
     reset() {
         this.selectedDataset.updateValue(null);
@@ -51,6 +52,7 @@ export const editorState = {
         this.selectedClassDataset.updateValue(null);
         this.selectedClassGraph.updateValue(null);
         this.selectedClassUUID.updateValue(null);
+        this.selectedContext.updateValue(null);
     },
 };
 

--- a/frontend/src/lib/sharedState.svelte.js
+++ b/frontend/src/lib/sharedState.svelte.js
@@ -43,9 +43,6 @@ export const editorState = {
     selectedClassDataset: new StateValuePair(),
     selectedClassGraph: new StateValuePair(),
     selectedClassUUID: new StateValuePair(),
-    previousSelectedClass: new StateValuePair(),
-    previousSelectedDatasetReadOnly: new StateValuePair(),
-    previousContext: new StateValuePair(),
 
     reset() {
         this.selectedDataset.updateValue(null);
@@ -54,9 +51,6 @@ export const editorState = {
         this.selectedClassDataset.updateValue(null);
         this.selectedClassGraph.updateValue(null);
         this.selectedClassUUID.updateValue(null);
-        this.previousSelectedClass.updateValue(null);
-        this.previousSelectedDatasetReadOnly.updateValue(null);
-        this.previousContext.updateValue(null);
     },
 };
 

--- a/frontend/src/lib/sharedState.svelte.js
+++ b/frontend/src/lib/sharedState.svelte.js
@@ -43,6 +43,9 @@ export const editorState = {
     selectedClassDataset: new StateValuePair(),
     selectedClassGraph: new StateValuePair(),
     selectedClassUUID: new StateValuePair(),
+    previousSelectedClass: new StateValuePair(),
+    previousSelectedDatasetReadOnly: new StateValuePair(),
+    previousContext: new StateValuePair(),
 
     reset() {
         this.selectedDataset.updateValue(null);
@@ -51,6 +54,9 @@ export const editorState = {
         this.selectedClassDataset.updateValue(null);
         this.selectedClassGraph.updateValue(null);
         this.selectedClassUUID.updateValue(null);
+        this.previousSelectedClass.updateValue(null);
+        this.previousSelectedDatasetReadOnly.updateValue(null);
+        this.previousContext.updateValue(null);
     },
 };
 

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -24,14 +24,14 @@
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import { mapClassDtoToReactiveClass } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";
-    import { editorState } from "$lib/sharedState.svelte.js";
+    import { editorState, forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
     import {
         getClasses,
         getDataTypes,
         getNamespaces,
         getPackages,
-        getStereotypes,
+        getStereotypes
     } from "./fetch-class-editor-context.js";
     import ShaclPropertySpecificDialog from "../../shacl/SHACLPropertySpecificDialog.svelte";
     import Associations from "./components/associations/Associations.svelte";
@@ -45,6 +45,7 @@
     import Stereotypes from "./components/stereotypes/Stereotypes.svelte";
     import SuperClass from "./components/SuperClass.svelte";
     import Uuid from "./components/Uuid.svelte";
+    import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
 
     const { datasetName, graphUri, classUuid } = $props();
 
@@ -57,7 +58,7 @@
         stereotypes: [],
         datatypes: [],
         packages: [],
-        classes: [],
+        classes: []
     };
 
     let isDatasetReadOnly = $state(false);
@@ -66,9 +67,11 @@
 
     let loadingContext = $state(true);
 
+    let loadingClass = $state(true);
+
     const propertyShaclRulesDialog = $state({
         showDialog: false,
-        property: null,
+        property: null
     });
 
     let showDiscardSaveConfirmDialog = $state(false);
@@ -78,7 +81,7 @@
     let classToOpenNext = $state(null);
 
     let isEnum = $derived(
-        reactiveClass?.stereotypes.contains(enumerationStereotype),
+        reactiveClass?.stereotypes.contains(enumerationStereotype)
     );
 
     onMount(async () => {
@@ -91,12 +94,29 @@
 
     onDestroy(() => eventStack.removeEvent(closeClassEditor));
 
+    $effect(async () => {
+        editorState.selectedClassUUID.subscribe();
+        loadingContext = true;
+        loadingClass = true;
+
+        isDatasetReadOnly = await isReadOnly(datasetName);
+        await loadContext();
+        await loadReactiveClass();
+    });
+
+
+    $effect(async () => {
+        editorState.selectedPackageUUID.subscribe();
+        isDatasetReadOnly = await isReadOnly(datasetName);
+    })
+
+
     function closeClassEditor(
         { datasetName = null, graphUri = null, classUuid = null } = {
             datasetName: null,
             graphUri: null,
-            classUuid: null,
-        },
+            classUuid: null
+        }
     ) {
         if (!showDiscardSaveConfirmDialog && reactiveClass?.isModified) {
             showDiscardSaveConfirmDialog = true;
@@ -125,6 +145,7 @@
             getNamespaces(datasetName),
         ]);
         loadingContext = false;
+        editorState.selectedContext.trigger();
     }
 
     async function loadReactiveClass() {
@@ -132,6 +153,7 @@
             await bec.getClassInfo(datasetName, graphUri, classUuid)
         ).json();
         reactiveClass = mapClassDtoToReactiveClass(classDto, context.classes);
+        loadingClass = false;
         console.log({ reactiveClass });
     }
 
@@ -170,14 +192,14 @@
         },
         // get Objects by identifier functions
         get getClassByUuid() {
-            return function (uuid) {
+            return function(uuid) {
                 return context.classes.find(cls => cls.uuid === uuid);
             };
         },
         get getSubstitutedNamespace() {
-            return function (namespace) {
+            return function(namespace) {
                 const namespaceObj = context.namespaces.find(
-                    p => p.prefix === namespace,
+                    p => p.prefix === namespace
                 );
                 let returnValue = namespaceObj
                     ? namespaceObj.substitutedPrefix
@@ -189,46 +211,48 @@
             };
         },
         get getDatatypeByUri() {
-            return function (uri) {
+            return function(uri) {
                 return context.datatypes.find(
-                    dt => dt.prefix + dt.label === uri,
+                    dt => dt.prefix + dt.label === uri
                 );
             };
         },
         get getPackageByUuid() {
-            return function (uuid) {
+            return function(uuid) {
                 return context.packages.find(pkg => pkg.uuid === uuid);
             };
-        },
+        }
     });
 </script>
 
-<Splitpanes
-    theme="opencgmes-theme"
-    horizontal
-    class="bg-window-background h-screen"
->
-    {#if !loadingContext && reactiveClass}
-        <Pane
-            size={75}
-            class="bg-window-background z-2 size-full rounded-xs border-none"
-        >
-            <div class="flex size-full flex-col p-2">
-                <ClassEditorButtons
-                    {reactiveClass}
-                    bind:showDiscardSaveConfirmDialog
-                    {datasetOfClassToOpenNext}
-                    {graphOfClassToOpenNext}
-                    {classToOpenNext}
-                />
-                <div
-                    class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
-                >
-                    <div class="mt-1 flex max-h-max flex-col justify-between">
-                        <table
-                            class="border-separate border-spacing-x-1.5 border-spacing-y-1"
-                        >
-                            <tbody>
+<div class="relative h-screen w-full">
+    <Splitpanes
+        theme="opencgmes-theme"
+        horizontal
+        class="bg-window-background h-screen"
+    >
+
+        {#if reactiveClass}
+            <Pane
+                size={75}
+                class="bg-window-background z-2 size-full rounded-xs border-none"
+            >
+                <div class="flex size-full flex-col p-2">
+                    <ClassEditorButtons
+                        {reactiveClass}
+                        bind:showDiscardSaveConfirmDialog
+                        {datasetOfClassToOpenNext}
+                        {graphOfClassToOpenNext}
+                        {classToOpenNext}
+                    />
+                    <div
+                        class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
+                    >
+                        <div class="mt-1 flex max-h-max flex-col justify-between">
+                            <table
+                                class="border-separate border-spacing-x-1.5 border-spacing-y-1"
+                            >
+                                <tbody>
                                 <Uuid uuid={reactiveClass.uuid} />
                                 <Label label={reactiveClass.label} />
                                 <Namespace
@@ -264,26 +288,28 @@
                                         </div>
                                     </td>
                                 </tr>
-                            </tbody>
-                        </table>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </Pane>
+            </Pane>
 
-        <Pane
-            size={25}
-            class="bg-window-background flex h-full flex-col space-y-1 rounded-xs border-none px-2 pb-2"
-        >
-            <Comment comment={reactiveClass.comment} />
-        </Pane>
-        <ShaclPropertySpecificDialog
-            bind:showDialog={propertyShaclRulesDialog.showDialog}
-            property={propertyShaclRulesDialog.property}
-        />
-    {:else}
-        <Pane class="bg-window-background z-2 h-full rounded-xs border-none">
-            Loading...
-        </Pane>
+            <Pane
+                size={25}
+                class="bg-window-background flex h-full flex-col space-y-1 rounded-xs border-none px-2 pb-2"
+            >
+                <Comment comment={reactiveClass.comment} />
+            </Pane>
+            <ShaclPropertySpecificDialog
+                bind:showDialog={propertyShaclRulesDialog.showDialog}
+                property={propertyShaclRulesDialog.property}
+            />
+        {/if}
+    </Splitpanes>
+    {#if loadingClass || loadingContext}
+        <div class="absolute inset-0 z-50 flex items-center justify-center bg-white/50">
+            <LoadingSpinner />
+        </div>
     {/if}
-</Splitpanes>
+</div>

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -19,9 +19,9 @@
     import { onDestroy, onMount, setContext } from "svelte";
     import { Pane, Splitpanes } from "svelte-splitpanes";
 
+    import { isReadOnly } from "$lib/api/apiDatasetUtils.js";
     import { BackendConnection } from "$lib/api/backend.js";
     import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
-    import { isReadOnly } from "$lib/api/apiDatasetUtils.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import { mapClassDtoToReactiveClass } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -60,9 +60,13 @@
         classes: [],
     };
 
+    let previousContext = $state();
+
     let isDatasetReadOnly = $state(false);
 
     let reactiveClass = $state();
+
+    let previousReactiveClass = $state();
 
     let loadingContext = $state(true);
 
@@ -82,12 +86,20 @@
     );
 
     onMount(async () => {
+        console.log("mounting class editor for class with uuid " + classUuid);
         isDatasetReadOnly = await isReadOnly(datasetName);
         await loadContext();
         await loadReactiveClass();
     });
 
-    onMount(() => eventStack.addEvent(closeClassEditor));
+    onMount(() => {
+        eventStack.addEvent(closeClassEditor);
+        previousReactiveClass = editorState.previousSelectedClass.getValue();
+        isDatasetReadOnly = editorState.previousSelectedDatasetReadOnly.getValue();
+        previousContext = editorState.previousContext.getValue();
+        console.log({ previousReactiveClass });
+        console.log({ previousContext });
+    })
 
     onDestroy(() => eventStack.removeEvent(closeClassEditor));
 
@@ -108,6 +120,10 @@
         editorState.selectedClassDataset.updateValue(datasetName);
         editorState.selectedClassGraph.updateValue(graphUri);
         editorState.selectedClassUUID.updateValue(classUuid);
+        editorState.previousSelectedClass.updateValue(reactiveClass);
+        editorState.previousSelectedDatasetReadOnly.updateValue(isDatasetReadOnly);
+        editorState.previousContext.updateValue(console);
+        console.log("closing class editor");
     }
 
     async function loadContext() {
@@ -125,9 +141,11 @@
             getNamespaces(datasetName),
         ]);
         loadingContext = false;
+        console.log("loading context");
     }
 
     async function loadReactiveClass() {
+        console.log("loading reactive class");
         const classDto = await (
             await bec.getClassInfo(datasetName, graphUri, classUuid)
         ).json();
@@ -176,9 +194,16 @@
         },
         get getSubstitutedNamespace() {
             return function (namespace) {
-                const namespaceObj = context.namespaces.find(
-                    p => p.prefix === namespace,
-                );
+                let namespaceObj;
+                //if (loadingContext) {
+                //    namespaceObj = previousContext.namespaces.find(
+                //        p => p.prefix === namespace,
+                //    );
+                //} else {
+                    namespaceObj = context.namespaces.find(
+                        p => p.prefix === namespace,
+                    );
+                //}
                 let returnValue = namespaceObj
                     ? namespaceObj.substitutedPrefix
                     : namespace;
@@ -281,9 +306,86 @@
             bind:showDialog={propertyShaclRulesDialog.showDialog}
             property={propertyShaclRulesDialog.property}
         />
+    {:else if previousReactiveClass}
+        <Pane
+            size={75}
+            class="bg-window-background z-2 size-full rounded-xs border-none"
+        >
+            <div class="flex size-full flex-col p-2">
+                <ClassEditorButtons
+                    reactiveClass={previousReactiveClass}
+                    bind:showDiscardSaveConfirmDialog
+                    {datasetOfClassToOpenNext}
+                    {graphOfClassToOpenNext}
+                    {classToOpenNext}
+                />
+                <div
+                    class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
+                >
+                    <div class="mt-1 flex max-h-max flex-col justify-between">
+                        <table
+                            class="border-separate border-spacing-x-1.5 border-spacing-y-1"
+                        >
+                            <tbody>
+                            <Uuid uuid={previousReactiveClass.uuid} />
+                            <Label label={previousReactiveClass.label} />
+                            <Namespace
+                                namespace={previousReactiveClass.namespace}
+                            />
+                            <Package pack={previousReactiveClass.package} />
+                            <SuperClass
+                                superClass={previousReactiveClass.superClass}
+                            />
+                            <Stereotypes
+                                classStereotypes={previousReactiveClass.stereotypes}
+                            />
+                            <tr>
+                                <td colspan="2">
+                                    <div
+                                        class="flex size-full flex-col space-y-1.5"
+                                    >
+                                        {#if isEnum}
+                                            <EnumEntries
+                                                enumEntries={previousReactiveClass.enumEntries}
+                                                cls={previousReactiveClass}
+                                            />
+                                        {:else}
+                                            <Attributes
+                                                attributes={previousReactiveClass.attributes}
+                                                {openPropertySHACLRulesDialog}
+                                            />
+                                            <Associations
+                                                associations={previousReactiveClass.associations}
+                                                {openPropertySHACLRulesDialog}
+                                            />
+                                        {/if}
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </Pane>
+
+        <Pane
+            size={25}
+            class="bg-window-background flex h-full flex-col space-y-1 rounded-xs border-none px-2 pb-2"
+        >
+            <Comment comment={previousReactiveClass.comment} />
+        </Pane>
+        <ShaclPropertySpecificDialog
+            bind:showDialog={propertyShaclRulesDialog.showDialog}
+            property={propertyShaclRulesDialog.property}
+        />
+        <Pane class="bg-white/50 z-2 h-full rounded-xs border-none">
+            Loading class details...
+        </Pane>
     {:else}
         <Pane class="bg-window-background z-2 h-full rounded-xs border-none">
             Loading...
+            {previousReactiveClass}
         </Pane>
     {/if}
 </Splitpanes>

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -19,10 +19,9 @@
     import { onDestroy, onMount, setContext } from "svelte";
     import { Pane, Splitpanes } from "svelte-splitpanes";
 
-    import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
-
-    import { isReadOnly } from "$lib/api/apiDatasetUtils.js";
     import { BackendConnection } from "$lib/api/backend.js";
+    import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
+    import { isReadOnly } from "$lib/api/apiDatasetUtils.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import { mapClassDtoToReactiveClass } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";
@@ -35,7 +34,6 @@
         getPackages,
         getStereotypes,
     } from "./fetch-class-editor-context.js";
-
     import ShaclPropertySpecificDialog from "../../shacl/SHACLPropertySpecificDialog.svelte";
     import Associations from "./components/associations/Associations.svelte";
     import Attributes from "./components/attributes/Attributes.svelte";

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -21,6 +21,7 @@
 
     import { isReadOnly } from "$lib/api/apiDatasetUtils.js";
     import { BackendConnection } from "$lib/api/backend.js";
+    import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import { mapClassDtoToReactiveClass } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";
@@ -66,6 +67,8 @@
 
     let loadingContext = $state(true);
 
+    let loadingClass = $state(true);
+
     const propertyShaclRulesDialog = $state({
         showDialog: false,
         property: null,
@@ -80,6 +83,21 @@
     let isEnum = $derived(
         reactiveClass?.stereotypes.contains(enumerationStereotype),
     );
+
+    $effect(async () => {
+        editorState.selectedClassUUID.subscribe();
+        loadingContext = true;
+        loadingClass = true;
+
+        isDatasetReadOnly = await isReadOnly(datasetName);
+        await loadContext();
+        await loadReactiveClass();
+    });
+
+    $effect(async () => {
+        editorState.selectedPackageUUID.subscribe();
+        isDatasetReadOnly = await isReadOnly(datasetName);
+    });
 
     onMount(async () => {
         isDatasetReadOnly = await isReadOnly(datasetName);
@@ -125,6 +143,7 @@
             getNamespaces(datasetName),
         ]);
         loadingContext = false;
+        editorState.selectedContext.trigger();
     }
 
     async function loadReactiveClass() {
@@ -132,6 +151,7 @@
             await bec.getClassInfo(datasetName, graphUri, classUuid)
         ).json();
         reactiveClass = mapClassDtoToReactiveClass(classDto, context.classes);
+        loadingClass = false;
         console.log({ reactiveClass });
     }
 
@@ -203,87 +223,94 @@
     });
 </script>
 
-<Splitpanes
-    theme="opencgmes-theme"
-    horizontal
-    class="bg-window-background h-screen"
->
-    {#if !loadingContext && reactiveClass}
-        <Pane
-            size={75}
-            class="bg-window-background z-2 size-full rounded-xs border-none"
-        >
-            <div class="flex size-full flex-col p-2">
-                <ClassEditorButtons
-                    {reactiveClass}
-                    bind:showDiscardSaveConfirmDialog
-                    {datasetOfClassToOpenNext}
-                    {graphOfClassToOpenNext}
-                    {classToOpenNext}
-                />
-                <div
-                    class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
-                >
-                    <div class="mt-1 flex max-h-max flex-col justify-between">
-                        <table
-                            class="border-separate border-spacing-x-1.5 border-spacing-y-1"
+<div class="relative h-screen w-full">
+    <Splitpanes
+        theme="opencgmes-theme"
+        horizontal
+        class="bg-window-background h-screen"
+    >
+        {#if reactiveClass}
+            <Pane
+                size={75}
+                class="bg-window-background z-2 size-full rounded-xs border-none"
+            >
+                <div class="flex size-full flex-col p-2">
+                    <ClassEditorButtons
+                        {reactiveClass}
+                        bind:showDiscardSaveConfirmDialog
+                        {datasetOfClassToOpenNext}
+                        {graphOfClassToOpenNext}
+                        {classToOpenNext}
+                    />
+                    <div
+                        class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
+                    >
+                        <div
+                            class="mt-1 flex max-h-max flex-col justify-between"
                         >
-                            <tbody>
-                                <Uuid uuid={reactiveClass.uuid} />
-                                <Label label={reactiveClass.label} />
-                                <Namespace
-                                    namespace={reactiveClass.namespace}
-                                />
-                                <Package pack={reactiveClass.package} />
-                                <SuperClass
-                                    superClass={reactiveClass.superClass}
-                                />
-                                <Stereotypes
-                                    classStereotypes={reactiveClass.stereotypes}
-                                />
-                                <tr>
-                                    <td colspan="2">
-                                        <div
-                                            class="flex size-full flex-col space-y-1.5"
-                                        >
-                                            {#if isEnum}
-                                                <EnumEntries
-                                                    enumEntries={reactiveClass.enumEntries}
-                                                    cls={reactiveClass}
-                                                />
-                                            {:else}
-                                                <Attributes
-                                                    attributes={reactiveClass.attributes}
-                                                    {openPropertySHACLRulesDialog}
-                                                />
-                                                <Associations
-                                                    associations={reactiveClass.associations}
-                                                    {openPropertySHACLRulesDialog}
-                                                />
-                                            {/if}
-                                        </div>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                            <table
+                                class="border-separate border-spacing-x-1.5 border-spacing-y-1"
+                            >
+                                <tbody>
+                                    <Uuid uuid={reactiveClass.uuid} />
+                                    <Label label={reactiveClass.label} />
+                                    <Namespace
+                                        namespace={reactiveClass.namespace}
+                                    />
+                                    <Package pack={reactiveClass.package} />
+                                    <SuperClass
+                                        superClass={reactiveClass.superClass}
+                                    />
+                                    <Stereotypes
+                                        classStereotypes={reactiveClass.stereotypes}
+                                    />
+                                    <tr>
+                                        <td colspan="2">
+                                            <div
+                                                class="flex size-full flex-col space-y-1.5"
+                                            >
+                                                {#if isEnum}
+                                                    <EnumEntries
+                                                        enumEntries={reactiveClass.enumEntries}
+                                                        cls={reactiveClass}
+                                                    />
+                                                {:else}
+                                                    <Attributes
+                                                        attributes={reactiveClass.attributes}
+                                                        {openPropertySHACLRulesDialog}
+                                                    />
+                                                    <Associations
+                                                        associations={reactiveClass.associations}
+                                                        {openPropertySHACLRulesDialog}
+                                                    />
+                                                {/if}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </Pane>
+            </Pane>
 
-        <Pane
-            size={25}
-            class="bg-window-background flex h-full flex-col space-y-1 rounded-xs border-none px-2 pb-2"
+            <Pane
+                size={25}
+                class="bg-window-background flex h-full flex-col space-y-1 rounded-xs border-none px-2 pb-2"
+            >
+                <Comment comment={reactiveClass.comment} />
+            </Pane>
+            <ShaclPropertySpecificDialog
+                bind:showDialog={propertyShaclRulesDialog.showDialog}
+                property={propertyShaclRulesDialog.property}
+            />
+        {/if}
+    </Splitpanes>
+    {#if loadingClass || loadingContext}
+        <div
+            class="absolute inset-0 z-50 flex items-center justify-center bg-white/50"
         >
-            <Comment comment={reactiveClass.comment} />
-        </Pane>
-        <ShaclPropertySpecificDialog
-            bind:showDialog={propertyShaclRulesDialog.showDialog}
-            property={propertyShaclRulesDialog.property}
-        />
-    {:else}
-        <Pane class="bg-window-background z-2 h-full rounded-xs border-none">
-            Loading...
-        </Pane>
+            <LoadingSpinner />
+        </div>
     {/if}
-</Splitpanes>
+</div>

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -24,14 +24,17 @@
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import { mapClassDtoToReactiveClass } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";
-    import { editorState, forceReloadTrigger } from "$lib/sharedState.svelte.js";
+    import {
+        editorState,
+        forceReloadTrigger,
+    } from "$lib/sharedState.svelte.js";
 
     import {
         getClasses,
         getDataTypes,
         getNamespaces,
         getPackages,
-        getStereotypes
+        getStereotypes,
     } from "./fetch-class-editor-context.js";
     import ShaclPropertySpecificDialog from "../../shacl/SHACLPropertySpecificDialog.svelte";
     import Associations from "./components/associations/Associations.svelte";
@@ -58,7 +61,7 @@
         stereotypes: [],
         datatypes: [],
         packages: [],
-        classes: []
+        classes: [],
     };
 
     let isDatasetReadOnly = $state(false);
@@ -71,7 +74,7 @@
 
     const propertyShaclRulesDialog = $state({
         showDialog: false,
-        property: null
+        property: null,
     });
 
     let showDiscardSaveConfirmDialog = $state(false);
@@ -81,7 +84,7 @@
     let classToOpenNext = $state(null);
 
     let isEnum = $derived(
-        reactiveClass?.stereotypes.contains(enumerationStereotype)
+        reactiveClass?.stereotypes.contains(enumerationStereotype),
     );
 
     onMount(async () => {
@@ -104,19 +107,17 @@
         await loadReactiveClass();
     });
 
-
     $effect(async () => {
         editorState.selectedPackageUUID.subscribe();
         isDatasetReadOnly = await isReadOnly(datasetName);
-    })
-
+    });
 
     function closeClassEditor(
         { datasetName = null, graphUri = null, classUuid = null } = {
             datasetName: null,
             graphUri: null,
-            classUuid: null
-        }
+            classUuid: null,
+        },
     ) {
         if (!showDiscardSaveConfirmDialog && reactiveClass?.isModified) {
             showDiscardSaveConfirmDialog = true;
@@ -192,14 +193,14 @@
         },
         // get Objects by identifier functions
         get getClassByUuid() {
-            return function(uuid) {
+            return function (uuid) {
                 return context.classes.find(cls => cls.uuid === uuid);
             };
         },
         get getSubstitutedNamespace() {
-            return function(namespace) {
+            return function (namespace) {
                 const namespaceObj = context.namespaces.find(
-                    p => p.prefix === namespace
+                    p => p.prefix === namespace,
                 );
                 let returnValue = namespaceObj
                     ? namespaceObj.substitutedPrefix
@@ -211,17 +212,17 @@
             };
         },
         get getDatatypeByUri() {
-            return function(uri) {
+            return function (uri) {
                 return context.datatypes.find(
-                    dt => dt.prefix + dt.label === uri
+                    dt => dt.prefix + dt.label === uri,
                 );
             };
         },
         get getPackageByUuid() {
-            return function(uuid) {
+            return function (uuid) {
                 return context.packages.find(pkg => pkg.uuid === uuid);
             };
-        }
+        },
     });
 </script>
 
@@ -231,7 +232,6 @@
         horizontal
         class="bg-window-background h-screen"
     >
-
         {#if reactiveClass}
             <Pane
                 size={75}
@@ -248,46 +248,48 @@
                     <div
                         class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
                     >
-                        <div class="mt-1 flex max-h-max flex-col justify-between">
+                        <div
+                            class="mt-1 flex max-h-max flex-col justify-between"
+                        >
                             <table
                                 class="border-separate border-spacing-x-1.5 border-spacing-y-1"
                             >
                                 <tbody>
-                                <Uuid uuid={reactiveClass.uuid} />
-                                <Label label={reactiveClass.label} />
-                                <Namespace
-                                    namespace={reactiveClass.namespace}
-                                />
-                                <Package pack={reactiveClass.package} />
-                                <SuperClass
-                                    superClass={reactiveClass.superClass}
-                                />
-                                <Stereotypes
-                                    classStereotypes={reactiveClass.stereotypes}
-                                />
-                                <tr>
-                                    <td colspan="2">
-                                        <div
-                                            class="flex size-full flex-col space-y-1.5"
-                                        >
-                                            {#if isEnum}
-                                                <EnumEntries
-                                                    enumEntries={reactiveClass.enumEntries}
-                                                    cls={reactiveClass}
-                                                />
-                                            {:else}
-                                                <Attributes
-                                                    attributes={reactiveClass.attributes}
-                                                    {openPropertySHACLRulesDialog}
-                                                />
-                                                <Associations
-                                                    associations={reactiveClass.associations}
-                                                    {openPropertySHACLRulesDialog}
-                                                />
-                                            {/if}
-                                        </div>
-                                    </td>
-                                </tr>
+                                    <Uuid uuid={reactiveClass.uuid} />
+                                    <Label label={reactiveClass.label} />
+                                    <Namespace
+                                        namespace={reactiveClass.namespace}
+                                    />
+                                    <Package pack={reactiveClass.package} />
+                                    <SuperClass
+                                        superClass={reactiveClass.superClass}
+                                    />
+                                    <Stereotypes
+                                        classStereotypes={reactiveClass.stereotypes}
+                                    />
+                                    <tr>
+                                        <td colspan="2">
+                                            <div
+                                                class="flex size-full flex-col space-y-1.5"
+                                            >
+                                                {#if isEnum}
+                                                    <EnumEntries
+                                                        enumEntries={reactiveClass.enumEntries}
+                                                        cls={reactiveClass}
+                                                    />
+                                                {:else}
+                                                    <Attributes
+                                                        attributes={reactiveClass.attributes}
+                                                        {openPropertySHACLRulesDialog}
+                                                    />
+                                                    <Associations
+                                                        associations={reactiveClass.associations}
+                                                        {openPropertySHACLRulesDialog}
+                                                    />
+                                                {/if}
+                                            </div>
+                                        </td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -308,7 +310,9 @@
         {/if}
     </Splitpanes>
     {#if loadingClass || loadingContext}
-        <div class="absolute inset-0 z-50 flex items-center justify-center bg-white/50">
+        <div
+            class="absolute inset-0 z-50 flex items-center justify-center bg-white/50"
+        >
             <LoadingSpinner />
         </div>
     {/if}

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -19,15 +19,14 @@
     import { onDestroy, onMount, setContext } from "svelte";
     import { Pane, Splitpanes } from "svelte-splitpanes";
 
+    import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
+
     import { isReadOnly } from "$lib/api/apiDatasetUtils.js";
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import { mapClassDtoToReactiveClass } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";
-    import {
-        editorState,
-        forceReloadTrigger,
-    } from "$lib/sharedState.svelte.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     import {
         getClasses,
@@ -36,6 +35,7 @@
         getPackages,
         getStereotypes,
     } from "./fetch-class-editor-context.js";
+
     import ShaclPropertySpecificDialog from "../../shacl/SHACLPropertySpecificDialog.svelte";
     import Associations from "./components/associations/Associations.svelte";
     import Attributes from "./components/attributes/Attributes.svelte";
@@ -48,7 +48,6 @@
     import Stereotypes from "./components/stereotypes/Stereotypes.svelte";
     import SuperClass from "./components/SuperClass.svelte";
     import Uuid from "./components/Uuid.svelte";
-    import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
 
     const { datasetName, graphUri, classUuid } = $props();
 
@@ -87,16 +86,6 @@
         reactiveClass?.stereotypes.contains(enumerationStereotype),
     );
 
-    onMount(async () => {
-        isDatasetReadOnly = await isReadOnly(datasetName);
-        await loadContext();
-        await loadReactiveClass();
-    });
-
-    onMount(() => eventStack.addEvent(closeClassEditor));
-
-    onDestroy(() => eventStack.removeEvent(closeClassEditor));
-
     $effect(async () => {
         editorState.selectedClassUUID.subscribe();
         loadingContext = true;
@@ -111,6 +100,16 @@
         editorState.selectedPackageUUID.subscribe();
         isDatasetReadOnly = await isReadOnly(datasetName);
     });
+
+    onMount(async () => {
+        isDatasetReadOnly = await isReadOnly(datasetName);
+        await loadContext();
+        await loadReactiveClass();
+    });
+
+    onMount(() => eventStack.addEvent(closeClassEditor));
+
+    onDestroy(() => eventStack.removeEvent(closeClassEditor));
 
     function closeClassEditor(
         { datasetName = null, graphUri = null, classUuid = null } = {

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -60,13 +60,9 @@
         classes: [],
     };
 
-    let previousContext = $state();
-
     let isDatasetReadOnly = $state(false);
 
     let reactiveClass = $state();
-
-    let previousReactiveClass = $state();
 
     let loadingContext = $state(true);
 
@@ -86,20 +82,12 @@
     );
 
     onMount(async () => {
-        console.log("mounting class editor for class with uuid " + classUuid);
         isDatasetReadOnly = await isReadOnly(datasetName);
         await loadContext();
         await loadReactiveClass();
     });
 
-    onMount(() => {
-        eventStack.addEvent(closeClassEditor);
-        previousReactiveClass = editorState.previousSelectedClass.getValue();
-        isDatasetReadOnly = editorState.previousSelectedDatasetReadOnly.getValue();
-        previousContext = editorState.previousContext.getValue();
-        console.log({ previousReactiveClass });
-        console.log({ previousContext });
-    })
+    onMount(() => eventStack.addEvent(closeClassEditor));
 
     onDestroy(() => eventStack.removeEvent(closeClassEditor));
 
@@ -120,10 +108,6 @@
         editorState.selectedClassDataset.updateValue(datasetName);
         editorState.selectedClassGraph.updateValue(graphUri);
         editorState.selectedClassUUID.updateValue(classUuid);
-        editorState.previousSelectedClass.updateValue(reactiveClass);
-        editorState.previousSelectedDatasetReadOnly.updateValue(isDatasetReadOnly);
-        editorState.previousContext.updateValue(console);
-        console.log("closing class editor");
     }
 
     async function loadContext() {
@@ -141,11 +125,9 @@
             getNamespaces(datasetName),
         ]);
         loadingContext = false;
-        console.log("loading context");
     }
 
     async function loadReactiveClass() {
-        console.log("loading reactive class");
         const classDto = await (
             await bec.getClassInfo(datasetName, graphUri, classUuid)
         ).json();
@@ -194,16 +176,9 @@
         },
         get getSubstitutedNamespace() {
             return function (namespace) {
-                let namespaceObj;
-                //if (loadingContext) {
-                //    namespaceObj = previousContext.namespaces.find(
-                //        p => p.prefix === namespace,
-                //    );
-                //} else {
-                    namespaceObj = context.namespaces.find(
-                        p => p.prefix === namespace,
-                    );
-                //}
+                const namespaceObj = context.namespaces.find(
+                    p => p.prefix === namespace,
+                );
                 let returnValue = namespaceObj
                     ? namespaceObj.substitutedPrefix
                     : namespace;
@@ -306,86 +281,9 @@
             bind:showDialog={propertyShaclRulesDialog.showDialog}
             property={propertyShaclRulesDialog.property}
         />
-    {:else if previousReactiveClass}
-        <Pane
-            size={75}
-            class="bg-window-background z-2 size-full rounded-xs border-none"
-        >
-            <div class="flex size-full flex-col p-2">
-                <ClassEditorButtons
-                    reactiveClass={previousReactiveClass}
-                    bind:showDiscardSaveConfirmDialog
-                    {datasetOfClassToOpenNext}
-                    {graphOfClassToOpenNext}
-                    {classToOpenNext}
-                />
-                <div
-                    class="border-border mt-2 size-full overflow-y-scroll rounded-sm border-t"
-                >
-                    <div class="mt-1 flex max-h-max flex-col justify-between">
-                        <table
-                            class="border-separate border-spacing-x-1.5 border-spacing-y-1"
-                        >
-                            <tbody>
-                            <Uuid uuid={previousReactiveClass.uuid} />
-                            <Label label={previousReactiveClass.label} />
-                            <Namespace
-                                namespace={previousReactiveClass.namespace}
-                            />
-                            <Package pack={previousReactiveClass.package} />
-                            <SuperClass
-                                superClass={previousReactiveClass.superClass}
-                            />
-                            <Stereotypes
-                                classStereotypes={previousReactiveClass.stereotypes}
-                            />
-                            <tr>
-                                <td colspan="2">
-                                    <div
-                                        class="flex size-full flex-col space-y-1.5"
-                                    >
-                                        {#if isEnum}
-                                            <EnumEntries
-                                                enumEntries={previousReactiveClass.enumEntries}
-                                                cls={previousReactiveClass}
-                                            />
-                                        {:else}
-                                            <Attributes
-                                                attributes={previousReactiveClass.attributes}
-                                                {openPropertySHACLRulesDialog}
-                                            />
-                                            <Associations
-                                                associations={previousReactiveClass.associations}
-                                                {openPropertySHACLRulesDialog}
-                                            />
-                                        {/if}
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-        </Pane>
-
-        <Pane
-            size={25}
-            class="bg-window-background flex h-full flex-col space-y-1 rounded-xs border-none px-2 pb-2"
-        >
-            <Comment comment={previousReactiveClass.comment} />
-        </Pane>
-        <ShaclPropertySpecificDialog
-            bind:showDialog={propertyShaclRulesDialog.showDialog}
-            property={propertyShaclRulesDialog.property}
-        />
-        <Pane class="bg-white/50 z-2 h-full rounded-xs border-none">
-            Loading class details...
-        </Pane>
     {:else}
         <Pane class="bg-window-background z-2 h-full rounded-xs border-none">
             Loading...
-            {previousReactiveClass}
         </Pane>
     {/if}
 </Splitpanes>

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -48,12 +48,12 @@
     const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $derived(classEditorContext.readonly);
-    let datasetName = $derived(classEditorContext.datasetName);
-    let graphUri = $derived(classEditorContext.graphUri);
 
     let showClassDeleteDialog = $state(false);
     let showSHACLClassDialog = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
+    let datasetName = $derived(classEditorContext.datasetName);
+    let graphUri = $derived(classEditorContext.graphUri);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -65,7 +65,7 @@
         readonly = classEditorContext.readonly;
         datasetName = classEditorContext.datasetName;
         graphUri = classEditorContext.graphUri;
-    })
+    });
 
     function saveChanges() {
         console.log("Saving changes for class");

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -21,7 +21,7 @@
         faRotateLeft,
         faTrash,
     } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import { BackendConnection } from "$lib/api/backend.js";
     import FaIconButton from "$lib/components/FaIconButton.svelte";
@@ -47,12 +47,25 @@
     const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const datasetName = classEditorContext.datasetName;
-    const graphUri = classEditorContext.graphUri;
+    let readonly = $state(false);
+    let datasetName = $state();
+    let graphUri = $state();
 
     let showClassDeleteDialog = $state(false);
     let showSHACLClassDialog = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+        datasetName = classEditorContext.datasetName;
+        graphUri = classEditorContext.graphUri;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        datasetName = classEditorContext.datasetName;
+        graphUri = classEditorContext.graphUri;
+    });
 
     function saveChanges() {
         console.log("Saving changes for class");

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -21,7 +21,7 @@
         faRotateLeft,
         faTrash,
     } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import { BackendConnection } from "$lib/api/backend.js";
     import FaIconButton from "$lib/components/FaIconButton.svelte";
@@ -47,12 +47,25 @@
     const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const datasetName = classEditorContext.datasetName;
-    const graphUri = classEditorContext.graphUri;
+    let readonly = $state(false);
+    let datasetName = $state();
+    let graphUri = $state();
 
     let showClassDeleteDialog = $state(false);
     let showSHACLClassDialog = $state(false);
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        datasetName = classEditorContext.datasetName;
+        graphUri = classEditorContext.graphUri;
+    });
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+        datasetName = classEditorContext.datasetName;
+        graphUri = classEditorContext.graphUri;
+    })
 
     function saveChanges() {
         console.log("Saving changes for class");

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -48,9 +48,9 @@
     const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
-    let datasetName = $state();
-    let graphUri = $state();
+    let readonly = $derived(classEditorContext.readonly);
+    let datasetName = $derived(classEditorContext.datasetName);
+    let graphUri = $derived(classEditorContext.graphUri);
 
     let showClassDeleteDialog = $state(false);
     let showSHACLClassDialog = $state(false);

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -54,14 +54,14 @@
     let showClassDeleteDialog = $state(false);
     let showSHACLClassDialog = $state(false);
 
-    onMount(() => {
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
         datasetName = classEditorContext.datasetName;
         graphUri = classEditorContext.graphUri;
     });
 
-    $effect(() => {
-        editorState.selectedPackageUUID.subscribe();
+    onMount(() => {
         readonly = classEditorContext.readonly;
         datasetName = classEditorContext.datasetName;
         graphUri = classEditorContext.graphUri;

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -23,8 +23,9 @@
     import TextAreaControl from "$lib/components/TextAreaControl.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
 
-    import AsciidocComment from "../asciidocComment.svelte";
     import { editorState } from "$lib/sharedState.svelte.js";
+
+    import AsciidocComment from "../asciidocComment.svelte";
 
     const { comment } = $props();
 
@@ -33,12 +34,12 @@
     let editClassComment = $state(false);
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col">

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -31,7 +31,7 @@
     const classEditorContext = getContext("classEditor");
     const id = uuidv4();
     let editClassComment = $state(false);
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -22,7 +22,6 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import TextAreaControl from "$lib/components/TextAreaControl.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
-
     import { editorState } from "$lib/sharedState.svelte.js";
 
     import AsciidocComment from "../asciidocComment.svelte";

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -33,13 +33,12 @@
     let editClassComment = $state(false);
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
-
+    });
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col">

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -16,20 +16,29 @@
   -->
 <script>
     import { faEye, faGear } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuidv4 } from "uuid";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import TextAreaControl from "$lib/components/TextAreaControl.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     import AsciidocComment from "../asciidocComment.svelte";
 
     const { comment } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
     const id = uuidv4();
     let editClassComment = $state(false);
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col">

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -16,7 +16,7 @@
   -->
 <script>
     import { faEye, faGear } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuidv4 } from "uuid";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
@@ -24,12 +24,22 @@
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
 
     import AsciidocComment from "../asciidocComment.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { comment } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
     const id = uuidv4();
     let editClassComment = $state(false);
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col">

--- a/frontend/src/routes/mainpage/classEditor/components/Label.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Label.svelte
@@ -28,7 +28,7 @@
     const id = uuid();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/Label.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Label.svelte
@@ -30,12 +30,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/Label.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Label.svelte
@@ -15,17 +15,27 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { label } = $props();
 
-    const readonly = getContext("classEditor").readonly;
     const id = uuid();
+
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/Label.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Label.svelte
@@ -30,13 +30,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
-
+    });
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/Label.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Label.svelte
@@ -15,17 +15,28 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { label } = $props();
 
-    const readonly = getContext("classEditor").readonly;
     const id = uuid();
+
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -27,9 +27,9 @@
     let { namespace } = $props();
 
     const classEditorContext = getContext("classEditor");
+    const id = uuid();
     let namespaces = $state();
     let reactiveClass = $state();
-    const id = uuid();
     let readonly = $state(false);
 
     $effect(() => {

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -28,9 +28,9 @@
 
     const classEditorContext = getContext("classEditor");
     const id = uuid();
-    let namespaces = $state();
-    let reactiveClass = $state();
-    let readonly = $state(false);
+    let namespaces = $derived(classEditorContext.namespaces);
+    let reactiveClass = $derived(classEditorContext.reactiveClass);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -36,18 +36,18 @@
         readonly = classEditorContext.readonly;
         namespaces = classEditorContext.namespaces;
         reactiveClass = classEditorContext.reactiveClass;
-    })
+    });
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     $effect(() => {
         editorState.selectedContext.subscribe();
         namespaces = classEditorContext.namespaces;
         reactiveClass = classEditorContext.reactiveClass;
-    })
+    });
 
     function trickleDownNamespaceChange(newNamespaceUri) {
         const oldNamespaceUri = namespace.value;

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -21,8 +21,8 @@
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
-    import { getNsPrefixNsUriString } from "$lib/utils/namespace.js";
     import { editorState } from "$lib/sharedState.svelte.js";
+    import { getNsPrefixNsUriString } from "$lib/utils/namespace.js";
 
     let { namespace } = $props();
 
@@ -32,12 +32,6 @@
     const id = uuid();
     let readonly = $state(false);
 
-    onMount(() => {
-        readonly = classEditorContext.readonly;
-        namespaces = classEditorContext.namespaces;
-        reactiveClass = classEditorContext.reactiveClass;
-    });
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
@@ -45,6 +39,12 @@
 
     $effect(() => {
         editorState.selectedContext.subscribe();
+        namespaces = classEditorContext.namespaces;
+        reactiveClass = classEditorContext.reactiveClass;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
         namespaces = classEditorContext.namespaces;
         reactiveClass = classEditorContext.reactiveClass;
     });

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -15,21 +15,39 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
     import { getNsPrefixNsUriString } from "$lib/utils/namespace.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { namespace } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const namespaces = classEditorContext.namespaces;
-    const reactiveClass = classEditorContext.reactiveClass;
+    let namespaces = $state();
+    let reactiveClass = $state();
     const id = uuid();
+    let readonly = $state(false);
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        namespaces = classEditorContext.namespaces;
+        reactiveClass = classEditorContext.reactiveClass;
+    })
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
+    $effect(() => {
+        editorState.selectedContext.subscribe();
+        namespaces = classEditorContext.namespaces;
+        reactiveClass = classEditorContext.reactiveClass;
+    })
 
     function trickleDownNamespaceChange(newNamespaceUri) {
         const oldNamespaceUri = namespace.value;

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -15,21 +15,39 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
     import { getNsPrefixNsUriString } from "$lib/utils/namespace.js";
 
     let { namespace } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const namespaces = classEditorContext.namespaces;
-    const reactiveClass = classEditorContext.reactiveClass;
     const id = uuid();
+    let namespaces = $state();
+    let reactiveClass = $state();
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    $effect(() => {
+        editorState.selectedContext.subscribe();
+        namespaces = classEditorContext.namespaces;
+        reactiveClass = classEditorContext.reactiveClass;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        namespaces = classEditorContext.namespaces;
+        reactiveClass = classEditorContext.reactiveClass;
+    });
 
     function trickleDownNamespaceChange(newNamespaceUri) {
         const oldNamespaceUri = namespace.value;

--- a/frontend/src/routes/mainpage/classEditor/components/Package.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Package.svelte
@@ -15,19 +15,27 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { pack } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
     const packages = classEditorContext.packages;
     const id = uuid();
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function getPackageLabel(packageUUID) {
         const pkg = classEditorContext.getPackageByUuid(packageUUID);

--- a/frontend/src/routes/mainpage/classEditor/components/Package.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Package.svelte
@@ -30,12 +30,12 @@
     const id = uuid();
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function getPackageLabel(packageUUID) {
         const pkg = classEditorContext.getPackageByUuid(packageUUID);

--- a/frontend/src/routes/mainpage/classEditor/components/Package.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Package.svelte
@@ -30,12 +30,12 @@
     const id = uuid();
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     function getPackageLabel(packageUUID) {
         const pkg = classEditorContext.getPackageByUuid(packageUUID);

--- a/frontend/src/routes/mainpage/classEditor/components/Package.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Package.svelte
@@ -28,7 +28,7 @@
     const classEditorContext = getContext("classEditor");
     const packages = classEditorContext.packages;
     const id = uuid();
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/Package.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Package.svelte
@@ -15,19 +15,27 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { pack } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
     const packages = classEditorContext.packages;
     const id = uuid();
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
 
     function getPackageLabel(packageUUID) {
         const pkg = classEditorContext.getPackageByUuid(packageUUID);

--- a/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
@@ -16,19 +16,36 @@
   -->
 
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { superClass } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const classes = classEditorContext.classes;
-    const readonly = classEditorContext.readonly;
     const id = uuid();
+
+    let classes = $state();
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    $effect(() => {
+        editorState.selectedContext.subscribe();
+        classes = classEditorContext.classes;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        classes = classEditorContext.classes;
+    });
 
     function getSuperClassLabel(superClassUuid) {
         const cls = classEditorContext.getClassByUuid(superClassUuid);

--- a/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
@@ -39,12 +39,12 @@
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     $effect(() => {
         editorState.selectedContext.subscribe();
         classes = classEditorContext.classes;
-    })
+    });
 
     function getSuperClassLabel(superClassUuid) {
         const cls = classEditorContext.getClassByUuid(superClassUuid);

--- a/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
@@ -27,14 +27,10 @@
     let { superClass } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let classes = $state();
     const id = uuid();
-    let readonly = $state(false);
 
-    onMount(() => {
-        readonly = classEditorContext.readonly;
-        classes = classEditorContext.classes;
-    });
+    let classes = $state();
+    let readonly = $state(false);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
@@ -43,6 +39,11 @@
 
     $effect(() => {
         editorState.selectedContext.subscribe();
+        classes = classEditorContext.classes;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
         classes = classEditorContext.classes;
     });
 

--- a/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
@@ -16,19 +16,35 @@
   -->
 
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuid } from "uuid";
 
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { superClass } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const classes = classEditorContext.classes;
-    const readonly = classEditorContext.readonly;
+    let classes = $state();
     const id = uuid();
+    let readonly = $state(false);
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        classes = classEditorContext.classes;
+    });
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
+    $effect(() => {
+        editorState.selectedContext.subscribe();
+        classes = classEditorContext.classes;
+    })
 
     function getSuperClassLabel(superClassUuid) {
         const cls = classEditorContext.getClassByUuid(superClassUuid);

--- a/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
@@ -29,8 +29,8 @@
     const classEditorContext = getContext("classEditor");
     const id = uuid();
 
-    let classes = $state();
-    let readonly = $state(false);
+    let classes = $derived(classEditorContext.classes);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
@@ -50,13 +50,13 @@
     onMount(() => {
         readonly = classEditorContext.readonly;
         classes = classEditorContext.classes;
-    })
+    });
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
         classes = classEditorContext.classes;
-    })
+    });
 
     function getButtons(multiplicityObject) {
         const buttons = getControlButtonsForReactiveObject(

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
@@ -22,13 +22,14 @@
         faGear,
         faMinus,
     } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import NumberInputControl from "$lib/components/NumberInputControl.svelte";
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const {
         associations,
@@ -39,12 +40,22 @@
     } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const classes = classEditorContext.classes;
+    let readonly = $state(false);
+    let classes = $state();
 
     let lowerButtons = $derived(getButtons(association.multiplicityLowerBound));
-
     let upperButtons = $derived(getButtons(association.multiplicityUpperBound));
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+        classes = classEditorContext.classes;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        classes = classEditorContext.classes;
+    });
 
     function getButtons(multiplicityObject) {
         const buttons = getControlButtonsForReactiveObject(

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
@@ -22,13 +22,14 @@
         faGear,
         faMinus,
     } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import NumberInputControl from "$lib/components/NumberInputControl.svelte";
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const {
         associations,
@@ -39,12 +40,23 @@
     } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const classes = classEditorContext.classes;
+    let readonly = $state(false);
+    let classes = $state();
 
     let lowerButtons = $derived(getButtons(association.multiplicityLowerBound));
 
     let upperButtons = $derived(getButtons(association.multiplicityUpperBound));
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        classes = classEditorContext.classes;
+    })
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+        classes = classEditorContext.classes;
+    })
 
     function getButtons(multiplicityObject) {
         const buttons = getControlButtonsForReactiveObject(

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
@@ -44,16 +44,15 @@
     let classes = $state();
 
     let lowerButtons = $derived(getButtons(association.multiplicityLowerBound));
-
     let upperButtons = $derived(getButtons(association.multiplicityUpperBound));
 
-    onMount(() => {
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
         classes = classEditorContext.classes;
     });
 
-    $effect(() => {
-        editorState.selectedPackageUUID.subscribe();
+    onMount(() => {
         readonly = classEditorContext.readonly;
         classes = classEditorContext.classes;
     });

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Association.svelte
@@ -40,8 +40,8 @@
     } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
-    let classes = $state();
+    let readonly = $derived(classEditorContext.readonly);
+    let classes = $derived(classEditorContext.classes);
 
     let lowerButtons = $derived(getButtons(association.multiplicityLowerBound));
     let upperButtons = $derived(getButtons(association.multiplicityUpperBound));

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
@@ -22,9 +22,10 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
+    import { editorState } from "$lib/sharedState.svelte.js";
+
     import Association from "./Association.svelte";
     import AssociationEditorDialog from "./associationEditorDialog/AssociationEditorDialog.svelte";
-    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { associations, openPropertySHACLRulesDialog } = $props();
 
@@ -46,15 +47,15 @@
     let resizeObserver;
     let readonly = $state(false);
 
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
     onMount(() => {
         updateWidth();
         resizeObserver = new ResizeObserver(updateWidth);
         resizeObserver.observe(container);
-        readonly = classEditorContext.readonly;
-    });
-
-    $effect(() => {
-        editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
 

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
@@ -44,7 +44,7 @@
     let container;
     let w = $state(MIN_W);
     let resizeObserver;
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
@@ -21,7 +21,6 @@
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
-
     import { editorState } from "$lib/sharedState.svelte.js";
 
     import Association from "./Association.svelte";

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
@@ -56,7 +56,7 @@
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     onDestroy(() => {
         resizeObserver?.disconnect();

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
@@ -24,6 +24,7 @@
 
     import Association from "./Association.svelte";
     import AssociationEditorDialog from "./associationEditorDialog/AssociationEditorDialog.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { associations, openPropertySHACLRulesDialog } = $props();
 
@@ -31,7 +32,7 @@
     const MAX_W = 20;
     const REM_PER_W = 0.25;
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
 
     const associationEditorDialog = $state({
         showDialog: false,
@@ -43,12 +44,19 @@
     let container;
     let w = $state(MIN_W);
     let resizeObserver;
+    let readonly = $state(false);
 
     onMount(() => {
         updateWidth();
         resizeObserver = new ResizeObserver(updateWidth);
         resizeObserver.observe(container);
+        readonly = classEditorContext.readonly;
     });
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
 
     onDestroy(() => {
         resizeObserver?.disconnect();

--- a/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/Associations.svelte
@@ -21,6 +21,7 @@
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     import Association from "./Association.svelte";
     import AssociationEditorDialog from "./associationEditorDialog/AssociationEditorDialog.svelte";
@@ -31,7 +32,7 @@
     const MAX_W = 20;
     const REM_PER_W = 0.25;
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
 
     const associationEditorDialog = $state({
         showDialog: false,
@@ -43,11 +44,18 @@
     let container;
     let w = $state(MIN_W);
     let resizeObserver;
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
 
     onMount(() => {
         updateWidth();
         resizeObserver = new ResizeObserver(updateWidth);
         resizeObserver.observe(container);
+        readonly = classEditorContext.readonly;
     });
 
     onDestroy(() => {

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
@@ -40,12 +40,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function getDatatypeLabelByUri(uri) {
         const datatype = classEditorContext.getDatatypeByUri(uri);

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
@@ -38,7 +38,7 @@
     } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
@@ -21,13 +21,14 @@
         faGear,
         faMinus,
     } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let {
         attributes,
@@ -37,7 +38,14 @@
     } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function getDatatypeLabelByUri(uri) {
         const datatype = classEditorContext.getDatatypeByUri(uri);

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
@@ -21,13 +21,14 @@
         faGear,
         faMinus,
     } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let {
         attributes,
@@ -37,7 +38,14 @@
     } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
 
     function getDatatypeLabelByUri(uri) {
         const datatype = classEditorContext.getDatatypeByUri(uri);

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
@@ -40,12 +40,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     function getDatatypeLabelByUri(uri) {
         const datatype = classEditorContext.getDatatypeByUri(uri);

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -28,7 +28,6 @@
     const { attributes, openPropertySHACLRulesDialog } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $derived(classEditorContext.readonly);
 
     const attributeEditorDialog = $state({
         showDialog: false,
@@ -36,6 +35,7 @@
     });
 
     let expandStereotypes = $state(true);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -20,7 +20,6 @@
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
-
     import { editorState } from "$lib/sharedState.svelte.js";
 
     import Attribute from "./Attribute.svelte";

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -16,17 +16,19 @@
   -->
 <script>
     import { faPlus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     import Attribute from "./Attribute.svelte";
     import AttributeEditorDialog from "./AttributeEditorDialog.svelte";
 
     const { attributes, openPropertySHACLRulesDialog } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
 
     const attributeEditorDialog = $state({
         showDialog: false,
@@ -34,6 +36,13 @@
     });
 
     let expandStereotypes = $state(true);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = getContext("classEditor").readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function openAttributeEditor(attribute) {
         attributeEditorDialog.attribute = attribute;

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -37,12 +37,12 @@
 
     let expandStereotypes = $state(true);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = getContext("classEditor").readonly;
-    })
+    });
 
     function openAttributeEditor(attribute) {
         attributeEditorDialog.attribute = attribute;

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -28,7 +28,7 @@
     const { attributes, openPropertySHACLRulesDialog } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     const attributeEditorDialog = $state({
         showDialog: false,

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -16,17 +16,19 @@
   -->
 <script>
     import { faPlus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
     import Attribute from "./Attribute.svelte";
     import AttributeEditorDialog from "./AttributeEditorDialog.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { attributes, openPropertySHACLRulesDialog } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
 
     const attributeEditorDialog = $state({
         showDialog: false,
@@ -34,6 +36,13 @@
     });
 
     let expandStereotypes = $state(true);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = getContext("classEditor").readonly;
+    })
 
     function openAttributeEditor(attribute) {
         attributeEditorDialog.attribute = attribute;

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attributes.svelte
@@ -21,9 +21,10 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
+    import { editorState } from "$lib/sharedState.svelte.js";
+
     import Attribute from "./Attribute.svelte";
     import AttributeEditorDialog from "./AttributeEditorDialog.svelte";
-    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { attributes, openPropertySHACLRulesDialog } = $props();
 
@@ -37,12 +38,12 @@
 
     let expandStereotypes = $state(true);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = getContext("classEditor").readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function openAttributeEditor(attribute) {
         attributeEditorDialog.attribute = attribute;

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -22,21 +22,22 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
+    import { editorState } from "$lib/sharedState.svelte.js";
+
     import EnumEntry from "./EnumEntry.svelte";
     import EnumEntryEditorDialog from "./EnumEntryEditorDialog.svelte";
-    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { enumEntries } = $props();
 
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     const enumEntryEditorDialog = $state({
         showDialog: false,

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -21,7 +21,6 @@
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
-
     import { editorState } from "$lib/sharedState.svelte.js";
 
     import EnumEntry from "./EnumEntry.svelte";
@@ -30,7 +29,13 @@
     const { enumEntries } = $props();
 
     const classEditorContext = getContext("classEditor");
+    const enumEntryEditorDialog = $state({
+        showDialog: false,
+        enumEntry: null,
+    });
     let readonly = $state(false);
+
+    let expandStereotypes = $state(true);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
@@ -38,13 +43,6 @@
     });
 
     onMount(() => (readonly = classEditorContext.readonly));
-
-    const enumEntryEditorDialog = $state({
-        showDialog: false,
-        enumEntry: null,
-    });
-
-    let expandStereotypes = $state(true);
 
     function openEnumEntryEditor(enumEntry) {
         enumEntryEditorDialog.enumEntry = enumEntry;

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -33,9 +33,9 @@
         showDialog: false,
         enumEntry: null,
     });
-    let readonly = $derived(classEditorContext.readonly);
 
     let expandStereotypes = $state(true);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -17,17 +17,26 @@
 
 <script>
     import { faPlus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
     import EnumEntry from "./EnumEntry.svelte";
     import EnumEntryEditorDialog from "./EnumEntryEditorDialog.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { enumEntries } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
 
     const enumEntryEditorDialog = $state({
         showDialog: false,

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -17,24 +17,32 @@
 
 <script>
     import { faPlus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     import EnumEntry from "./EnumEntry.svelte";
     import EnumEntryEditorDialog from "./EnumEntryEditorDialog.svelte";
 
     const { enumEntries } = $props();
 
-    const readonly = getContext("classEditor").readonly;
-
+    const classEditorContext = getContext("classEditor");
     const enumEntryEditorDialog = $state({
         showDialog: false,
         enumEntry: null,
     });
+    let readonly = $state(false);
 
     let expandStereotypes = $state(true);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     function openEnumEntryEditor(enumEntry) {
         enumEntryEditorDialog.enumEntry = enumEntry;

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -31,12 +31,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     const enumEntryEditorDialog = $state({
         showDialog: false,

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntries.svelte
@@ -33,7 +33,7 @@
         showDialog: false,
         enumEntry: null,
     });
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     let expandStereotypes = $state(true);
 

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
@@ -30,12 +30,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
@@ -28,7 +28,7 @@
     const { enumEntries, enumEntry, openEnumEntryEditor } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
@@ -30,13 +30,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
-
+    });
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
@@ -17,16 +17,25 @@
 
 <script>
     import { faEye, faGear, faMinus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { enumEntries, enumEntry, openEnumEntryEditor } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntry.svelte
@@ -17,16 +17,26 @@
 
 <script>
     import { faEye, faGear, faMinus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { enumEntries, enumEntry, openEnumEntryEditor } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -15,18 +15,30 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuidv4 } from "uuid";
 
     import CheckBoxEditControl from "$lib/components/CheckBoxEditControl.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { classStereotypes } = $props();
 
     const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
-    const readonly = getContext("classEditor").readonly;
-    const id = uuidv4();
+    const classEditorContext = getContext("classEditor");
+    let id = uuidv4();
 
     let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
+    let readonly = $state(false);
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+    })
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -31,12 +31,12 @@
 
     let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
 
-    onMount(() => {
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
 
-    $effect(() => {
-        editorState.selectedPackageUUID.subscribe();
+    onMount(() => {
         readonly = classEditorContext.readonly;
     });
 </script>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -32,13 +32,12 @@
 
     onMount(() => {
         readonly = classEditorContext.readonly;
-    })
+    });
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
-
+    });
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -27,8 +27,9 @@
     const classEditorContext = getContext("classEditor");
     let id = uuidv4();
 
-    let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
     let readonly = $state(false);
+
+    let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
 
     onMount(() => {
         readonly = classEditorContext.readonly;

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -25,9 +25,9 @@
 
     const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
     const classEditorContext = getContext("classEditor");
-    let id = uuidv4();
+    const id = uuidv4();
 
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
 
     let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
 

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -15,18 +15,30 @@
   -
   -->
 <script>
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import { v4 as uuidv4 } from "uuid";
 
     import CheckBoxEditControl from "$lib/components/CheckBoxEditControl.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { classStereotypes } = $props();
 
     const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
-    const readonly = getContext("classEditor").readonly;
-    const id = uuidv4();
+    const classEditorContext = getContext("classEditor");
+    let id = uuidv4();
+
+    let readonly = $state(false);
 
     let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+    });
 </script>
 
 <tr>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
@@ -17,19 +17,35 @@
 
 <script>
     import { faMinus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import ComboBoxEditControl from "$lib/components/ComboBoxEditControl.svelte";
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { classStereotypes, stereotype } = $props();
 
-    const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const suggestedStereotypes = classEditorContext.stereotypes;
+    const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
+    let suggestedStereotypes = $state();
+    let readonly = $state(false);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    $effect(() => {
+        editorState.selectedContext.subscribe();
+        suggestedStereotypes = classEditorContext.stereotypes;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        suggestedStereotypes = classEditorContext.stereotypes;
+    });
 </script>
 
 {#if stereotype.value !== concreteStereotype}

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
@@ -32,11 +32,6 @@
     let suggestedStereotypes = $state();
     let readonly = $state(false);
 
-    onMount(() => {
-        readonly = classEditorContext.readonly;
-        suggestedStereotypes = classEditorContext.stereotypes;
-    });
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
@@ -44,6 +39,11 @@
 
     $effect(() => {
         editorState.selectedContext.subscribe();
+        suggestedStereotypes = classEditorContext.stereotypes;
+    });
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
         suggestedStereotypes = classEditorContext.stereotypes;
     });
 </script>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
@@ -17,19 +17,36 @@
 
 <script>
     import { faMinus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import ComboBoxEditControl from "$lib/components/ComboBoxEditControl.svelte";
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/reactive-utils.js";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     let { classStereotypes, stereotype } = $props();
 
-    const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
     const classEditorContext = getContext("classEditor");
-    const readonly = classEditorContext.readonly;
-    const suggestedStereotypes = classEditorContext.stereotypes;
+    const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
+    let suggestedStereotypes = $state();
+    let readonly = $state(false);
+
+    onMount(() => {
+        readonly = classEditorContext.readonly;
+        suggestedStereotypes = classEditorContext.stereotypes;
+    });
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
+
+    $effect(() => {
+        editorState.selectedContext.subscribe();
+        suggestedStereotypes = classEditorContext.stereotypes;
+    })
+
 </script>
 
 {#if stereotype.value !== concreteStereotype}

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
@@ -40,13 +40,12 @@
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     $effect(() => {
         editorState.selectedContext.subscribe();
         suggestedStereotypes = classEditorContext.stereotypes;
-    })
-
+    });
 </script>
 
 {#if stereotype.value !== concreteStereotype}

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
@@ -29,8 +29,8 @@
 
     const classEditorContext = getContext("classEditor");
     const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
-    let suggestedStereotypes = $state();
-    let readonly = $state(false);
+    let suggestedStereotypes = $derived(classEditorContext.stereotypes);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -29,8 +29,8 @@
     const { classStereotypes } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $derived(classEditorContext.readonly);
     let expandStereotypes = $state(true);
+    let readonly = $derived(classEditorContext.readonly);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -29,7 +29,7 @@
     const { classStereotypes } = $props();
 
     const classEditorContext = getContext("classEditor");
-    let readonly = $state(false);
+    let readonly = $derived(classEditorContext.readonly);
     let expandStereotypes = $state(true);
 
     $effect(() => {

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -22,21 +22,22 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
+    import { editorState } from "$lib/sharedState.svelte.js";
+
     import IsAbstract from "./IsAbstract.svelte";
     import Stereotype from "./Stereotype.svelte";
-    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { classStereotypes } = $props();
 
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => (readonly = classEditorContext.readonly));
-
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
     });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 
     let expandStereotypes = $state(true);
 </script>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -17,17 +17,26 @@
 
 <script>
     import { faPlus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
 
     import IsAbstract from "./IsAbstract.svelte";
     import Stereotype from "./Stereotype.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     const { classStereotypes } = $props();
 
-    const readonly = getContext("classEditor").readonly;
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
+
+    onMount(() => readonly = classEditorContext.readonly);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    })
 
     let expandStereotypes = $state(true);
 </script>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -31,12 +31,12 @@
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
 
-    onMount(() => readonly = classEditorContext.readonly);
+    onMount(() => (readonly = classEditorContext.readonly));
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
         readonly = classEditorContext.readonly;
-    })
+    });
 
     let expandStereotypes = $state(true);
 </script>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -21,7 +21,6 @@
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
-
     import { editorState } from "$lib/sharedState.svelte.js";
 
     import IsAbstract from "./IsAbstract.svelte";
@@ -31,6 +30,7 @@
 
     const classEditorContext = getContext("classEditor");
     let readonly = $state(false);
+    let expandStereotypes = $state(true);
 
     $effect(() => {
         editorState.selectedPackageUUID.subscribe();
@@ -38,8 +38,6 @@
     });
 
     onMount(() => (readonly = classEditorContext.readonly));
-
-    let expandStereotypes = $state(true);
 </script>
 
 <IsAbstract {classStereotypes} />

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotypes.svelte
@@ -17,19 +17,27 @@
 
 <script>
     import { faPlus } from "@fortawesome/free-solid-svg-icons";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import List from "$lib/components/List.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
 
     import IsAbstract from "./IsAbstract.svelte";
     import Stereotype from "./Stereotype.svelte";
 
     const { classStereotypes } = $props();
 
-    const readonly = getContext("classEditor").readonly;
-
+    const classEditorContext = getContext("classEditor");
+    let readonly = $state(false);
     let expandStereotypes = $state(true);
+
+    $effect(() => {
+        editorState.selectedPackageUUID.subscribe();
+        readonly = classEditorContext.readonly;
+    });
+
+    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
 <IsAbstract {classStereotypes} />

--- a/frontend/src/routes/mainpage/packageWindow.svelte
+++ b/frontend/src/routes/mainpage/packageWindow.svelte
@@ -54,7 +54,7 @@
         </div>
     {/key}
 
-    {#key editorState.selectedClassUUID.subscribe()}
+    <!--{#key editorState.selectedClassUUID.subscribe()}-->
         {#if editorState.selectedClassUUID.getValue()}
             <Splitpanes
                 theme="opencgmes-theme"
@@ -78,5 +78,5 @@
                 </Pane>
             </Splitpanes>
         {/if}
-    {/key}
+    <!--{/key}-->
 </div>

--- a/frontend/src/routes/mainpage/packageWindow.svelte
+++ b/frontend/src/routes/mainpage/packageWindow.svelte
@@ -54,29 +54,27 @@
         </div>
     {/key}
 
-    {#key editorState.selectedClassUUID.subscribe()}
-        {#if editorState.selectedClassUUID.getValue()}
-            <Splitpanes
-                theme="opencgmes-theme"
-                class="pointer-events-none absolute top-0 right-0 h-screen w-screen"
-                onresize={handleSplitPaneResize}
+    {#if editorState.selectedClassUUID.getValue()}
+        <Splitpanes
+            theme="opencgmes-theme"
+            class="pointer-events-none absolute top-0 right-0 h-screen w-screen"
+            onresize={handleSplitPaneResize}
+        >
+            <Pane
+                size={100 - classEditorPaneWidth}
+                class="pointer-events-none bg-transparent"
+            ></Pane>
+            <Pane
+                size={classEditorPaneWidth}
+                minSize={25}
+                class="pointer-events-auto h-full overflow-auto"
             >
-                <Pane
-                    size={100 - classEditorPaneWidth}
-                    class="pointer-events-none bg-transparent"
-                ></Pane>
-                <Pane
-                    size={classEditorPaneWidth}
-                    minSize={25}
-                    class="pointer-events-auto h-full overflow-auto"
-                >
-                    <ClassEditor
-                        datasetName={classDatasetName}
-                        graphUri={classGraphUri}
-                        classUuid={editorState.selectedClassUUID.getValue()}
-                    />
-                </Pane>
-            </Splitpanes>
-        {/if}
-    {/key}
+                <ClassEditor
+                    datasetName={classDatasetName}
+                    graphUri={classGraphUri}
+                    classUuid={editorState.selectedClassUUID.getValue()}
+                />
+            </Pane>
+        </Splitpanes>
+    {/if}
 </div>

--- a/frontend/src/routes/mainpage/packageWindow.svelte
+++ b/frontend/src/routes/mainpage/packageWindow.svelte
@@ -26,11 +26,11 @@
     let classEditorPaneWidth = 30;
     let classDatasetName = $derived(
         editorState.selectedClassDataset.getValue() ??
-        editorState.selectedDataset.getValue()
+            editorState.selectedDataset.getValue(),
     );
     let classGraphUri = $derived(
         editorState.selectedClassGraph.getValue() ??
-        editorState.selectedGraph.getValue()
+            editorState.selectedGraph.getValue(),
     );
 
     function handleSplitPaneResize(event) {

--- a/frontend/src/routes/mainpage/packageWindow.svelte
+++ b/frontend/src/routes/mainpage/packageWindow.svelte
@@ -26,11 +26,11 @@
     let classEditorPaneWidth = 30;
     let classDatasetName = $derived(
         editorState.selectedClassDataset.getValue() ??
-            editorState.selectedDataset.getValue(),
+        editorState.selectedDataset.getValue()
     );
     let classGraphUri = $derived(
         editorState.selectedClassGraph.getValue() ??
-            editorState.selectedGraph.getValue(),
+        editorState.selectedGraph.getValue()
     );
 
     function handleSplitPaneResize(event) {
@@ -54,29 +54,27 @@
         </div>
     {/key}
 
-    {#key editorState.selectedClassUUID.subscribe()}
-        {#if editorState.selectedClassUUID.getValue()}
-            <Splitpanes
-                theme="opencgmes-theme"
-                class="pointer-events-none absolute top-0 right-0 h-screen w-screen"
-                onresize={handleSplitPaneResize}
+    {#if editorState.selectedClassUUID.getValue()}
+        <Splitpanes
+            theme="opencgmes-theme"
+            class="pointer-events-none absolute top-0 right-0 h-screen w-screen"
+            onresize={handleSplitPaneResize}
+        >
+            <Pane
+                size={100 - classEditorPaneWidth}
+                class="pointer-events-none bg-transparent"
+            ></Pane>
+            <Pane
+                size={classEditorPaneWidth}
+                minSize={25}
+                class="pointer-events-auto h-full overflow-auto"
             >
-                <Pane
-                    size={100 - classEditorPaneWidth}
-                    class="pointer-events-none bg-transparent"
-                ></Pane>
-                <Pane
-                    size={classEditorPaneWidth}
-                    minSize={25}
-                    class="pointer-events-auto h-full overflow-auto"
-                >
-                    <ClassEditor
-                        datasetName={classDatasetName}
-                        graphUri={classGraphUri}
-                        classUuid={editorState.selectedClassUUID.getValue()}
-                    />
-                </Pane>
-            </Splitpanes>
-        {/if}
-    {/key}
+                <ClassEditor
+                    datasetName={classDatasetName}
+                    graphUri={classGraphUri}
+                    classUuid={editorState.selectedClassUUID.getValue()}
+                />
+            </Pane>
+        </Splitpanes>
+    {/if}
 </div>

--- a/frontend/src/routes/mainpage/packageWindow.svelte
+++ b/frontend/src/routes/mainpage/packageWindow.svelte
@@ -54,7 +54,7 @@
         </div>
     {/key}
 
-    <!--{#key editorState.selectedClassUUID.subscribe()}-->
+    {#key editorState.selectedClassUUID.subscribe()}
         {#if editorState.selectedClassUUID.getValue()}
             <Splitpanes
                 theme="opencgmes-theme"
@@ -78,5 +78,5 @@
                 </Pane>
             </Splitpanes>
         {/if}
-    <!--{/key}-->
+    {/key}
 </div>


### PR DESCRIPTION
## Description
Improved the loading animation when loading the class editor and when switching between classes

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
