### PR TITLE
chore(deps): update dependency apache jena to v6

### DIFF
--- a/backend/LICENSES-THIRD-PARTY.md
+++ b/backend/LICENSES-THIRD-PARTY.md
@@ -14,13 +14,13 @@
 
 ### Apache Jena - Extras - Query Builder
 - **Package:** org.apache.jena
-- **Version:** 5.6.0
+- **Version:** 6.0.0
 - **License:** Apache License 2.0
-- **URL:** [https://jena.apache.org/jena-extras/jena-querybuilder/](https://jena.apache.org/jena-extras/jena-querybuilder/)
+- **URL:** [https://jena.apache.org/jena-querybuilder/](https://jena.apache.org/jena-querybuilder/)
 
 ### Apache Jena - Libraries POM
 - **Package:** org.apache.jena
-- **Version:** 5.6.0
+- **Version:** 6.0.0
 - **License:** Apache License 2.0
 - **URL:** [https://jena.apache.org/apache-jena-libs/](https://jena.apache.org/apache-jena-libs/)
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -325,7 +325,7 @@
             <groupId>org.apache.jena</groupId>
             <artifactId>apache-jena-libs</artifactId>
             <type>pom</type>
-            <version>5.6.0</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -330,7 +330,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-querybuilder</artifactId>
-            <version>5.6.0</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/backend/src/main/java/org/rdfarchitect/rdf/graph/wrapper/GraphRewindable.java
+++ b/backend/src/main/java/org/rdfarchitect/rdf/graph/wrapper/GraphRewindable.java
@@ -17,7 +17,6 @@
 
 package org.rdfarchitect.rdf.graph.wrapper;
 
-import org.apache.jena.graph.Capabilities;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphEventManager;
 import org.apache.jena.graph.Node;
@@ -281,27 +280,11 @@ public class GraphRewindable implements Graph, Transactional, Rewindable {
 
     // Graph
     @Override
-    public boolean dependsOn(Graph other) {
-        if (!isInTransaction()) {
-            throw new GraphNotInATransactionException();
-        }
-        return currentDelta.dependsOn(other);
-    }
-
-    @Override
     public TransactionHandler getTransactionHandler() {
         if (!isInTransaction()) {
             throw new GraphNotInATransactionException();
         }
         return currentDelta.getTransactionHandler();
-    }
-
-    @Override
-    public Capabilities getCapabilities() {
-        if (!isInTransaction()) {
-            throw new GraphNotInATransactionException();
-        }
-        return currentDelta.getCapabilities();
     }
 
     @Override

--- a/backend/src/test/java/org/rdfarchitect/rdf/graph/wrapper/GraphRewindableTest.java
+++ b/backend/src/test/java/org/rdfarchitect/rdf/graph/wrapper/GraphRewindableTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.rdfarchitect.rdf.TestRDFUtils.*;
 
-import org.apache.jena.graph.Capabilities;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphEventManager;
 import org.apache.jena.graph.Node;
@@ -92,22 +91,9 @@ class GraphRewindableTest {
         }
 
         @Test
-        void dependsOn() {
-            Graph emtpyGraph = GraphFactory.createDefaultGraph();
-            assertThatExceptionOfType(GraphNotInATransactionException.class)
-                    .isThrownBy(() -> graphRewindable.dependsOn(emtpyGraph));
-        }
-
-        @Test
         void getTransactionHandler_noTransactionStarted_throwsGraphNotInATransactionException() {
             assertThatExceptionOfType(GraphNotInATransactionException.class)
                     .isThrownBy(() -> graphRewindable.getTransactionHandler());
-        }
-
-        @Test
-        void getCapabilities_noTransactionStarted_throwsGraphNotInATransactionException() {
-            assertThatExceptionOfType(GraphNotInATransactionException.class)
-                    .isThrownBy(() -> graphRewindable.getCapabilities());
         }
 
         @Test
@@ -275,25 +261,10 @@ class GraphRewindableTest {
         }
 
         @Test
-        void dependsOn() {
-            graphRewindable.begin(TxnType.READ);
-            assertThat(graphRewindable.dependsOn(GraphFactory.createDefaultGraph()))
-                    .isInstanceOf(Boolean.class);
-            graphRewindable.end();
-        }
-
-        @Test
         void getTransactionHandler() {
             graphRewindable.begin(TxnType.READ);
             assertThat(graphRewindable.getTransactionHandler())
                     .isInstanceOf(TransactionHandler.class);
-            graphRewindable.end();
-        }
-
-        @Test
-        void getCapabilities() {
-            graphRewindable.begin(TxnType.READ);
-            assertThat(graphRewindable.getCapabilities()).isInstanceOf(Capabilities.class);
             graphRewindable.end();
         }
 


### PR DESCRIPTION
- Bumps `apache-jena-libs` and `jena-querybuilder` to `6.0.0`.
- Adapts `GraphRewindable` to the Jena 6 `Graph` interface, which no longer declares `getCapabilities()` / `Capabilities` or `dependsOn(Graph)`.
- Removes the now-obsolete `getCapabilities` and `dependsOn` test cases in `GraphRewindableTest`.

The `Model.write(OutputStream)` / `Model.write(Writer)` methods are deprecated-for-removal in Jena 6. This throws some warnings in `CimSortedModel`. Both methods are unused, but are generated via Lombok `@Delegate`. Fine for now, can be removed when both methods are deleted.