### PR TITLE
fix(editor): reset new item save state in class editor dialogs (RDFA-469)

### DIFF
--- a/frontend/src/routes/mainpage/classEditor/components/associations/associationEditorDialog/AssociationEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/associationEditorDialog/AssociationEditorDialog.svelte
@@ -29,8 +29,8 @@
     let { showDialog = $bindable(), associations, association } = $props();
 
     let classEditorContext = $state();
+    let isNewAssociation = $state(true);
     let readonly = $derived(classEditorContext?.readonly);
-    let isNewAssociation = $derived(true);
 
     function onOpen() {
         classEditorContext = getContext("classEditor");
@@ -49,25 +49,29 @@
     }
 
     async function saveAssociation() {
-        if (isNewAssociation) {
-            associations.append(association);
-        }
         const apiAssociation = mapReactiveAssociationToAssociationDto(
             association,
             classEditorContext.reactiveClass,
             classEditorContext.getClassByUuid,
         );
-        saveApiAssociationToBackend(
+        const result = await saveApiAssociationToBackend(
             classEditorContext.datasetName,
             classEditorContext.graphUri,
             classEditorContext.reactiveClass.uuid.value,
             apiAssociation,
             isNewAssociation,
-        ).then(res => {
-            if (res.ok) {
-                association.save();
-            }
-        });
+        );
+        if (!result.ok) {
+            return;
+        }
+
+        association.uuid.value = result.associationUUIDs.fromUUID;
+        association.inverse.uuid.value = result.associationUUIDs.toUUID;
+        if (isNewAssociation) {
+            associations.append(association);
+            isNewAssociation = false;
+        }
+        association.save();
     }
 </script>
 

--- a/frontend/src/routes/mainpage/classEditor/components/associations/save-association-to-backend.js
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/save-association-to-backend.js
@@ -27,41 +27,28 @@ export function saveApiAssociationToBackend(
     associationDTO,
     isNewAssociation,
 ) {
-    let saveAssociationPairCall;
-    if (isNewAssociation) {
-        saveAssociationPairCall = bec.postAssociationPair(
-            dataset,
-            graph,
-            classUUID,
-            associationDTO,
-        );
-    } else {
-        saveAssociationPairCall = bec.putAssociationPair(
-            dataset,
-            graph,
-            classUUID,
-            associationDTO,
-        );
-    }
+    const saveAssociationPairCall = isNewAssociation
+        ? bec.postAssociationPair(dataset, graph, classUUID, associationDTO)
+        : bec.putAssociationPair(dataset, graph, classUUID, associationDTO);
 
     return saveAssociationPairCall
         .then(async res => {
             if (res.ok) {
-                const associationPairUUIDs = await res.json();
+                const associationUUIDs = await res.json();
                 console.log(
                     "Successfully saved association:",
-                    associationPairUUIDs.fromUUID,
-                    associationPairUUIDs.toUUID,
+                    associationUUIDs.fromUUID,
+                    associationUUIDs.toUUID,
                 );
-            } else {
-                const errorText = await res.text();
-                console.error("Could not save association:", errorText);
+                return { ok: true, associationUUIDs };
             }
-            return res;
+
+            const errorText = await res.text();
+            console.error("Could not save association:", errorText);
+            return { ok: false, errorText };
         })
-        .finally(res => {
+        .finally(() => {
             editorState.selectedClassUUID.trigger();
             editorState.selectedPackageUUID.trigger();
-            return res;
         });
 }

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
@@ -65,20 +65,23 @@
             classEditorContext.reactiveClass.namespace.value +
                 classEditorContext.reactiveClass.label.value,
         );
-        saveApiAttributeToBackend(
+        const result = await saveApiAttributeToBackend(
             classEditorContext.datasetName,
             classEditorContext.graphUri,
             classEditorContext.reactiveClass.uuid.value,
             apiAttribute,
             isNewAttribute,
-        ).then(res => {
-            if (res.ok) {
-                if (isNewAttribute) {
-                    attributes.append(attribute);
-                }
-                attribute.save();
-            }
-        });
+        );
+        if (!result.ok) {
+            return;
+        }
+
+        attribute.uuid.value = result.attributeUUID;
+        if (isNewAttribute) {
+            attributes.append(attribute);
+            isNewAttribute = false;
+        }
+        attribute.save();
     }
 </script>
 

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/save-attribute-to-backend.js
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/save-attribute-to-backend.js
@@ -28,37 +28,23 @@ export async function saveApiAttributeToBackend(
     attribute,
     isNewAttribute,
 ) {
-    let saveAttributeCall;
-    if (isNewAttribute) {
-        saveAttributeCall = bec.postAttribute(
-            dataset,
-            graph,
-            classUUID,
-            attribute,
-        );
-    } else {
-        saveAttributeCall = bec.putAttribute(
-            dataset,
-            graph,
-            classUUID,
-            attribute,
-        );
-    }
+    const saveAttributeCall = isNewAttribute
+        ? bec.postAttribute(dataset, graph, classUUID, attribute)
+        : bec.putAttribute(dataset, graph, classUUID, attribute);
 
-    return saveAttributeCall
-        .then(async res => {
-            if (res.ok) {
-                const attributeUUID = await res.json();
-                console.log("Successfully saved attribute:", attributeUUID);
-            } else {
-                const errorText = await res.text();
-                console.error("Could not save attribute:", errorText);
-            }
-            return res;
-        })
-        .finally(res => {
-            editorState.selectedClassUUID.trigger();
-            editorState.selectedPackageUUID.trigger();
-            return res;
-        });
+    try {
+        const res = await saveAttributeCall;
+        if (res.ok) {
+            const attributeUUID = await res.json();
+            console.log("Successfully saved attribute:", attributeUUID);
+            return { ok: true, attributeUUID };
+        }
+
+        const errorText = await res.text();
+        console.error("Could not save attribute:", errorText);
+        return { ok: false, errorText };
+    } finally {
+        editorState.selectedClassUUID.trigger();
+        editorState.selectedPackageUUID.trigger();
+    }
 }

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntryEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntryEditorDialog.svelte
@@ -54,20 +54,23 @@
             classEditorContext.reactiveClass.namespace.value +
                 classEditorContext.reactiveClass.label.value,
         );
-        saveApiEnumEntryToBackend(
+        const result = await saveApiEnumEntryToBackend(
             classEditorContext.datasetName,
             classEditorContext.graphUri,
             classEditorContext.reactiveClass.uuid.value,
             apiEnumEntry,
             isNewEnumEntry,
-        ).then(res => {
-            if (res.ok) {
-                if (isNewEnumEntry) {
-                    enumEntries.append(enumEntry);
-                }
-                enumEntry.save();
-            }
-        });
+        );
+        if (!result.ok) {
+            return;
+        }
+
+        enumEntry.uuid.value = result.enumEntryUUID;
+        if (isNewEnumEntry) {
+            enumEntries.append(enumEntry);
+            isNewEnumEntry = false;
+        }
+        enumEntry.save();
     }
 </script>
 

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/save-enum-entry-to-backend.js
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/save-enum-entry-to-backend.js
@@ -28,37 +28,23 @@ export async function saveApiEnumEntryToBackend(
     enumEntry,
     isNewEnumEntry,
 ) {
-    let saveEnumEntryCall;
-    if (isNewEnumEntry) {
-        saveEnumEntryCall = bec.postEnumEntry(
-            dataset,
-            graph,
-            classUUID,
-            enumEntry,
-        );
-    } else {
-        saveEnumEntryCall = bec.putEnumEntry(
-            dataset,
-            graph,
-            classUUID,
-            enumEntry,
-        );
-    }
+    const saveEnumEntryCall = isNewEnumEntry
+        ? bec.postEnumEntry(dataset, graph, classUUID, enumEntry)
+        : bec.putEnumEntry(dataset, graph, classUUID, enumEntry);
 
-    return saveEnumEntryCall
-        .then(async res => {
-            if (res.ok) {
-                const enumEntryUUID = await res.json();
-                console.log("Successfully saved enum entry:", enumEntryUUID);
-            } else {
-                const errorText = await res.text();
-                console.error("Could not save enum entry:", errorText);
-            }
-            return res;
-        })
-        .finally(res => {
-            editorState.selectedClassUUID.trigger();
-            editorState.selectedPackageUUID.trigger();
-            return res;
-        });
+    try {
+        const res = await saveEnumEntryCall;
+        if (res.ok) {
+            const enumEntryUUID = await res.json();
+            console.log("Successfully saved enum entry:", enumEntryUUID);
+            return { ok: true, enumEntryUUID };
+        }
+
+        const errorText = await res.text();
+        console.error("Could not save enum entry:", errorText);
+        return { ok: false, errorText };
+    } finally {
+        editorState.selectedClassUUID.trigger();
+        editorState.selectedPackageUUID.trigger();
+    }
 }


### PR DESCRIPTION
## Description

With https://github.com/SOPTIM/RDFArchitect/commit/b60098663b24a4b8ccf436c36d3943987794fde8, saving a newly created attribute, association or enum entry persisted to the backend, but the editor kept treating it as a brand-new unsaved item. So clicking Save again triggered another create request instead of switching to the normal "no new changes" state.

## What's changed

- The three dialogs now await the backend save result beofre updating local state.
- On sucessful create, the fronend now applies the returned backend UUID to the new item.
- The new item is append only once in the local collection.
- The local `isNew...` flag is switched to `false` after the first successful save.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
