### PR TITLE
feat(diagram): association edge rendering with labels (RDFA-478)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/packages/AssociationLayoutDataRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/packages/AssociationLayoutDataRESTController.java
@@ -1,0 +1,95 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.controller.datasets.graphs.packages;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.rdfarchitect.api.dto.dl.AssociationDecorationPositionDTO;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.services.ExpandURIUseCase;
+import org.rdfarchitect.services.dl.update.associationlayout.UpdateAssociationDecorationPositionsUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/packages/{packageUUID}/layout/associations")
+@RequiredArgsConstructor
+public class AssociationLayoutDataRESTController {
+
+    private static final Logger logger = LoggerFactory.getLogger(AssociationLayoutDataRESTController.class);
+
+    private final ExpandURIUseCase expandURIUseCase;
+    private final UpdateAssociationDecorationPositionsUseCase updateAssociationDecorationPositionsUseCase;
+
+    @Operation(
+              summary = "updates association decoration positions",
+              description = "Updates the persisted node-relative offsets for association labels and multiplicities.",
+              tags = {"diagram", "layout", "association"}
+    )
+    @PutMapping
+    public String updateAssociationDecorationPositions(
+              @Parameter(description = "The name/url of the inquirer.")
+              @RequestHeader(value = "origin", required = false, defaultValue = "unknown")
+              String originURL,
+              @Parameter(description = "The literal name of the dataset.")
+              @PathVariable
+              String datasetName,
+              @Parameter(description = "The url encoded uri of the graph, or \"default\" to access the default graph.")
+              @PathVariable
+              String graphURI,
+              @Parameter(description = "The UUID of the package to be updated.")
+              @PathVariable
+              String packageUUID,
+              @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                        required = true,
+                        description = "The DTO with necessary information for association decoration reposition",
+                        content = @Content(
+                                  array = @ArraySchema(schema = @Schema(implementation = AssociationDecorationPositionDTO.class))
+                        ))
+              @RequestBody
+              List<AssociationDecorationPositionDTO> associationDecorationPositionDTOList) {
+
+        logger.info("Received PUT request: \"/api/datasets/{{}}/graphs/{{}}/packages/{{}}/layout/associations\" from \"{}\".", datasetName, graphURI, packageUUID,
+                    originURL);
+
+        var extendedGraphURI = expandURIUseCase.expandUri(datasetName, graphURI);
+        var resolvedPackageUUID = !packageUUID.equals("default") ? UUID.fromString(packageUUID) : null;
+
+        updateAssociationDecorationPositionsUseCase.updateAssociationDecorationPositions(
+                  new GraphIdentifier(datasetName, extendedGraphURI),
+                  resolvedPackageUUID,
+                  associationDecorationPositionDTOList);
+
+        logger.info("Sending response to PUT request: \"/api/datasets/{{}}/graphs/{{}}/packages/{{}}/layout/associations\" from \"{}\".", datasetName, graphURI,
+                    packageUUID, originURL);
+        return "success";
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/api/dto/dl/AssociationDecorationPositionDTO.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/dl/AssociationDecorationPositionDTO.java
@@ -17,23 +17,25 @@
 
 package org.rdfarchitect.api.dto.dl;
 
-import lombok.Builder;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import lombok.NoArgsConstructor;
 
-import java.util.Map;
 import java.util.UUID;
 
-/**
- * DTO for backend-interal usage that represents layout data required for creating rendering information
- */
 @Data
-@Builder
-public class RenderingLayoutData {
+@NoArgsConstructor
+public class AssociationDecorationPositionDTO {
 
-    @Builder.Default
-    Map<UUID, DiagramObjectPoint> classLayoutingData = Map.of();
+    @JsonProperty("associationUUID")
+    private UUID associationUUID;
 
-    @Builder.Default
-    Map<UUID, AssociationRoleLayoutData> associationLayoutingData = Map.of();
+    @JsonProperty("decorationType")
+    private String decorationType;
+
+    @JsonProperty("xPosition")
+    private float xPosition;
+
+    @JsonProperty("yPosition")
+    private float yPosition;
 }

--- a/backend/src/main/java/org/rdfarchitect/api/dto/dl/AssociationRoleLayoutData.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/dl/AssociationRoleLayoutData.java
@@ -17,23 +17,18 @@
 
 package org.rdfarchitect.api.dto.dl;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
 
-import java.util.Map;
-import java.util.UUID;
-
-/**
- * DTO for backend-interal usage that represents layout data required for creating rendering information
- */
 @Data
 @Builder
-public class RenderingLayoutData {
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssociationRoleLayoutData {
 
-    @Builder.Default
-    Map<UUID, DiagramObjectPoint> classLayoutingData = Map.of();
-
-    @Builder.Default
-    Map<UUID, AssociationRoleLayoutData> associationLayoutingData = Map.of();
+    private DiagramObjectPoint labelLayoutingData;
+    private DiagramObjectPoint multiplicityLayoutingData;
 }

--- a/backend/src/main/java/org/rdfarchitect/api/dto/rendering/svelteflow/sub/EdgeDataDTO.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/rendering/svelteflow/sub/EdgeDataDTO.java
@@ -20,6 +20,8 @@ package org.rdfarchitect.api.dto.rendering.svelteflow.sub;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.UUID;
+
 /**
  * DTO representing the specific data object in a SvelteFlow edge.
  */
@@ -27,8 +29,16 @@ import lombok.Data;
 @Builder
 public class EdgeDataDTO {
 
+    private UUID fromAssociationUUID;
+    private UUID toAssociationUUID;
+    private String fromLabel;
     private String toMultiplicity;
+    private String toLabel;
     private String fromMultiplicity;
+    private PositionDTO fromLabelOffset;
+    private PositionDTO toMultiplicityOffset;
+    private PositionDTO toLabelOffset;
+    private PositionDTO fromMultiplicityOffset;
     private boolean useToAssociation;
     private boolean useFromAssociation;
 }

--- a/backend/src/main/java/org/rdfarchitect/models/cim/data/CIMObjectFactory.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/data/CIMObjectFactory.java
@@ -152,7 +152,7 @@ public class CIMObjectFactory {
     public static CIMAssociation createInverseCIMAssociation(QuerySolution associationQuerySolution) {
         var parser = new CIMQuerySolutionParser(associationQuerySolution);
         return CIMAssociation.builder()
-                             .uuid(parser.getUUID(CIMQueryVars.UUID))
+                             .uuid(parser.getUUID(CIMQueryVars.Inverse.UUID))
                              .uri(parser.getURI(CIMQueryVars.INVERSE_ROLE_NAME))
                              .label(parser.getLabel(CIMQueryVars.Inverse.LABEL))
                              .multiplicity(parser.getMultiplicity(CIMQueryVars.Inverse.MULTIPLICITY))

--- a/backend/src/main/java/org/rdfarchitect/models/cim/queries/select/CIMQueries.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/queries/select/CIMQueries.java
@@ -120,6 +120,7 @@ public class CIMQueries {
                   .appendRangeQuery(REQUIRED)
                   .appendAssociationUsedQuery(REQUIRED)
                   .appendInverseRoleNameQuery(REQUIRED)
+                  .appendInverseUUIDQuery(REQUIRED)
                   .appendMultiplicityQuery(REQUIRED)
                   .appendDomainQuery(REQUIRED)
                   .appendCommentQuery(OPTIONAL)
@@ -153,6 +154,7 @@ public class CIMQueries {
         var builder = new CIMQueryBuilder(baseQuery);
 
         return builder
+                  .appendUUIDQuery(REQUIRED)
                   .appendLabelQuery(REQUIRED)
                   .appendRangeQuery(REQUIRED)
                   .appendAssociationUsedQuery(REQUIRED)

--- a/backend/src/main/java/org/rdfarchitect/models/cim/queries/select/CIMQueryBuilder.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/queries/select/CIMQueryBuilder.java
@@ -150,6 +150,21 @@ public class CIMQueryBuilder {
     }
 
     /**
+     * Appends query for inverse UUIDs as {@link CIMQueryVars.Inverse#UUID}.
+     *
+     * @param mode Whether the result of this is mode.
+     *
+     * @return {@link CIMQueryBuilder this}
+     */
+    public CIMQueryBuilder appendInverseUUIDQuery(Mode mode) {
+        if (this.inverseSubquery == null) {
+            initInverseSubquery();
+        }
+
+        return appendInverseSingleQuery(RDFA.uuid, CIMQueryVars.Inverse.UUID, mode);
+    }
+
+    /**
      * Appends query for labels as {@link CIMQueryVars LABEL}.
      *
      * @param mode Whether the result of this is mode.

--- a/backend/src/main/java/org/rdfarchitect/models/cim/rendering/svelteflow/RenderCIMCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/rendering/svelteflow/RenderCIMCollectionSvelteFlowService.java
@@ -18,6 +18,7 @@
 package org.rdfarchitect.models.cim.rendering.svelteflow;
 
 import lombok.RequiredArgsConstructor;
+import org.rdfarchitect.api.dto.dl.AssociationRoleLayoutData;
 import org.rdfarchitect.api.dto.dl.RenderingLayoutData;
 import org.rdfarchitect.api.dto.rendering.RenderingDataDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.SvelteFlowDTO;
@@ -28,6 +29,7 @@ import org.rdfarchitect.api.dto.rendering.svelteflow.sub.NodeDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.NodeDataDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.PositionDTO;
 import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
 import org.rdfarchitect.models.cim.data.dto.CIMAssociation;
 import org.rdfarchitect.models.cim.data.dto.CIMClass;
 import org.rdfarchitect.models.cim.data.dto.CIMCollection;
@@ -300,14 +302,26 @@ public class RenderCIMCollectionSvelteFlowService implements RenderCIMCollection
         var sourceUUID = renderContext.uriToUUIDMap.get(from.getDomain().getUri().toString());
         var targetUUID = renderContext.uriToUUIDMap.get(from.getRange().getUri().toString());
 
+        var fromLabel = extractAssociationLabel(from);
         var fromMultiplicity = extractMultiplicityString(from.getMultiplicity());
+        var toLabel = extractAssociationLabel(to);
         var toMultiplicity = extractMultiplicityString(to.getMultiplicity());
         var useToAssociation = getAssociationUsedValue(from.getAssociationUsed());
         var useFromAssociation = getAssociationUsedValue(to.getAssociationUsed());
+        var fromAssociationLayoutData = renderContext.layoutingData().getAssociationLayoutingData().get(from.getUuid());
+        var toAssociationLayoutData = renderContext.layoutingData().getAssociationLayoutingData().get(to.getUuid());
 
         var edgeDataDTO = EdgeDataDTO.builder()
+                                     .fromAssociationUUID(from.getUuid())
+                                     .toAssociationUUID(to.getUuid())
+                                     .fromLabel(fromLabel)
                                      .toMultiplicity(toMultiplicity)
+                                     .toLabel(toLabel)
                                      .fromMultiplicity(fromMultiplicity)
+                                     .fromLabelOffset(extractPositionDTO(fromAssociationLayoutData, true))
+                                     .toMultiplicityOffset(extractPositionDTO(toAssociationLayoutData, false))
+                                     .toLabelOffset(extractPositionDTO(toAssociationLayoutData, true))
+                                     .fromMultiplicityOffset(extractPositionDTO(fromAssociationLayoutData, false))
                                      .useToAssociation(useToAssociation)
                                      .useFromAssociation(useFromAssociation)
                                      .build();
@@ -319,6 +333,30 @@ public class RenderCIMCollectionSvelteFlowService implements RenderCIMCollection
                       .target(targetUUID)
                       .data(edgeDataDTO)
                       .build();
+    }
+
+    private String extractAssociationLabel(CIMAssociation association) {
+        return association.getLabel() == null ? null : association.getLabel().getValue();
+    }
+
+    private PositionDTO extractPositionDTO(AssociationRoleLayoutData associationRoleLayoutData, boolean labelPosition) {
+        if (associationRoleLayoutData == null) {
+            return null;
+        }
+
+        var diagramObjectPoint = labelPosition ? associationRoleLayoutData.getLabelLayoutingData() : associationRoleLayoutData.getMultiplicityLayoutingData();
+        return extractPositionDTO(diagramObjectPoint);
+    }
+
+    private PositionDTO extractPositionDTO(DiagramObjectPoint diagramObjectPoint) {
+        if (diagramObjectPoint == null) {
+            return null;
+        }
+
+        return PositionDTO.builder()
+                          .x(diagramObjectPoint.getPosition().getX())
+                          .y(diagramObjectPoint.getPosition().getY())
+                          .build();
     }
 
     /**

--- a/backend/src/main/java/org/rdfarchitect/services/dl/AssociationLayoutConstants.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/AssociationLayoutConstants.java
@@ -1,0 +1,46 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class AssociationLayoutConstants {
+
+    public static final String LABEL_DECORATION_TYPE = "label";
+    public static final String MULTIPLICITY_DECORATION_TYPE = "multiplicity";
+
+    private static final String LABEL_DIAGRAM_OBJECT_NAME = "__association_label__";
+    private static final String MULTIPLICITY_DIAGRAM_OBJECT_NAME = "__association_multiplicity__";
+
+    public String getDiagramObjectName(String decorationType) {
+        return switch (decorationType) {
+            case LABEL_DECORATION_TYPE -> LABEL_DIAGRAM_OBJECT_NAME;
+            case MULTIPLICITY_DECORATION_TYPE -> MULTIPLICITY_DIAGRAM_OBJECT_NAME;
+            default -> throw new IllegalArgumentException("Unexpected association decoration type: " + decorationType);
+        };
+    }
+
+    public String getDecorationTypeForDiagramObjectName(String diagramObjectName) {
+        return switch (diagramObjectName) {
+            case LABEL_DIAGRAM_OBJECT_NAME -> LABEL_DECORATION_TYPE;
+            case MULTIPLICITY_DIAGRAM_OBJECT_NAME -> MULTIPLICITY_DECORATION_TYPE;
+            default -> null;
+        };
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/services/dl/select/QueryDiagramLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/select/QueryDiagramLayoutService.java
@@ -18,13 +18,18 @@
 package org.rdfarchitect.services.dl.select;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.jena.rdf.model.Model;
+import org.rdfarchitect.api.dto.dl.AssociationRoleLayoutData;
 import org.rdfarchitect.api.dto.dl.RenderingLayoutData;
 import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.MRID;
 import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
+import org.rdfarchitect.services.dl.AssociationLayoutConstants;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,6 +43,7 @@ public class QueryDiagramLayoutService implements FetchRenderingLayoutDataUseCas
     public RenderingLayoutData fetchRenderingLayoutData(GraphIdentifier graphIdentifier, UUID packageUUID) {
         var diagramLayout = databasePort.getGraphWithContext(graphIdentifier).getDiagramLayout();
         var diagramLayoutModel = diagramLayout.getDiagramLayoutModel();
+        var resolvedPackageUUID = packageUUID == null ? diagramLayout.getDefaultPackageMRID().getUuid() : packageUUID;
 
         Map<UUID, DiagramObjectPoint> classLayoutingData;
         if (packageUUID == null) {
@@ -48,6 +54,38 @@ public class QueryDiagramLayoutService implements FetchRenderingLayoutDataUseCas
 
         return RenderingLayoutData.builder()
                                   .classLayoutingData(classLayoutingData)
+                                  .associationLayoutingData(fetchAssociationLayoutingData(diagramLayoutModel, resolvedPackageUUID))
                                   .build();
+    }
+
+    private Map<UUID, AssociationRoleLayoutData> fetchAssociationLayoutingData(Model diagramLayoutModel, UUID packageUUID) {
+        Map<UUID, AssociationRoleLayoutData> associationLayoutingData = new HashMap<>();
+
+        for (var diagramObject : DLObjectFetcher.fetchDiagramDOs(diagramLayoutModel, new MRID(packageUUID))) {
+            var decorationType = AssociationLayoutConstants.getDecorationTypeForDiagramObjectName(diagramObject.getName());
+            if (decorationType == null) {
+                continue;
+            }
+
+            var diagramObjectPoint = DLObjectFetcher.fetchDOPForDO(diagramLayoutModel, diagramObject.getMRID());
+            if (diagramObjectPoint == null) {
+                continue;
+            }
+
+            var associationUUID = diagramObject.getBelongsToIdentifiedObject().getUuid();
+            var associationRoleLayoutData = associationLayoutingData.getOrDefault(associationUUID, new AssociationRoleLayoutData());
+
+            switch (decorationType) {
+                case AssociationLayoutConstants.LABEL_DECORATION_TYPE ->
+                      associationRoleLayoutData.setLabelLayoutingData(diagramObjectPoint);
+                case AssociationLayoutConstants.MULTIPLICITY_DECORATION_TYPE ->
+                      associationRoleLayoutData.setMultiplicityLayoutingData(diagramObjectPoint);
+                default -> throw new IllegalArgumentException("Unexpected association decoration type: " + decorationType);
+            }
+
+            associationLayoutingData.put(associationUUID, associationRoleLayoutData);
+        }
+
+        return associationLayoutingData;
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/DiagramLayoutServiceUtils.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/DiagramLayoutServiceUtils.java
@@ -56,21 +56,21 @@ public class DiagramLayoutServiceUtils {
      * Helper method for creating and inserting a {@link DiagramObject} into a given model.
      *
      * @param diagramLayoutModel the model into which the diagram object is inserted
-     * @param packageUUID        the UUID of the package whose diagram the object belongs to
-     * @param className          the name of the class represented by the diagram object
-     * @param classUUID          the UUID of the class represented by the diagram object
+     * @param packageUUID          the UUID of the package whose diagram the object belongs to
+     * @param diagramObjectName    the name of the diagram object
+     * @param identifiedObjectUUID the UUID of the represented object
      *
      * @return the mRID of the created diagram object, used for creating diagram object points
      *
      */
-    public MRID insertDiagramObject(Model diagramLayoutModel, UUID packageUUID, String className, UUID classUUID) {
+    public MRID insertDiagramObject(Model diagramLayoutModel, UUID packageUUID, String diagramObjectName, UUID identifiedObjectUUID) {
         var diagramObjectMRID = new MRID(UUID.randomUUID());
 
         var diagramObject = DiagramObject.builder()
                                          .mRID(diagramObjectMRID)
-                                         .name(className)
+                                         .name(diagramObjectName)
                                          .belongsToDiagram(new MRID(packageUUID))
-                                         .belongsToIdentifiedObject(new MRID(classUUID))
+                                         .belongsToIdentifiedObject(new MRID(identifiedObjectUUID))
                                          .build();
         DLUpdates.insertDiagramObject(diagramLayoutModel, diagramObject);
 
@@ -84,9 +84,13 @@ public class DiagramLayoutServiceUtils {
      * @param diagramObjectMRID  the mRID of the diagram object the point belongs to
      */
     public void insertDiagramObjectPoint(Model diagramLayoutModel, MRID diagramObjectMRID) {
+        insertDiagramObjectPoint(diagramLayoutModel, diagramObjectMRID, new XYPosition(0, 0));
+    }
+
+    public void insertDiagramObjectPoint(Model diagramLayoutModel, MRID diagramObjectMRID, XYPosition position) {
         var diagramObjectPoint = DiagramObjectPoint.builder()
                                                    .mRID(new MRID(UUID.randomUUID()))
-                                                   .position(new XYPosition(0, 0))
+                                                   .position(position)
                                                    .belongsToDiagramObject(diagramObjectMRID)
                                                    .build();
         DLUpdates.insertDiagramObjectPoint(diagramLayoutModel, diagramObjectPoint);

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/associationlayout/UpdateAssociationDecorationPositionsUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/associationlayout/UpdateAssociationDecorationPositionsUseCase.java
@@ -15,25 +15,15 @@
  *
  */
 
-package org.rdfarchitect.api.dto.dl;
+package org.rdfarchitect.services.dl.update.associationlayout;
 
-import lombok.Builder;
-import lombok.Data;
-import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.api.dto.dl.AssociationDecorationPositionDTO;
+import org.rdfarchitect.database.GraphIdentifier;
 
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 
-/**
- * DTO for backend-interal usage that represents layout data required for creating rendering information
- */
-@Data
-@Builder
-public class RenderingLayoutData {
+public interface UpdateAssociationDecorationPositionsUseCase {
 
-    @Builder.Default
-    Map<UUID, DiagramObjectPoint> classLayoutingData = Map.of();
-
-    @Builder.Default
-    Map<UUID, AssociationRoleLayoutData> associationLayoutingData = Map.of();
+    void updateAssociationDecorationPositions(GraphIdentifier graphIdentifier, UUID packageUUID, List<AssociationDecorationPositionDTO> associationDecorationPositionDTOList);
 }

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/associationlayout/UpdateAssociationLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/associationlayout/UpdateAssociationLayoutService.java
@@ -1,0 +1,79 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl.update.associationlayout;
+
+import lombok.RequiredArgsConstructor;
+import org.rdfarchitect.api.dto.dl.AssociationDecorationPositionDTO;
+import org.rdfarchitect.database.DatabasePort;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.dl.data.dto.relations.XYPosition;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
+import org.rdfarchitect.dl.queries.update.DLUpdates;
+import org.rdfarchitect.services.dl.AssociationLayoutConstants;
+import org.rdfarchitect.services.dl.update.DiagramLayoutServiceUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateAssociationLayoutService implements UpdateAssociationDecorationPositionsUseCase {
+
+    private final DatabasePort databasePort;
+
+    @Override
+    public void updateAssociationDecorationPositions(GraphIdentifier graphIdentifier, UUID packageUUID, List<AssociationDecorationPositionDTO> associationDecorationPositionDTOList) {
+        var diagramLayout = databasePort.getGraphWithContext(graphIdentifier).getDiagramLayout();
+        var diagramLayoutModel = diagramLayout.getDiagramLayoutModel();
+        var resolvedPackageUUID = packageUUID == null ? diagramLayout.getDefaultPackageMRID().getUuid() : packageUUID;
+
+        for (var associationDecorationPositionDTO : associationDecorationPositionDTOList) {
+            var diagramObjectName = AssociationLayoutConstants.getDiagramObjectName(associationDecorationPositionDTO.getDecorationType());
+            var existingDiagramObject = DLObjectFetcher.fetchAllDOs(diagramLayoutModel, associationDecorationPositionDTO.getAssociationUUID())
+                                                       .stream()
+                                                       .filter(diagramObject -> resolvedPackageUUID.equals(diagramObject.getBelongsToDiagram().getUuid()))
+                                                       .filter(diagramObject -> diagramObjectName.equals(diagramObject.getName()))
+                                                       .findFirst()
+                                                       .orElse(null);
+
+            if (existingDiagramObject == null) {
+                var diagramObjectMRID = DiagramLayoutServiceUtils.insertDiagramObject(
+                          diagramLayoutModel,
+                          resolvedPackageUUID,
+                          diagramObjectName,
+                          associationDecorationPositionDTO.getAssociationUUID());
+                DiagramLayoutServiceUtils.insertDiagramObjectPoint(
+                          diagramLayoutModel,
+                          diagramObjectMRID,
+                          new XYPosition(associationDecorationPositionDTO.getXPosition(), associationDecorationPositionDTO.getYPosition()));
+                continue;
+            }
+
+            var diagramObjectPoint = DLObjectFetcher.fetchDOPForDO(diagramLayoutModel, existingDiagramObject.getMRID());
+            if (diagramObjectPoint != null) {
+                DLUpdates.deleteDiagramObjectPoint(diagramLayoutModel, diagramObjectPoint.getMRID());
+            }
+
+            DiagramLayoutServiceUtils.insertDiagramObjectPoint(
+                      diagramLayoutModel,
+                      existingDiagramObject.getMRID(),
+                      new XYPosition(associationDecorationPositionDTO.getXPosition(), associationDecorationPositionDTO.getYPosition()));
+        }
+    }
+}

--- a/backend/src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/GraphToCIMCollectionConverterImplNoFilterTest.java
+++ b/backend/src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/GraphToCIMCollectionConverterImplNoFilterTest.java
@@ -321,4 +321,20 @@ class GraphToCIMCollectionConverterImplNoFilterTest {
 
     }
 
+    @Test
+    void convert_associatedClassesWithAssociationUuids_preservesBothAssociationUuids() throws IOException {
+        addFileGraphToDatabase(PATH + "associationWithUuids.ttl");
+        var filter = new GraphFilter(true);
+        filter.setPackageUUID("123e4567-e89b-12d3-a456-426614174000");
+
+        var cimCollection = converter.convert(graphIdentifier, filter);
+
+        assertThat(cimCollection.getAssociations())
+                .extracting(association -> association.getUuid())
+                .containsExactlyInAnyOrder(
+                        UUID.fromString("823e4567-e89b-12d3-a456-426614174000"),
+                        UUID.fromString("923e4567-e89b-12d3-a456-426614174000")
+                );
+    }
+
 }

--- a/backend/src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/associationWithUuids.ttl
+++ b/backend/src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/associationWithUuids.ttl
@@ -1,0 +1,42 @@
+PREFIX cim:    <http://iec.ch/TC57/2013/CIM-schema-cim16#>
+PREFIX cims:   <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#>
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ex:     <http://example.com#>
+
+ex:Package_Infrastruktur
+    <http://example.org#uuid> "123e4567-e89b-12d3-a456-426614174000" ;
+    rdf:type                  cims:ClassCategory ;
+    rdfs:label                "Infrastruktur"@en .
+
+ex:ChildClass
+    <http://example.org#uuid> "623e4567-e89b-12d3-a456-426614174000" ;
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "ChildClass"@en ;
+    cims:belongsToCategory    ex:Package_Infrastruktur .
+
+ex:AssociatedClass
+    <http://example.org#uuid> "723e4567-e89b-12d3-a456-426614174000" ;
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "AssociatedClass"@en ;
+    cims:belongsToCategory    ex:Package_Infrastruktur .
+
+ex:ChildClass.AssociatedClass
+    <http://example.org#uuid> "823e4567-e89b-12d3-a456-426614174000" ;
+    rdf:type                  rdf:Property ;
+    rdfs:domain               ex:ChildClass ;
+    rdfs:label                "AssociatedClass"@en ;
+    rdfs:range                ex:AssociatedClass ;
+    cims:AssociationUsed      "No" ;
+    cims:inverseRoleName      ex:AssociatedClass.ChildClass ;
+    cims:multiplicity         cims:M:1 .
+
+ex:AssociatedClass.ChildClass
+    <http://example.org#uuid> "923e4567-e89b-12d3-a456-426614174000" ;
+    rdf:type                  rdf:Property ;
+    rdfs:domain               ex:AssociatedClass ;
+    rdfs:label                "ChildClass"@en ;
+    rdfs:range                ex:ChildClass ;
+    cims:AssociationUsed      "Yes" ;
+    cims:inverseRoleName      ex:ChildClass.AssociatedClass ;
+    cims:multiplicity         cims:M:0..n .

--- a/backend/src/test/java/org/rdfarchitect/services/dl/select/QueryDiagramLayoutServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/dl/select/QueryDiagramLayoutServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl.select;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.rdfarchitect.api.dto.dl.AssociationDecorationPositionDTO;
+import org.rdfarchitect.services.dl.AssociationLayoutConstants;
+import org.rdfarchitect.services.dl.DiagramLayoutServicesTestBase;
+import org.rdfarchitect.services.dl.update.associationlayout.UpdateAssociationLayoutService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+class QueryDiagramLayoutServiceTest extends DiagramLayoutServicesTestBase {
+
+    private static final UUID FROM_ASSOCIATION_UUID = UUID.fromString("43236908-a7f7-4749-bb8b-3ac9250de656");
+
+    private static QueryDiagramLayoutService queryDiagramLayoutService;
+    private static UpdateAssociationLayoutService updateAssociationLayoutService;
+
+    @BeforeAll
+    static void setUpEnvironment() {
+        queryDiagramLayoutService = new QueryDiagramLayoutService(databasePort);
+        updateAssociationLayoutService = new UpdateAssociationLayoutService(databasePort);
+    }
+
+    @Test
+    void fetchRenderingLayoutData_withAssociationLayout_returnsPersistedOffsets() {
+        addGraphFromFile("association.ttl");
+        updateDiagramLayoutService.createDiagramLayout(graphIdentifier);
+
+        var labelPositionDTO = new AssociationDecorationPositionDTO();
+        labelPositionDTO.setAssociationUUID(FROM_ASSOCIATION_UUID);
+        labelPositionDTO.setDecorationType(AssociationLayoutConstants.LABEL_DECORATION_TYPE);
+        labelPositionDTO.setXPosition(14.0F);
+        labelPositionDTO.setYPosition(-6.0F);
+
+        var multiplicityPositionDTO = new AssociationDecorationPositionDTO();
+        multiplicityPositionDTO.setAssociationUUID(FROM_ASSOCIATION_UUID);
+        multiplicityPositionDTO.setDecorationType(AssociationLayoutConstants.MULTIPLICITY_DECORATION_TYPE);
+        multiplicityPositionDTO.setXPosition(4.0F);
+        multiplicityPositionDTO.setYPosition(9.0F);
+
+        updateAssociationLayoutService.updateAssociationDecorationPositions(
+                  graphIdentifier,
+                  PACKAGE_A_UUID,
+                  List.of(labelPositionDTO, multiplicityPositionDTO));
+
+        var result = queryDiagramLayoutService.fetchRenderingLayoutData(graphIdentifier, PACKAGE_A_UUID);
+        var associationLayoutData = result.getAssociationLayoutingData().get(FROM_ASSOCIATION_UUID);
+
+        assertThat(associationLayoutData).isNotNull();
+        assertThat(associationLayoutData.getLabelLayoutingData().getPosition().getX()).isEqualTo(14.0F);
+        assertThat(associationLayoutData.getLabelLayoutingData().getPosition().getY()).isEqualTo(-6.0F);
+        assertThat(associationLayoutData.getMultiplicityLayoutingData().getPosition().getX()).isEqualTo(4.0F);
+        assertThat(associationLayoutData.getMultiplicityLayoutingData().getPosition().getY()).isEqualTo(9.0F);
+    }
+}

--- a/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateAssociationLayoutServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateAssociationLayoutServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl.update;
+
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.rdfarchitect.api.dto.dl.AssociationDecorationPositionDTO;
+import org.rdfarchitect.dl.data.DLUtils;
+import org.rdfarchitect.dl.data.dto.relations.MRID;
+import org.rdfarchitect.dl.rdf.resources.CIM;
+import org.rdfarchitect.dl.rdf.resources.DL;
+import org.rdfarchitect.services.dl.AssociationLayoutConstants;
+import org.rdfarchitect.services.dl.DiagramLayoutServicesTestBase;
+import org.rdfarchitect.services.dl.update.associationlayout.UpdateAssociationLayoutService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+class UpdateAssociationLayoutServiceTest extends DiagramLayoutServicesTestBase {
+
+    private static final UUID FROM_ASSOCIATION_UUID = UUID.fromString("43236908-a7f7-4749-bb8b-3ac9250de656");
+    private static final UUID TO_ASSOCIATION_UUID = UUID.fromString("e88a28a4-bced-4945-9157-8cd4a0af7268");
+
+    private static UpdateAssociationLayoutService service;
+
+    @BeforeAll
+    static void setUpEnvironment() {
+        service = new UpdateAssociationLayoutService(databasePort);
+    }
+
+    @Test
+    void updateAssociationDecorationPositions_missingEntries_createsLayoutData() {
+        addGraphFromFile("association.ttl");
+        updateDiagramLayoutService.createDiagramLayout(graphIdentifier);
+
+        service.updateAssociationDecorationPositions(graphIdentifier, PACKAGE_A_UUID, List.of(
+                  createPositionDTO(FROM_ASSOCIATION_UUID, AssociationLayoutConstants.LABEL_DECORATION_TYPE, 12.5F, -9.0F),
+                  createPositionDTO(TO_ASSOCIATION_UUID, AssociationLayoutConstants.MULTIPLICITY_DECORATION_TYPE, -7.0F, 18.0F)));
+
+        assertAssociationDecorationCoordinates(
+                  FROM_ASSOCIATION_UUID,
+                  PACKAGE_A_UUID,
+                  AssociationLayoutConstants.LABEL_DECORATION_TYPE,
+                  12.5F,
+                  -9.0F);
+        assertAssociationDecorationCoordinates(
+                  TO_ASSOCIATION_UUID,
+                  PACKAGE_A_UUID,
+                  AssociationLayoutConstants.MULTIPLICITY_DECORATION_TYPE,
+                  -7.0F,
+                  18.0F);
+    }
+
+    @Test
+    void updateAssociationDecorationPositions_existingEntries_updatesCoordinates() {
+        addGraphFromFile("association.ttl");
+        updateDiagramLayoutService.createDiagramLayout(graphIdentifier);
+
+        service.updateAssociationDecorationPositions(graphIdentifier, PACKAGE_A_UUID, List.of(
+                  createPositionDTO(FROM_ASSOCIATION_UUID, AssociationLayoutConstants.LABEL_DECORATION_TYPE, 2.0F, 3.0F)));
+        service.updateAssociationDecorationPositions(graphIdentifier, PACKAGE_A_UUID, List.of(
+                  createPositionDTO(FROM_ASSOCIATION_UUID, AssociationLayoutConstants.LABEL_DECORATION_TYPE, 8.0F, -4.0F)));
+
+        assertAssociationDecorationCoordinates(
+                  FROM_ASSOCIATION_UUID,
+                  PACKAGE_A_UUID,
+                  AssociationLayoutConstants.LABEL_DECORATION_TYPE,
+                  8.0F,
+                  -4.0F);
+    }
+
+    private static AssociationDecorationPositionDTO createPositionDTO(UUID associationUUID, String decorationType, float xPosition, float yPosition) {
+        var positionDTO = new AssociationDecorationPositionDTO();
+        positionDTO.setAssociationUUID(associationUUID);
+        positionDTO.setDecorationType(decorationType);
+        positionDTO.setXPosition(xPosition);
+        positionDTO.setYPosition(yPosition);
+        return positionDTO;
+    }
+
+    private static void assertAssociationDecorationCoordinates(
+              UUID associationUUID,
+              UUID packageUUID,
+              String decorationType,
+              float xPosition,
+              float yPosition) {
+        var model = databasePort.getGraphWithContext(graphIdentifier).getDiagramLayout().getDiagramLayoutModel();
+        var associationResource = ResourceFactory.createResource(new MRID(associationUUID).getFullMRID());
+        var packageResource = ResourceFactory.createResource(new MRID(packageUUID).getFullMRID());
+        var diagramObjectName = AssociationLayoutConstants.getDiagramObjectName(decorationType);
+
+        var diagramObject = model.listSubjectsWithProperty(DL.belongsToIdentifiedObject, associationResource)
+                                 .toList()
+                                 .stream()
+                                 .filter(candidate -> candidate.hasProperty(DL.belongsToDiagram, packageResource))
+                                 .filter(candidate -> candidate.hasProperty(CIM.ioName, ResourceFactory.createPlainLiteral(diagramObjectName)))
+                                 .findFirst()
+                                 .orElseThrow();
+
+        var diagramObjectMRID = new MRID(DLUtils.extractUUIDFromMRID(diagramObject.getURI()));
+        assertDiagramObjectPoint(diagramObjectMRID, xPosition, yPosition);
+    }
+}

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMCollectionSvelteFlowServiceTest.java
@@ -19,6 +19,8 @@ package org.rdfarchitect.services.rendering;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.junit.jupiter.api.Test;
+import org.rdfarchitect.api.dto.dl.AssociationRoleLayoutData;
+import org.rdfarchitect.api.dto.dl.RenderingLayoutData;
 import org.rdfarchitect.api.dto.rendering.svelteflow.SvelteFlowDTO;
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSBelongsToCategory;
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSMultiplicity;
@@ -26,11 +28,19 @@ import org.rdfarchitect.models.cim.data.dto.relations.CIMSStereotype;
 import org.rdfarchitect.models.cim.data.dto.relations.RDFSLabel;
 import org.rdfarchitect.models.cim.data.dto.relations.RDFSSubClassOf;
 import org.rdfarchitect.models.cim.data.dto.relations.uri.URI;
+import org.rdfarchitect.models.cim.rendering.svelteflow.RenderCIMCollectionSvelteFlowService;
+import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.XYPosition;
+import org.rdfarchitect.services.dl.select.FetchRenderingLayoutDataUseCase;
+import org.rdfarchitect.services.dl.update.EnsureDiagramLayoutForCIMCollectionUseCase;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class RenderCIMCollectionSvelteFlowServiceTest extends RenderCIMCollectionTestBase {
 
@@ -167,9 +177,67 @@ class RenderCIMCollectionSvelteFlowServiceTest extends RenderCIMCollectionTestBa
         //Assert
         var associationEdgeDTO = result.getEdges().get(0);
         assertThat(result.getEdges()).hasSize(1);
+        assertThat(associationEdgeDTO.getData().getFromLabel()).isEqualTo("class1.class2");
         assertThat(associationEdgeDTO.getData().getFromMultiplicity()).isEqualTo("0...n");
+        assertThat(associationEdgeDTO.getData().getToLabel()).isEqualTo("class2.class1");
         assertThat(associationEdgeDTO.getData().getToMultiplicity()).isEqualTo("1...1");
         assertThat(associationEdgeDTO.getData().isUseFromAssociation()).isFalse();
         assertThat(associationEdgeDTO.getData().isUseToAssociation()).isTrue();
+    }
+
+    @Test
+    void renderUML_twoClassesAndAssociation_includesPersistedAssociationOffsets() {
+        addPackage("package_package1");
+        addClass("package_package1", "class1");
+        addClass("package_package2", "class2");
+        addAssociation("class1", "class2", AssociationUsed.YES, AssociationUsed.NO);
+
+        var associationIterator = cimCollection.getAssociations().iterator();
+        var fromAssoc = associationIterator.next();
+        var toAssoc = associationIterator.next();
+
+        FetchRenderingLayoutDataUseCase fetchRenderingLayoutDataUseCase = mock(FetchRenderingLayoutDataUseCase.class);
+        EnsureDiagramLayoutForCIMCollectionUseCase ensureDiagramLayoutForCIMCollectionUseCase = mock(EnsureDiagramLayoutForCIMCollectionUseCase.class);
+        var mockXYPosition = mock(XYPosition.class);
+        when(mockXYPosition.getX()).thenReturn(0f);
+        when(mockXYPosition.getY()).thenReturn(0f);
+
+        var mockDop = mock(DiagramObjectPoint.class);
+        when(mockDop.getPosition()).thenReturn(mockXYPosition);
+
+        var mockClassLayoutingData = mock(Map.class);
+        when(mockClassLayoutingData.get(any(UUID.class))).thenReturn(mockDop);
+
+        var renderingLayoutData = RenderingLayoutData.builder()
+                                                     .classLayoutingData(mockClassLayoutingData)
+                                                     .associationLayoutingData(Map.of(
+                                                               fromAssoc.getUuid(),
+                                                               AssociationRoleLayoutData.builder()
+                                                                                        .labelLayoutingData(DiagramObjectPoint.builder().position(new XYPosition(11.0F, 12.0F)).build())
+                                                                                        .multiplicityLayoutingData(DiagramObjectPoint.builder().position(new XYPosition(13.0F, 14.0F)).build())
+                                                                                        .build(),
+                                                               toAssoc.getUuid(),
+                                                               AssociationRoleLayoutData.builder()
+                                                                                        .labelLayoutingData(DiagramObjectPoint.builder().position(new XYPosition(21.0F, 22.0F)).build())
+                                                                                        .multiplicityLayoutingData(DiagramObjectPoint.builder().position(new XYPosition(23.0F, 24.0F)).build())
+                                                                                        .build()))
+                                                     .build();
+        when(fetchRenderingLayoutDataUseCase.fetchRenderingLayoutData(any(), any())).thenReturn(renderingLayoutData);
+
+        var renderer = new RenderCIMCollectionSvelteFlowService(fetchRenderingLayoutDataUseCase, ensureDiagramLayoutForCIMCollectionUseCase);
+
+        var result = (SvelteFlowDTO) renderer.renderUML(cimCollection, null, null);
+
+        var associationEdgeDTO = result.getEdges().get(0);
+        assertThat(associationEdgeDTO.getData().getFromAssociationUUID()).isEqualTo(fromAssoc.getUuid());
+        assertThat(associationEdgeDTO.getData().getToAssociationUUID()).isEqualTo(toAssoc.getUuid());
+        assertThat(associationEdgeDTO.getData().getFromLabelOffset().getX()).isEqualTo(11.0);
+        assertThat(associationEdgeDTO.getData().getFromLabelOffset().getY()).isEqualTo(12.0);
+        assertThat(associationEdgeDTO.getData().getFromMultiplicityOffset().getX()).isEqualTo(13.0);
+        assertThat(associationEdgeDTO.getData().getFromMultiplicityOffset().getY()).isEqualTo(14.0);
+        assertThat(associationEdgeDTO.getData().getToLabelOffset().getX()).isEqualTo(21.0);
+        assertThat(associationEdgeDTO.getData().getToLabelOffset().getY()).isEqualTo(22.0);
+        assertThat(associationEdgeDTO.getData().getToMultiplicityOffset().getX()).isEqualTo(23.0);
+        assertThat(associationEdgeDTO.getData().getToMultiplicityOffset().getY()).isEqualTo(24.0);
     }
 }

--- a/frontend/src/lib/api/backend.js
+++ b/frontend/src/lib/api/backend.js
@@ -391,6 +391,22 @@ export class BackendConnection {
         });
     }
 
+    async updateAssociationDecorationPositions(
+        datasetName,
+        graphURI,
+        packageUUID,
+        associationDecorationPositionDTOList,
+    ) {
+        let url = `${PUBLIC_BACKEND_URL}/datasets/${encodeURIComponent(datasetName)}/graphs/${encodeURIComponent(graphURI)}/packages/${encodeURIComponent(packageUUID)}/layout/associations`;
+        return await fetch(url, {
+            method: "PUT",
+            headers: new Headers({ "Content-Type": "application/json" }),
+            mode: "cors",
+            body: JSON.stringify(associationDecorationPositionDTOList),
+            credentials: "include",
+        });
+    }
+
     async getKnownOntologyFields() {
         let url = `${PUBLIC_BACKEND_URL}/ontology-fields`;
         return await fetch(url, {

--- a/frontend/src/lib/rendering/svelteflow/components/AssociationEdge.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/AssociationEdge.svelte
@@ -19,52 +19,412 @@
     import {
         BaseEdge,
         EdgeLabel,
-        getStraightPath,
         useInternalNode,
+        useSvelteFlow,
     } from "@xyflow/svelte";
+    import { onDestroy } from "svelte";
 
-    import { getEdgeParams } from "./edgeUtils.ts";
+    import { BackendConnection } from "$lib/api/backend.js";
+    import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { editorState } from "$lib/sharedState.svelte.js";
+
+    import {
+        getAssociationEdgeGeometry,
+        getAssociationLabelTransform,
+    } from "./edgeUtils.ts";
 
     let { id, source, target, data } = $props();
 
-    const style = "stroke-width: 2px; stroke: #000";
-    let markerEnd = data.useToAssociation ? "url(#associationTo)" : "";
-    let markerStart = data.useFromAssociation ? "url(#associationFrom)" : "";
-    let sourceNode = useInternalNode(source);
-    let targetNode = useInternalNode(target);
+    const DECORATION_TYPE_LABEL = "label";
+    const DECORATION_TYPE_MULTIPLICITY = "multiplicity";
+    const MOVE_EPSILON = 0.5;
+    const baseDecorationClass =
+        "nodrag nopan select-none rounded border-0 px-2 py-0.5 text-left text-xs font-medium text-[#303030] shadow-sm touch-none";
 
-    let edgeParams = $derived.by(() => {
+    const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
+    const style = "stroke-width: 2px; stroke: #000";
+    const svelteFlow = useSvelteFlow();
+    let activeDrag = $state(null);
+    let localOffsets = $state({});
+    let sourceNode = $derived(useInternalNode(source));
+    let targetNode = $derived(useInternalNode(target));
+    let markerEnd = $derived(
+        data?.useToAssociation ? "url(#associationTo)" : "",
+    );
+    let markerStart = $derived(
+        data?.useFromAssociation ? "url(#associationFrom)" : "",
+    );
+
+    let edgeGeometry = $derived.by(() => {
         if (sourceNode.current && targetNode.current) {
-            return getEdgeParams(sourceNode.current, targetNode.current);
+            return getAssociationEdgeGeometry(
+                sourceNode.current,
+                targetNode.current,
+                data?.parallelOffset ?? 0,
+            );
         }
     });
 
-    let path = $derived(
-        getStraightPath({
-            sourceX: edgeParams.sx,
-            sourceY: edgeParams.sy,
-            targetX: edgeParams.tx,
-            targetY: edgeParams.ty,
-        })[0],
-    );
+    onDestroy(() => {
+        removePointerListeners();
+    });
+
+    function getStoredOffset(offset) {
+        return {
+            x: offset?.x ?? 0,
+            y: offset?.y ?? 0,
+        };
+    }
+
+    function getPersistedOffset(offsetKey, offset) {
+        return getStoredOffset(localOffsets[offsetKey] ?? offset);
+    }
+
+    function getDecorationPosition(anchor, offset) {
+        return {
+            x: anchor.x + offset.x,
+            y: anchor.y + offset.y,
+        };
+    }
+
+    function getDecorationClass(isLabel, canMove, isDragging) {
+        return `${baseDecorationClass} ${isLabel ? "bg-white/90 whitespace-nowrap" : "bg-white/80"} ${canMove ? "cursor-grab" : "cursor-default"} ${isDragging ? "cursor-grabbing ring-1 ring-[#8a8a8a]" : ""}`;
+    }
+
+    function getLabelStyle(position, node) {
+        if (!node) {
+            return "";
+        }
+
+        return `transform: ${getAssociationLabelTransform(position, node)};`;
+    }
+
+    function hasMeaningfulMove(dragState) {
+        return (
+            Math.abs(dragState.currentOffset.x - dragState.initialOffset.x) >
+                MOVE_EPSILON ||
+            Math.abs(dragState.currentOffset.y - dragState.initialOffset.y) >
+                MOVE_EPSILON
+        );
+    }
+
+    function getFlowPointerPosition(pointerEvent) {
+        return svelteFlow.screenToFlowPosition(
+            {
+                x: pointerEvent.clientX,
+                y: pointerEvent.clientY,
+            },
+            { snapToGrid: false },
+        );
+    }
+
+    function handlePointerMove(pointerEvent) {
+        if (
+            !activeDrag ||
+            activeDrag.isPersisting ||
+            pointerEvent.pointerId !== activeDrag.pointerId
+        ) {
+            return;
+        }
+
+        const currentPointerPosition = getFlowPointerPosition(pointerEvent);
+        const deltaX =
+            currentPointerPosition.x - activeDrag.startPointerPosition.x;
+        const deltaY =
+            currentPointerPosition.y - activeDrag.startPointerPosition.y;
+
+        activeDrag = {
+            ...activeDrag,
+            currentOffset: {
+                x: activeDrag.initialOffset.x + deltaX,
+                y: activeDrag.initialOffset.y + deltaY,
+            },
+        };
+    }
+
+    async function finishDrag(pointerEvent, canceled = false) {
+        if (!activeDrag || pointerEvent.pointerId !== activeDrag.pointerId) {
+            return;
+        }
+
+        const dragState = activeDrag;
+        removePointerListeners();
+        releasePointerCapture(dragState);
+
+        if (canceled || !hasMeaningfulMove(dragState)) {
+            activeDrag = null;
+            return;
+        }
+
+        activeDrag = {
+            ...dragState,
+            isPersisting: true,
+        };
+
+        const didPersist = await persistAssociationDecorationOffset({
+            offsetKey: dragState.offsetKey,
+            associationUUID: dragState.associationUUID,
+            decorationType: dragState.decorationType,
+            xPosition: dragState.currentOffset.x,
+            yPosition: dragState.currentOffset.y,
+        });
+
+        activeDrag = null;
+
+        if (!didPersist) {
+            return;
+        }
+    }
+
+    function handlePointerUp(pointerEvent) {
+        finishDrag(pointerEvent);
+    }
+
+    function handlePointerCancel(pointerEvent) {
+        finishDrag(pointerEvent, true);
+    }
+
+    function addPointerListeners(pointerTarget) {
+        pointerTarget?.addEventListener("pointermove", handlePointerMove);
+        pointerTarget?.addEventListener("pointerup", handlePointerUp);
+        pointerTarget?.addEventListener("pointercancel", handlePointerCancel);
+    }
+
+    function removePointerListeners() {
+        activeDrag?.pointerTarget?.removeEventListener(
+            "pointermove",
+            handlePointerMove,
+        );
+        activeDrag?.pointerTarget?.removeEventListener(
+            "pointerup",
+            handlePointerUp,
+        );
+        activeDrag?.pointerTarget?.removeEventListener(
+            "pointercancel",
+            handlePointerCancel,
+        );
+    }
+
+    function releasePointerCapture(dragState) {
+        dragState?.pointerTarget?.releasePointerCapture?.(dragState.pointerId);
+    }
+
+    function startDecorationDrag(pointerEvent, dragConfig) {
+        if (
+            !data?.canMoveAssociationDecoration ||
+            !dragConfig.associationUUID
+        ) {
+            return;
+        }
+
+        pointerEvent.preventDefault();
+        pointerEvent.stopPropagation();
+        removePointerListeners();
+
+        const storedOffset = getStoredOffset(dragConfig.storedOffset);
+        pointerEvent.currentTarget?.setPointerCapture?.(pointerEvent.pointerId);
+        activeDrag = {
+            pointerId: pointerEvent.pointerId,
+            pointerTarget: pointerEvent.currentTarget,
+            associationUUID: dragConfig.associationUUID,
+            decorationType: dragConfig.decorationType,
+            offsetKey: dragConfig.offsetKey,
+            startPointerPosition: getFlowPointerPosition(pointerEvent),
+            initialOffset: storedOffset,
+            currentOffset: storedOffset,
+            isPersisting: false,
+        };
+        addPointerListeners(pointerEvent.currentTarget);
+    }
+
+    async function persistAssociationDecorationOffset({
+        offsetKey,
+        associationUUID,
+        decorationType,
+        xPosition,
+        yPosition,
+    }) {
+        const packageUUID =
+            editorState.selectedPackageUUID.getValue() ?? "default";
+        const res = await bec.updateAssociationDecorationPositions(
+            editorState.selectedDataset.getValue(),
+            editorState.selectedGraph.getValue(),
+            packageUUID,
+            [
+                {
+                    associationUUID,
+                    decorationType,
+                    xPosition,
+                    yPosition,
+                },
+            ],
+        );
+
+        if (!res.ok) {
+            const errorText = await res.text();
+            console.error(
+                "Could not update association decoration position:",
+                errorText,
+            );
+            return false;
+        }
+
+        localOffsets = {
+            ...localOffsets,
+            [offsetKey]: {
+                x: xPosition,
+                y: yPosition,
+            },
+        };
+
+        return true;
+    }
 </script>
 
-<BaseEdge {id} {path} {markerStart} {markerEnd} {style} />
-<EdgeLabel>
-    {#if data.fromMultiplicity}
-        <div
-            style:transform={`translate(-50%, -50%) translate(${edgeParams.sx + edgeParams.startX}px, ${edgeParams.sy + edgeParams.startY}px)`}
-            class="nodrag nopan pointer-events-auto absolute z-50 cursor-pointer rounded bg-white/80 px-2 py-0.5 text-xs font-medium text-[#303030] shadow-sm"
+{#if edgeGeometry}
+    <BaseEdge {id} path={edgeGeometry.path} {markerStart} {markerEnd} {style} />
+    {#if data?.toLabel && data?.showAssociationLabels}
+        {@const canMoveDecoration =
+            (data?.canMoveAssociationDecoration ?? false) &&
+            Boolean(data?.toAssociationUUID)}
+        {@const isDragging = activeDrag?.offsetKey === "toLabelOffset"}
+        {@const currentOffset = isDragging
+            ? activeDrag.currentOffset
+            : getPersistedOffset("toLabelOffset", data?.toLabelOffset)}
+        {@const position = getDecorationPosition(
+            edgeGeometry.startAssociationLabelAnchor,
+            currentOffset,
+        )}
+        <EdgeLabel
+            x={position.x}
+            y={position.y}
+            transparent
+            class={`nodrag nopan ${canMoveDecoration ? "pointer-events-auto" : "pointer-events-none"} bg-transparent p-0`}
+            onpointerdown={canMoveDecoration
+                ? pointerEvent =>
+                      startDecorationDrag(pointerEvent, {
+                          associationUUID: data?.toAssociationUUID,
+                          decorationType: DECORATION_TYPE_LABEL,
+                          offsetKey: "toLabelOffset",
+                          storedOffset: data?.toLabelOffset,
+                      })
+                : undefined}
         >
-            {data.fromMultiplicity}
-        </div>
+            <div
+                class={getDecorationClass(true, canMoveDecoration, isDragging)}
+                style={getLabelStyle(position, sourceNode.current)}
+            >
+                {data.toLabel}
+            </div>
+        </EdgeLabel>
     {/if}
-    {#if data.toMultiplicity}
-        <div
-            style:transform={`translate(-50%, -50%) translate(${edgeParams.tx + edgeParams.endX}px, ${edgeParams.ty + edgeParams.endY}px)`}
-            class="nodrag nopan pointer-events-auto absolute z-50 cursor-pointer rounded bg-white/80 px-2 py-0.5 text-xs font-medium text-[#303030] shadow-sm"
+    {#if data?.fromLabel && data?.showAssociationLabels}
+        {@const canMoveDecoration =
+            (data?.canMoveAssociationDecoration ?? false) &&
+            Boolean(data?.fromAssociationUUID)}
+        {@const isDragging = activeDrag?.offsetKey === "fromLabelOffset"}
+        {@const currentOffset = isDragging
+            ? activeDrag.currentOffset
+            : getPersistedOffset("fromLabelOffset", data?.fromLabelOffset)}
+        {@const position = getDecorationPosition(
+            edgeGeometry.endAssociationLabelAnchor,
+            currentOffset,
+        )}
+        <EdgeLabel
+            x={position.x}
+            y={position.y}
+            transparent
+            class={`nodrag nopan ${canMoveDecoration ? "pointer-events-auto" : "pointer-events-none"} bg-transparent p-0`}
+            onpointerdown={canMoveDecoration
+                ? pointerEvent =>
+                      startDecorationDrag(pointerEvent, {
+                          associationUUID: data?.fromAssociationUUID,
+                          decorationType: DECORATION_TYPE_LABEL,
+                          offsetKey: "fromLabelOffset",
+                          storedOffset: data?.fromLabelOffset,
+                      })
+                : undefined}
         >
-            {data.toMultiplicity}
-        </div>
+            <div
+                class={getDecorationClass(true, canMoveDecoration, isDragging)}
+                style={getLabelStyle(position, targetNode.current)}
+            >
+                {data.fromLabel}
+            </div>
+        </EdgeLabel>
     {/if}
-</EdgeLabel>
+    {#if data?.fromMultiplicity}
+        {@const canMoveDecoration =
+            (data?.canMoveAssociationDecoration ?? false) &&
+            Boolean(data?.fromAssociationUUID)}
+        {@const isDragging = activeDrag?.offsetKey === "fromMultiplicityOffset"}
+        {@const currentOffset = isDragging
+            ? activeDrag.currentOffset
+            : getPersistedOffset(
+                  "fromMultiplicityOffset",
+                  data?.fromMultiplicityOffset,
+              )}
+        {@const position = getDecorationPosition(
+            edgeGeometry.startMultiplicityAnchor,
+            currentOffset,
+        )}
+        <EdgeLabel
+            x={position.x}
+            y={position.y}
+            transparent
+            class={`nodrag nopan ${canMoveDecoration ? "pointer-events-auto" : "pointer-events-none"} bg-transparent p-0`}
+            onpointerdown={canMoveDecoration
+                ? pointerEvent =>
+                      startDecorationDrag(pointerEvent, {
+                          associationUUID: data?.fromAssociationUUID,
+                          decorationType: DECORATION_TYPE_MULTIPLICITY,
+                          offsetKey: "fromMultiplicityOffset",
+                          storedOffset: data?.fromMultiplicityOffset,
+                      })
+                : undefined}
+        >
+            <div
+                class={getDecorationClass(false, canMoveDecoration, isDragging)}
+            >
+                {data.fromMultiplicity}
+            </div>
+        </EdgeLabel>
+    {/if}
+    {#if data?.toMultiplicity}
+        {@const canMoveDecoration =
+            (data?.canMoveAssociationDecoration ?? false) &&
+            Boolean(data?.toAssociationUUID)}
+        {@const isDragging = activeDrag?.offsetKey === "toMultiplicityOffset"}
+        {@const currentOffset = isDragging
+            ? activeDrag.currentOffset
+            : getPersistedOffset(
+                  "toMultiplicityOffset",
+                  data?.toMultiplicityOffset,
+              )}
+        {@const position = getDecorationPosition(
+            edgeGeometry.endMultiplicityAnchor,
+            currentOffset,
+        )}
+        <EdgeLabel
+            x={position.x}
+            y={position.y}
+            transparent
+            class={`nodrag nopan ${canMoveDecoration ? "pointer-events-auto" : "pointer-events-none"} bg-transparent p-0`}
+            onpointerdown={canMoveDecoration
+                ? pointerEvent =>
+                      startDecorationDrag(pointerEvent, {
+                          associationUUID: data?.toAssociationUUID,
+                          decorationType: DECORATION_TYPE_MULTIPLICITY,
+                          offsetKey: "toMultiplicityOffset",
+                          storedOffset: data?.toMultiplicityOffset,
+                      })
+                : undefined}
+        >
+            <div
+                class={getDecorationClass(false, canMoveDecoration, isDragging)}
+            >
+                {data.toMultiplicity}
+            </div>
+        </EdgeLabel>
+    {/if}
+{/if}

--- a/frontend/src/lib/rendering/svelteflow/components/edgeUtils.ts
+++ b/frontend/src/lib/rendering/svelteflow/components/edgeUtils.ts
@@ -17,30 +17,85 @@
 
 import { type InternalNode } from "@xyflow/svelte";
 
+type Point = {
+    x: number;
+    y: number;
+};
+
+const LABEL_ALIGNMENT_THRESHOLD = 8;
+
+function getNodeCenter(node: InternalNode): Point {
+    const positionAbsolute = node.internals.positionAbsolute || { x: 0, y: 0 };
+
+    return {
+        x: positionAbsolute.x + (node.measured.width ?? 0) / 2,
+        y: positionAbsolute.y + (node.measured.height ?? 0) / 2,
+    };
+}
+
+function getAxisAlignment(value: number, center: number) {
+    if (value < center - LABEL_ALIGNMENT_THRESHOLD) {
+        return "min";
+    }
+
+    if (value > center + LABEL_ALIGNMENT_THRESHOLD) {
+        return "max";
+    }
+
+    return "center";
+}
+
+function getTranslateValue(alignment: "min" | "center" | "max") {
+    if (alignment === "min") {
+        return "-100%";
+    }
+
+    if (alignment === "max") {
+        return "0%";
+    }
+
+    return "-50%";
+}
+
+export function getAssociationLabelTransform(
+    position: Point,
+    node: InternalNode,
+) {
+    const nodeCenter = getNodeCenter(node);
+    const horizontalAlignment = getAxisAlignment(position.x, nodeCenter.x);
+    const verticalAlignment = getAxisAlignment(position.y, nodeCenter.y);
+
+    return `translate(${getTranslateValue(horizontalAlignment)}, ${getTranslateValue(verticalAlignment)})`;
+}
+
 /**
  * Calculates the intersection point between a line (from the target to the node center)
  * and the border of the intersection node. Used to determine edge start and end points.
  * This and the following methods are adapted from the SvelteFlow "Easy Connect" example.
  * See: https://svelteflow.dev/examples/nodes/easy-connect
  */
-function getNodeIntersection(
+function getNodeIntersectionForPoint(
     intersectionNode: InternalNode,
-    targetNode: InternalNode,
-    offsetY: number = 0,
+    targetPoint: Point,
 ) {
     const intersectionPos = intersectionNode.internals.positionAbsolute || {
         x: 0,
         y: 0,
     };
-    const targetPos = targetNode.internals.positionAbsolute || { x: 0, y: 0 };
-
     const w = (intersectionNode.measured.width ?? 0) / 2;
     const h = (intersectionNode.measured.height ?? 0) / 2;
 
+    if (w === 0 || h === 0) {
+        return {
+            x: intersectionPos.x + w,
+            y: intersectionPos.y + h,
+        };
+    }
+
     const x2 = intersectionPos.x + w;
     const y2 = intersectionPos.y + h;
-    const x1 = targetPos.x + (targetNode.measured.width ?? 0) / 2;
-    const y1 = targetPos.y + (targetNode.measured.height ?? 0) / 2 + offsetY;
+    const x1 = targetPoint.x;
+    const y1 = targetPoint.y;
 
     const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
     const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);
@@ -53,6 +108,19 @@ function getNodeIntersection(
         x: w * (xx3 + yy3) + x2,
         y: h * (-xx3 + yy3) + y2,
     };
+}
+
+function getNodeIntersection(
+    intersectionNode: InternalNode,
+    targetNode: InternalNode,
+    offsetY: number = 0,
+) {
+    const targetCenter = getNodeCenter(targetNode);
+
+    return getNodeIntersectionForPoint(intersectionNode, {
+        x: targetCenter.x,
+        y: targetCenter.y + offsetY,
+    });
 }
 
 /**
@@ -91,6 +159,131 @@ function getLabelOffsets(sx: number, sy: number, tx: number, ty: number) {
     };
 }
 
+function getVectorData(sx: number, sy: number, tx: number, ty: number) {
+    const dx = tx - sx;
+    const dy = ty - sy;
+    const length = Math.sqrt(dx * dx + dy * dy) || 1;
+
+    return {
+        dx,
+        dy,
+        length,
+        unitX: dx / length,
+        unitY: dy / length,
+        normalX: -dy / length,
+        normalY: dx / length,
+    };
+}
+
+function getPreferredLabelSide(sx: number, sy: number, tx: number, ty: number) {
+    const { dx, dy } = getVectorData(sx, sy, tx, ty);
+    const angle = Math.atan2(-dy, dx) * (180 / Math.PI);
+    const normalizedAngle = (angle + 360) % 360;
+    const labelOnLeft =
+        (normalizedAngle >= 90 && normalizedAngle < 180) ||
+        normalizedAngle >= 270;
+
+    return labelOnLeft ? 1 : -1;
+}
+
+function getSign(value: number) {
+    if (value === 0) {
+        return 0;
+    }
+
+    return value > 0 ? 1 : -1;
+}
+
+function getQuadraticBezierTangent(
+    sx: number,
+    sy: number,
+    cx: number,
+    cy: number,
+    tx: number,
+    ty: number,
+    t: number,
+) {
+    return {
+        x: 2 * (1 - t) * (cx - sx) + 2 * t * (tx - cx),
+        y: 2 * (1 - t) * (cy - sy) + 2 * t * (ty - cy),
+    };
+}
+
+function getNormalizedVector(x: number, y: number) {
+    const length = Math.sqrt(x * x + y * y) || 1;
+
+    return {
+        x: x / length,
+        y: y / length,
+    };
+}
+
+function getAssociationEndpointDirections(
+    sx: number,
+    sy: number,
+    cx: number,
+    cy: number,
+    tx: number,
+    ty: number,
+) {
+    const startTangentAtSource = getQuadraticBezierTangent(
+        sx,
+        sy,
+        cx,
+        cy,
+        tx,
+        ty,
+        0.08,
+    );
+    const endTangentAtTarget = getQuadraticBezierTangent(
+        sx,
+        sy,
+        cx,
+        cy,
+        tx,
+        ty,
+        0.92,
+    );
+    const startTangent = getNormalizedVector(
+        startTangentAtSource.x,
+        startTangentAtSource.y,
+    );
+    const endTangent = getNormalizedVector(
+        endTangentAtTarget.x,
+        endTangentAtTarget.y,
+    );
+    const startNormal = { x: -startTangent.y, y: startTangent.x };
+    const endInward = { x: -endTangent.x, y: -endTangent.y };
+    const endNormal = { x: -endInward.y, y: endInward.x };
+
+    return {
+        startInward: startTangent,
+        startNormal,
+        endInward,
+        endNormal,
+    };
+}
+
+function getAssociationDecorationAnchor(
+    point: Point,
+    inward: Point,
+    normal: Point,
+    alongDistance: number,
+    perpendicularDistance: number,
+    side: number,
+) {
+    return {
+        x:
+            point.x +
+            inward.x * alongDistance +
+            normal.x * perpendicularDistance * side,
+        y:
+            point.y +
+            inward.y * alongDistance +
+            normal.y * perpendicularDistance * side,
+    };
+}
+
 /**
  * Returns all parameters needed to render an edge and its labels.
  * Contains the start/end points of the edge as well as the calculated label positions.
@@ -119,5 +312,102 @@ export function getEdgeParams(
         startY: labelOffsets.startY,
         endX: labelOffsets.endX,
         endY: labelOffsets.endY,
+    };
+}
+
+export function getAssociationEdgeGeometry(
+    source: InternalNode,
+    target: InternalNode,
+    parallelOffset: number = 0,
+) {
+    const sourceCenter = getNodeCenter(source);
+    const targetCenter = getNodeCenter(target);
+    const centerVector = getVectorData(
+        sourceCenter.x,
+        sourceCenter.y,
+        targetCenter.x,
+        targetCenter.y,
+    );
+    const endpointOffset = parallelOffset * 0.32;
+    const sourceIntersection = getNodeIntersectionForPoint(source, {
+        x: targetCenter.x + centerVector.normalX * endpointOffset,
+        y: targetCenter.y + centerVector.normalY * endpointOffset,
+    });
+    const targetIntersection = getNodeIntersectionForPoint(target, {
+        x: sourceCenter.x + centerVector.normalX * endpointOffset,
+        y: sourceCenter.y + centerVector.normalY * endpointOffset,
+    });
+    const { normalX, normalY } = getVectorData(
+        sourceIntersection.x,
+        sourceIntersection.y,
+        targetIntersection.x,
+        targetIntersection.y,
+    );
+    const controlPoint = {
+        x:
+            (sourceIntersection.x + targetIntersection.x) / 2 +
+            normalX * parallelOffset,
+        y:
+            (sourceIntersection.y + targetIntersection.y) / 2 +
+            normalY * parallelOffset,
+    };
+    const labelSide =
+        parallelOffset === 0
+            ? getPreferredLabelSide(
+                  sourceIntersection.x,
+                  sourceIntersection.y,
+                  targetIntersection.x,
+                  targetIntersection.y,
+              )
+            : getSign(parallelOffset);
+    const endpointDirections = getAssociationEndpointDirections(
+        sourceIntersection.x,
+        sourceIntersection.y,
+        controlPoint.x,
+        controlPoint.y,
+        targetIntersection.x,
+        targetIntersection.y,
+    );
+
+    return {
+        sx: sourceIntersection.x,
+        sy: sourceIntersection.y,
+        tx: targetIntersection.x,
+        ty: targetIntersection.y,
+        cx: controlPoint.x,
+        cy: controlPoint.y,
+        path: `M ${sourceIntersection.x},${sourceIntersection.y} Q ${controlPoint.x},${controlPoint.y} ${targetIntersection.x},${targetIntersection.y}`,
+        startMultiplicityAnchor: getAssociationDecorationAnchor(
+            sourceIntersection,
+            endpointDirections.startInward,
+            endpointDirections.startNormal,
+            16,
+            14,
+            labelSide,
+        ),
+        endMultiplicityAnchor: getAssociationDecorationAnchor(
+            targetIntersection,
+            endpointDirections.endInward,
+            endpointDirections.endNormal,
+            16,
+            14,
+            labelSide,
+        ),
+        startAssociationLabelAnchor: getAssociationDecorationAnchor(
+            sourceIntersection,
+            endpointDirections.startInward,
+            endpointDirections.startNormal,
+            42,
+            24,
+            -labelSide,
+        ),
+        endAssociationLabelAnchor: getAssociationDecorationAnchor(
+            targetIntersection,
+            endpointDirections.endInward,
+            endpointDirections.endNormal,
+            42,
+            24,
+            -labelSide,
+        ),
     };
 }

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -27,6 +27,7 @@
     import ElkWorkerURL from "elkjs/lib/elk-worker.js?url";
     import ELK from "elkjs/lib/elk.bundled.js"; //keep this import! the 'elkjs' import has a bug
     import { onMount } from "svelte";
+    import { untrack } from "svelte";
 
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
@@ -34,6 +35,7 @@
     import {
         editorState,
         forceReloadTrigger,
+        graphViewState,
     } from "$lib/sharedState.svelte.js";
 
     import AssociationEdge from "./components/AssociationEdge.svelte";
@@ -59,7 +61,7 @@
 
     let nodes = $state.raw([...inputNodes]);
     let edges = $state.raw([...inputEdges]);
-    let isDatasetReadOnly = $state();
+    let isDatasetReadOnly = $state(true);
 
     let nodesInit = useNodesInitialized();
     let layouted = $state(false);
@@ -72,7 +74,59 @@
 
     $effect(() => {
         nodes = [...inputNodes];
+        const associationEdgeGroups = inputEdges.reduce((groups, edge) => {
+            if (edge.type !== "association") {
+                return groups;
+            }
+
+            const groupKey = getAssociationGroupKey(edge);
+            const group = groups.get(groupKey) ?? [];
+            group.push(edge);
+            groups.set(groupKey, group);
+
+            return groups;
+        }, new Map());
+
+        for (const group of associationEdgeGroups.values()) {
+            group.sort((a, b) =>
+                getAssociationOrderKey(a).localeCompare(
+                    getAssociationOrderKey(b),
+                ),
+            );
+        }
+
         edges = inputEdges.map(edge => {
+            let renderedEdge =
+                edge.type === "association"
+                    ? (() => {
+                          const groupKey = getAssociationGroupKey(edge);
+                          const group = associationEdgeGroups.get(groupKey) ?? [
+                              edge,
+                          ];
+                          const edgeIndex = group.findIndex(
+                              groupedEdge => groupedEdge.id === edge.id,
+                          );
+                          const canonicalOffset =
+                              (edgeIndex - (group.length - 1) / 2) * 34;
+                          const [canonicalSource] = [
+                              String(edge.source),
+                              String(edge.target),
+                          ].sort();
+                          const orientationMatchesCanonical =
+                              String(edge.source) === canonicalSource;
+
+                          return {
+                              ...edge,
+                              data: {
+                                  ...decorateAssociationEdgeData(edge.data),
+                                  parallelOffset: orientationMatchesCanonical
+                                      ? canonicalOffset
+                                      : -canonicalOffset,
+                              },
+                          };
+                      })()
+                    : edge;
+
             //applies offset to inheritance edge if an association edge already exists between the same two nodes
             if (edge.type === "inheritance") {
                 const hasAssociationEdgeBetweenSameNodes = inputEdges.some(
@@ -92,16 +146,16 @@
 
                 if (hasAssociationEdgeBetweenSameNodes) {
                     return {
-                        ...edge,
+                        ...renderedEdge,
                         data: {
-                            ...(edge.data || {}),
+                            ...(renderedEdge.data || {}),
                             offsetEdge: true,
                         },
                     };
                 }
             }
 
-            return edge;
+            return renderedEdge;
         });
         layouted = false;
         isLoading = false;
@@ -121,12 +175,50 @@
         isDatasetReadOnly = dataset ? await isReadOnly(dataset) : false;
     });
 
+    $effect(() => {
+        graphViewState.filter.subscribe();
+        const canMoveAssociationDecoration = !isDatasetReadOnly;
+        const showAssociationLabels =
+            graphViewState.filter.getValue().includeAssociationLabels;
+
+        edges = untrack(() =>
+            edges.map(edge =>
+                edge.type === "association"
+                    ? {
+                          ...edge,
+                          data: {
+                              ...(edge.data || {}),
+                              canMoveAssociationDecoration,
+                              showAssociationLabels,
+                          },
+                      }
+                    : edge,
+            ),
+        );
+    });
+
     onMount(() => {
         svelteFlowAPI = {
             svelteFlow: useSvelteFlow(),
             nodes: useNodes(),
         };
     });
+
+    function getAssociationGroupKey(edge) {
+        const sortedNodeIds = [String(edge.source), String(edge.target)].sort();
+
+        return `${sortedNodeIds[0]}::${sortedNodeIds[1]}`;
+    }
+
+    function getAssociationOrderKey(edge) {
+        return [
+            String(edge.source),
+            String(edge.target),
+            edge.data?.fromLabel ?? "",
+            edge.data?.toLabel ?? "",
+            edge.id ?? "",
+        ].join("::");
+    }
 
     async function isReadOnly(datasetName) {
         const res = await bec.isReadOnly(datasetName);
@@ -161,6 +253,16 @@
 
     function handleNodeMove(nodeMoveEvent) {
         updateNodePositions(nodeMoveEvent.nodes);
+    }
+
+    function decorateAssociationEdgeData(data = {}, overrideData = {}) {
+        return {
+            ...(data || {}),
+            ...overrideData,
+            showAssociationLabels:
+                graphViewState.filter.getValue().includeAssociationLabels,
+            canMoveAssociationDecoration: !isDatasetReadOnly,
+        };
     }
 
     function updateNodePositions(movedNodes) {

--- a/frontend/src/lib/sharedState.svelte.js
+++ b/frontend/src/lib/sharedState.svelte.js
@@ -67,7 +67,8 @@ export const editorState = {
  *      includeAttributes: boolean,
  *      includeAssociations: boolean,
  *      includeInheritance: boolean,
- *      includeRelationsToExternalPackages: boolean
+ *      includeRelationsToExternalPackages: boolean,
+ *      includeAssociationLabels: boolean
  *  }>
  * }}
  */
@@ -79,6 +80,7 @@ export const graphViewState = {
         includeAssociations: true,
         includeInheritance: true,
         includeRelationsToExternalPackages: true,
+        includeAssociationLabels: true,
     }),
 };
 

--- a/frontend/src/routes/FilterViewDialog.svelte
+++ b/frontend/src/routes/FilterViewDialog.svelte
@@ -16,63 +16,155 @@
   -->
 
 <script>
-    import CheckBoxEditControl from "$lib/components/CheckBoxEditControl.svelte";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
     import { graphViewState } from "$lib/sharedState.svelte.js";
 
     let { showDialog = $bindable() } = $props();
 
-    let options = $state([
+    const FILTER_GROUPS = [
         {
-            label: "include enum entries",
-            value: graphViewState.filter.getValue().includeEnumEntries,
+            title: "Class Content",
+            description:
+                "Control which class members are rendered inside the package view.",
+            options: [
+                {
+                    key: "includeAttributes",
+                    title: "Attributes",
+                    description: "Show attributes inside class boxes.",
+                },
+                {
+                    key: "includeEnumEntries",
+                    title: "Enum Entries",
+                    description: "Show enum members inside enum classes.",
+                },
+            ],
         },
         {
-            label: "include attributes",
-            value: graphViewState.filter.getValue().includeAttributes,
+            title: "Relationships",
+            description:
+                "Decide which connections are rendered between classes in the diagram.",
+            options: [
+                {
+                    key: "includeAssociations",
+                    title: "Associations",
+                    description: "Show association edges between classes.",
+                },
+                {
+                    key: "includeAssociationLabels",
+                    title: "Association Role Labels",
+                    description:
+                        "Show association role labels on edges in the SvelteFlow diagram.",
+                },
+                {
+                    key: "includeInheritance",
+                    title: "Inheritance",
+                    description: "Show superclass relationships.",
+                },
+            ],
         },
         {
-            label: "include associations",
-            value: graphViewState.filter.getValue().includeAssociations,
+            title: "Package Scope",
+            description:
+                "Choose whether links beyond the selected package stay visible.",
+            options: [
+                {
+                    key: "includeRelationsToExternalPackages",
+                    title: "External Package Relations",
+                    description:
+                        "Keep edges to classes outside the selected package visible.",
+                },
+            ],
         },
-        {
-            label: "include inheritance",
-            value: graphViewState.filter.getValue().includeInheritance,
-        },
-        {
-            label: "include relations to external packages",
-            value: graphViewState.filter.getValue()
-                .includeRelationsToExternalPackages,
-        },
-    ]);
+    ];
+
+    let options = $state([]);
+
+    function syncOptions() {
+        const currentFilter = graphViewState.filter.getValue();
+
+        options = FILTER_GROUPS.map(group => ({
+            ...group,
+            options: group.options.map(option => ({
+                ...option,
+                value: currentFilter[option.key],
+            })),
+        }));
+    }
 
     function submit() {
-        graphViewState.filter.updateValue({
-            includeEnumEntries: options[0].value,
-            includeAttributes: options[1].value,
-            includeAssociations: options[2].value,
-            includeInheritance: options[3].value,
-            includeRelationsToExternalPackages: options[4].value,
-        });
+        const nextFilter = options.reduce((filter, group) => {
+            for (const option of group.options) {
+                filter[option.key] = option.value;
+            }
+
+            return filter;
+        }, {});
+
+        graphViewState.filter.updateValue(nextFilter);
         showDialog = false;
     }
+
+    syncOptions();
 </script>
 
 <ActionDialog
     bind:showDialog
-    primaryLabel="Save"
+    primaryLabel="Apply"
     onPrimary={submit}
-    title="Select filters"
+    onOpen={syncOptions}
+    title="Filter Diagram"
+    size="w-[34rem] max-w-[calc(100vw-2rem)]"
 >
-    <div class="flex flex-col space-y-2">
-        {#each options as option}
-            <div class="flex items-center space-x-2">
-                <CheckBoxEditControl
-                    label={option.label}
-                    labelFirst={false}
-                    bind:value={option.value}
-                />
-            </div>
+    <div class="flex flex-col gap-4 px-2 py-1">
+        <div class="border-border bg-default-background rounded border p-3">
+            <p class="text-default-text text-sm font-medium">
+                Choose what should stay visible in the current diagram.
+            </p>
+            <p class="text-default-text mt-1 text-sm opacity-75">
+                These filters affect the package view only and can be changed at
+                any time.
+            </p>
+        </div>
+
+        {#each options as group}
+            <section class="border-border rounded border">
+                <div
+                    class="bg-default-background border-border border-b px-4 py-3"
+                >
+                    <h3 class="text-default-text text-sm font-semibold">
+                        {group.title}
+                    </h3>
+                    <p class="text-default-text mt-1 text-sm opacity-75">
+                        {group.description}
+                    </p>
+                </div>
+
+                <div class="flex flex-col gap-3 p-3">
+                    {#each group.options as option}
+                        <label
+                            class="border-border bg-window-background hover:bg-default-background flex cursor-pointer items-start gap-3 rounded border px-3 py-3 transition-colors"
+                        >
+                            <input
+                                type="checkbox"
+                                class="text-button-default-text bg-default-background checked:bg-button-default-background mt-0.5 h-4 w-4 rounded border-none"
+                                bind:checked={option.value}
+                            />
+                            <span class="min-w-0">
+                                <span
+                                    class="text-default-text block text-sm font-medium"
+                                >
+                                    {option.title}
+                                </span>
+                                <span
+                                    class="text-default-text mt-1 block text-sm opacity-75"
+                                >
+                                    {option.description}
+                                </span>
+                            </span>
+                        </label>
+                    {/each}
+                </div>
+            </section>
         {/each}
     </div>
 </ActionDialog>

--- a/frontend/src/routes/mainpage/mermaidWrapper.svelte
+++ b/frontend/src/routes/mainpage/mermaidWrapper.svelte
@@ -49,6 +49,7 @@
         editorState.selectedGraph.subscribe();
         editorState.selectedPackageUUID.subscribe();
         forceReloadTrigger.subscribe();
+        graphViewState.filter.subscribe();
 
         if (!editorState.selectedPackageUUID.getValue()) return;
 
@@ -65,6 +66,8 @@
             includeRelationsToExternalPackages:
                 graphViewState.filter.getValue()
                     .includeRelationsToExternalPackages,
+            includeAssociationLabels:
+                graphViewState.filter.getValue().includeAssociationLabels,
         };
         new BackendConnection(fetch, PUBLIC_BACKEND_URL)
             .fetchMermaidUMLFiltered(

--- a/frontend/src/routes/mainpage/renderingWrapper.svelte
+++ b/frontend/src/routes/mainpage/renderingWrapper.svelte
@@ -66,6 +66,7 @@
         editorState.selectedDataset.subscribe();
         editorState.selectedGraph.subscribe();
         editorState.selectedPackageUUID.subscribe();
+        graphViewState.filter.subscribe();
 
         if (!editorState.selectedPackageUUID.getValue()) {
             response = null;
@@ -86,6 +87,8 @@
             includeRelationsToExternalPackages:
                 graphViewState.filter.getValue()
                     .includeRelationsToExternalPackages,
+            includeAssociationLabels:
+                graphViewState.filter.getValue().includeAssociationLabels,
         };
 
         try {

--- a/frontend/tests/lib/rendering/svelteflow/components/edgeUtils.test.js
+++ b/frontend/tests/lib/rendering/svelteflow/components/edgeUtils.test.js
@@ -1,0 +1,95 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+    getAssociationEdgeGeometry,
+    getAssociationLabelTransform,
+} from "$lib/rendering/svelteflow/components/edgeUtils.ts";
+
+function createNode(x, y, width, height) {
+    return {
+        measured: {
+            width,
+            height,
+        },
+        internals: {
+            positionAbsolute: {
+                x,
+                y,
+            },
+        },
+    };
+}
+
+describe("edgeUtils", () => {
+    test("aligns labels away from the node when the anchor is left of center", () => {
+        const node = createNode(100, 100, 120, 60);
+
+        expect(
+            getAssociationLabelTransform(
+                {
+                    x: 90,
+                    y: 130,
+                },
+                node,
+            ),
+        ).toBe("translate(-100%, -50%)");
+    });
+
+    test("aligns labels away from the node when the anchor is right and below", () => {
+        const node = createNode(100, 100, 120, 60);
+
+        expect(
+            getAssociationLabelTransform(
+                {
+                    x: 250,
+                    y: 180,
+                },
+                node,
+            ),
+        ).toBe("translate(0%, 0%)");
+    });
+
+    test("centers labels when the anchor stays near the node center line", () => {
+        const node = createNode(100, 100, 120, 60);
+
+        expect(
+            getAssociationLabelTransform(
+                {
+                    x: 160,
+                    y: 130,
+                },
+                node,
+            ),
+        ).toBe("translate(-50%, -50%)");
+    });
+
+    test("returns finite association geometry even before a node has been measured", () => {
+        const source = createNode(100, 100, 0, 0);
+        const target = createNode(300, 100, 120, 60);
+
+        const geometry = getAssociationEdgeGeometry(source, target);
+
+        expect(Number.isFinite(geometry.sx)).toBe(true);
+        expect(Number.isFinite(geometry.sy)).toBe(true);
+        expect(Number.isFinite(geometry.tx)).toBe(true);
+        expect(Number.isFinite(geometry.ty)).toBe(true);
+        expect(geometry.path).not.toContain("NaN");
+    });
+});


### PR DESCRIPTION
## Description

Improved diagram association edge rendering.
Added labels for associations in diagram.
Reformatted the filter view dialog.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
