### PR TITLE
chore: add GitHub PR validation workflows

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          requireScope: false


### PR DESCRIPTION
- Added a workflow for enforcing the PR title in conventional commit style.
- Added config for GitHub DCO App to ignore SOPTIM organization members from DCO Sign-Off.