### PR TITLE
fix: load SPARQL templates from classpath in packaged backend

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/models/cim/queries/templates/SparqlTemplateLoader.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/queries/templates/SparqlTemplateLoader.java
@@ -19,17 +19,24 @@ package org.rdfarchitect.models.cim.queries.templates;
 
 import org.apache.jena.query.ParameterizedSparqlString;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 public class SparqlTemplateLoader {
     public static ParameterizedSparqlString loadTemplate(String path) {
         try {
             var resource = new ClassPathResource("sparql-templates/" + path + ".sparql");
-            return new ParameterizedSparqlString(Files.readString(resource.getFile().toPath(), StandardCharsets.UTF_8));
+            return new ParameterizedSparqlString(readTemplate(resource));
         } catch (Exception e) {
             throw new RuntimeException("Failed to load SPARQL template: " + path, e);
+        }
+    }
+
+    static String readTemplate(Resource resource) throws IOException {
+        try (var inputStream = resource.getInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 }


### PR DESCRIPTION
The loader was calling ClassPathResource#getFile(), which which only works when the resource exists as a real filesystem file. In a packaged jar it becomes a nested classpath resource, so getFile() throws a FileNotFoundException.