### PR TITLE
chore: remove duplicated input ref from test image workflow

### DIFF
--- a/.github/workflows/publish-test-images.yml
+++ b/.github/workflows/publish-test-images.yml
@@ -2,12 +2,6 @@ name: Publish Test Images
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch, tag, or commit SHA to publish as :test"
-        required: true
-        default: main
-        type: string
 
 permissions:
   contents: read
@@ -23,7 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -80,7 +73,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0


### PR DESCRIPTION
Removed the input from the test image workflow, as its not needed.

Target branch can be preselected in GitHub Actions by default.