### PR TITLE
fix: classes are now opened in the class editor on creation (RDFA-96)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/AllClassesRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/AllClassesRESTController.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
-import org.rdfarchitect.api.controller.Response;
 import org.rdfarchitect.api.dto.ClassUMLAdaptedDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.database.GraphIdentifier;
@@ -107,11 +106,12 @@ public class AllClassesRESTController {
                 expandURIUseCase.expandUri(datasetName, addNewClassRequest.classURIPrefix);
         var graphIdentifier = new GraphIdentifier(datasetName, extendedGraphURI);
 
-        addClassUseCase.addClass(
-                graphIdentifier,
-                addNewClassRequest.packageDTO,
-                extendedClassURIPrefix,
-                addNewClassRequest.className);
+        var classUUID =
+                addClassUseCase.addClass(
+                        graphIdentifier,
+                        addNewClassRequest.packageDTO,
+                        extendedClassURIPrefix,
+                        addNewClassRequest.className);
 
         logger.info(
                 "Sending response to POST request: \"/api/datasets/{{}}/graphs/{{}}/classes\" to \"{}\".",
@@ -119,7 +119,7 @@ public class AllClassesRESTController {
                 graphURI,
                 originURL);
 
-        return Response.SUCCESS;
+        return classUUID.toString();
     }
 
     @Operation(

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/AddClassUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/AddClassUseCase.java
@@ -20,6 +20,8 @@ package org.rdfarchitect.services.update.classes;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.database.GraphIdentifier;
 
+import java.util.UUID;
+
 public interface AddClassUseCase {
 
     /**
@@ -31,8 +33,9 @@ public interface AddClassUseCase {
      * @param packageDTO The Package to which the class will be added.
      * @param classURIPrefix The prefix of the class to be added.
      * @param className The name of the class to be added.
+     * @return The UUID of the newly created class.
      */
-    void addClass(
+    UUID addClass(
             GraphIdentifier graphIdentifier,
             PackageDTO packageDTO,
             String classURIPrefix,

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
@@ -83,7 +83,7 @@ public class UpdateClassService
     }
 
     @Override
-    public void addClass(
+    public UUID addClass(
             GraphIdentifier graphIdentifier,
             PackageDTO packageDTO,
             String classURIPrefix,
@@ -114,6 +114,8 @@ public class UpdateClassService
         changeLogUseCase.recordChange(
                 graphIdentifier,
                 new ChangeLogEntry("Added class " + className, graph.getLastDelta()));
+
+        return newClassUUID;
     }
 
     private CIMClass constructClass(

--- a/frontend/src/routes/NewClassDialog.svelte
+++ b/frontend/src/routes/NewClassDialog.svelte
@@ -192,26 +192,32 @@
         const classNameLocal = className;
         const classURINamespaceLocal = classURINamespace;
         const selectedPackageUUID = classPackage?.uuid ?? "default";
-        const packageDTO = classPackage?.uuid ? classPackage : null;
-        let promise = fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(datasetNameLocal) +
-                "/graphs/" +
-                encodeURIComponent(graphURILocal) +
-                "/classes",
-            {
-                method: "POST",
-                headers: new Headers({ "Content-Type": "application/json" }),
-                body: JSON.stringify({
-                    packageDTO,
-                    classURIPrefix: classURINamespaceLocal.value,
-                    className: classNameLocal.value,
-                }),
-                credentials: "include",
-            },
-        ).then(res => {
+        let packageDTO = classPackage?.uuid === "default" ? null : classPackage;
+
+        try {
+            const res = await fetch(
+                PUBLIC_BACKEND_URL +
+                    "/datasets/" +
+                    encodeURIComponent(datasetNameLocal) +
+                    "/graphs/" +
+                    encodeURIComponent(graphURILocal) +
+                    "/classes",
+                {
+                    method: "POST",
+                    headers: new Headers({
+                        "Content-Type": "application/json",
+                    }),
+                    body: JSON.stringify({
+                        packageDTO,
+                        classURIPrefix: classURINamespaceLocal.value,
+                        className: classNameLocal.value,
+                    }),
+                    credentials: "include",
+                },
+            );
+
             if (res.ok) {
+                const uuid = await res.text();
                 console.log("successfully added class");
                 onClassCreated({
                     datasetName: datasetNameLocal,
@@ -219,29 +225,31 @@
                     packageUUID: selectedPackageUUID,
                     className: classNameLocal.value,
                 });
+                console.warn(
+                    "Received response text for new class UUID:",
+                    uuid,
+                    "Make sure the backend returns the new class UUID in the response body.",
+                );
                 editorState.selectedDataset.updateValue(datasetNameLocal);
                 editorState.selectedGraph.updateValue(graphURILocal);
                 editorState.selectedPackageUUID.updateValue(
                     selectedPackageUUID,
                 );
-                editorState.selectedClassDataset.updateValue(null);
-                editorState.selectedClassGraph.updateValue(null);
-                editorState.selectedClassUUID.updateValue(null);
+                editorState.selectedClassDataset.updateValue(datasetNameLocal);
+                editorState.selectedClassGraph.updateValue(graphURILocal);
+                editorState.selectedClassUUID.updateValue(uuid);
             } else {
                 console.log("failed to insert data");
             }
-        });
-        promise
-            .catch(e => {
-                console.log("failed to add class:", e);
-            })
-            .finally(() => {
-                forceReloadTrigger.trigger();
-                editorState.selectedDataset.trigger();
-                editorState.selectedGraph.trigger();
-                editorState.selectedPackageUUID.trigger();
-                editorState.selectedClassUUID.trigger();
-            });
+        } catch (e) {
+            console.log("failed to add class:", e);
+        } finally {
+            forceReloadTrigger.trigger();
+            editorState.selectedDataset.trigger();
+            editorState.selectedGraph.trigger();
+            editorState.selectedPackageUUID.trigger();
+            editorState.selectedClassUUID.trigger();
+        }
     }
 </script>
 

--- a/frontend/src/routes/NewClassDialog.svelte
+++ b/frontend/src/routes/NewClassDialog.svelte
@@ -225,11 +225,6 @@
                     packageUUID: selectedPackageUUID,
                     className: classNameLocal.value,
                 });
-                console.warn(
-                    "Received response text for new class UUID:",
-                    uuid,
-                    "Make sure the backend returns the new class UUID in the response body.",
-                );
                 editorState.selectedDataset.updateValue(datasetNameLocal);
                 editorState.selectedGraph.updateValue(graphURILocal);
                 editorState.selectedPackageUUID.updateValue(

--- a/frontend/src/routes/mainpage/packageNavigation/PackageButton.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/PackageButton.svelte
@@ -186,9 +186,7 @@
     bind:showDialog={showNewClassDialog}
     lockedDatasetName={datasetNavEntry.id}
     lockedGraphUri={graphNavEntry.id}
-    lockedPackage={packageNavEntry.data?.uuid === "default"
-        ? null
-        : packageNavEntry.data}
+    lockedPackage={packageNavEntry.data}
 />
 
 <PackageEditorDialog


### PR DESCRIPTION
## Description
fixed:
- classes are now opened on creation
- bug, where creating a class in the default package when selecting a different one would cause the default selection to not work

## Test Checklist
### General Behavior
- [x] Components reload automatically when data changes
- [x] Editing features are disabled in readonly datasets
- [x] Dialogs pre-select current dataset/graph
- [x] Required fields are validated in dialogs
- [x] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [x] Navigate to home page works
- File menu:
    - [x] Import → Graph/SHACL works
    - [x] Export → Graph/SHACL works
    - [x] Share Snapshot works
    - [x] Delete → Dataset/Graph works
- Edit menu:
    - [x] New → Class works
    - [x] New → Package works
    - [x] Edit/View → Create/Edit/View Ontology works
    - [x] Edit/View → Package works
    - [x] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [x] Enable/Disable editing works
    - [x] Manage/View namespaces works
    - [x] Delete → Ontology/Package works
- View menu:
    - [x] Changelog opens and shows current graph
    - [x] Compare Graphs opens
    - [x] Full SHACL works
- Help menu:
    - [x] Help link works
    - [x] Submit Feedback link works
    - [x] About navigation works

### Welcome Page
- [x] Navigation to Editor works
- [x] Tips are displayed
- [x] Security and data information displayed
- [x] Copyright and version information displayed

### Editor - MenuBar
- [x] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [x] Search finds classes, attributes, associations, packages
- [x] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [x] Hierarchical display (Datasets → Graphs → Packages) works
- [x] Selection is highlighted
- [x] Selecting a class does not change dataset/graph/package selection
- [x] Class selection stays open/highlighted when switching dataset/graph/package
- [x] Datasets and graphs are collapsible
- [x] Single click selects; double click or chevron toggles expand/collapse
- [x] State persists on reload (non-browser)
- [x] Context menus act on the dataset/graph/package they were opened on
- [x] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: UUID (readonly), Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
