### PR TITLE
fix: Add custom shacl to graph context (RDFA-502)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/shacl/custom/SHACLCustomContentRestController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/shacl/custom/SHACLCustomContentRestController.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.shacl.ShaclException;
 import org.rdfarchitect.api.controller.Response;
 import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.models.cim.data.dto.relations.uri.URI;
@@ -253,9 +252,6 @@ public class SHACLCustomContentRestController {
                 datasetName,
                 graphURI,
                 originURL);
-        if (shaclString.isEmpty()) {
-            throw new ShaclException("SHACL graph is empty for graph: " + extendedGraphURI);
-        }
         return shaclString;
     }
 

--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/shacl/custom/SHACLCustomNamespacesRestController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/shacl/custom/SHACLCustomNamespacesRestController.java
@@ -40,21 +40,21 @@ import org.springframework.web.bind.annotation.RestController;
 import java.nio.charset.StandardCharsets;
 
 @RestController
-@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/shacl/custom/prefixes")
+@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/shacl/custom/namespaces")
 @RequiredArgsConstructor
-public class SHACLCustomPrefixesRestController {
+public class SHACLCustomNamespacesRestController {
 
     private static final Logger logger =
-            LoggerFactory.getLogger(SHACLCustomPrefixesRestController.class);
+            LoggerFactory.getLogger(SHACLCustomNamespacesRestController.class);
 
     private final ExpandURIUseCase expandURIUseCase;
 
     private final SHACLExportUseCase shaclExportUseCase;
 
     @Operation(
-            summary = "export custom SHACL prefixes",
+            summary = "export custom SHACL namespaces",
             description =
-                    "Export the prefixes of the custom SHACL graph for a given graph identifier.",
+                    "Export the namespaces of the custom SHACL graph for a given graph identifier.",
             tags = {"shacl"},
             responses = {
                 @ApiResponse(
@@ -64,7 +64,7 @@ public class SHACLCustomPrefixesRestController {
                         })
             })
     @GetMapping("/ttl")
-    public String getCustomSHACLAsString(
+    public String getCustomSHACLNamespacesAsString(
             @Parameter(description = "The name/url of the inquirer.")
                     @RequestHeader(
                             value = HttpHeaders.ORIGIN,
@@ -79,7 +79,7 @@ public class SHACLCustomPrefixesRestController {
                     @PathVariable
                     String graphURI) {
         logger.info(
-                "Received GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/custom/prefixes/ttl\" from \"{}\".",
+                "Received GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/custom/namespaces/ttl\" from \"{}\".",
                 datasetName,
                 graphURI,
                 originURL);
@@ -89,13 +89,13 @@ public class SHACLCustomPrefixesRestController {
         // fetch data
         var shaclString =
                 shaclExportUseCase
-                        .exportCustomSHACLPrefixes(
+                        .exportCustomSHACLNamespaces(
                                 new GraphIdentifier(datasetName, extendedGraphURI),
                                 RDFFormat.TURTLE)
                         .toString(StandardCharsets.UTF_8);
 
         logger.info(
-                "Sending response to GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/custom/prefixes/ttl\" to \"{}\".",
+                "Sending response to GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/custom/namespaces/ttl\" to \"{}\".",
                 datasetName,
                 graphURI,
                 originURL);

--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/shacl/generate/SHACLGeneratedNamespacesRestController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/shacl/generate/SHACLGeneratedNamespacesRestController.java
@@ -40,21 +40,21 @@ import org.springframework.web.bind.annotation.RestController;
 import java.nio.charset.StandardCharsets;
 
 @RestController
-@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/shacl/generated/prefixes")
+@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/shacl/generated/namespaces")
 @RequiredArgsConstructor
-public class SHACLGeneratedPrefixesRestController {
+public class SHACLGeneratedNamespacesRestController {
 
     private static final Logger logger =
-            LoggerFactory.getLogger(SHACLGeneratedPrefixesRestController.class);
+            LoggerFactory.getLogger(SHACLGeneratedNamespacesRestController.class);
 
     private final ExpandURIUseCase expandURIUseCase;
 
     private final SHACLExportUseCase shaclExportUseCase;
 
     @Operation(
-            summary = "export generated SHACL prefixes",
+            summary = "export generated SHACL namespaces",
             description =
-                    "Export the prefixes of the generated SHACL graph for a given graph identifier.",
+                    "Export the namespaces of the generated SHACL graph for a given graph identifier.",
             tags = {"shacl"},
             responses = {
                 @ApiResponse(
@@ -64,7 +64,7 @@ public class SHACLGeneratedPrefixesRestController {
                         })
             })
     @GetMapping("/ttl")
-    public String getGeneratedSHACLPrefixesAsString(
+    public String getGeneratedSHACLNamespacesAsString(
             @Parameter(description = "The name/url of the inquirer.")
                     @RequestHeader(
                             value = HttpHeaders.ORIGIN,
@@ -79,7 +79,7 @@ public class SHACLGeneratedPrefixesRestController {
                     @PathVariable
                     String graphURI) {
         logger.info(
-                "Received GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/generated/prefixes/ttl\" from \"{}\".",
+                "Received GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/generated/namespaces/ttl\" from \"{}\".",
                 datasetName,
                 graphURI,
                 originURL);
@@ -89,13 +89,13 @@ public class SHACLGeneratedPrefixesRestController {
         // fetch data
         var shaclString =
                 shaclExportUseCase
-                        .exportGeneratedSHACLPrefixes(
+                        .exportGeneratedSHACLNamespaces(
                                 new GraphIdentifier(datasetName, extendedGraphURI),
                                 RDFFormat.TURTLE)
                         .toString(StandardCharsets.UTF_8);
 
         logger.info(
-                "Sending response to GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/generated/prefixes/ttl\" to \"{}\".",
+                "Sending response to GET request: \"/api/datasets/{{}}/graphs/{{}}/shacl/generated/namespaces/ttl\" to \"{}\".",
                 datasetName,
                 graphURI,
                 originURL);

--- a/backend/src/main/java/org/rdfarchitect/config/SHACLCustomConfig.java
+++ b/backend/src/main/java/org/rdfarchitect/config/SHACLCustomConfig.java
@@ -24,8 +24,8 @@ import org.rdfarchitect.services.shacl.SHACLGetClassRelationsUseCase;
 import org.rdfarchitect.services.shacl.SHACLGetShapeUseCase;
 import org.rdfarchitect.services.shacl.SHACLInsertUseCase;
 import org.rdfarchitect.services.shacl.SHACLReplaceShapeUseCase;
+import org.rdfarchitect.services.shacl.SHACLStoringService;
 import org.rdfarchitect.services.shacl.SHACLUpdateUseCase;
-import org.rdfarchitect.services.shacl.SingletonPrimitiveSHACLStoringService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -34,36 +34,36 @@ public class SHACLCustomConfig {
 
     @Bean
     public SHACLInsertUseCase shaclInsertUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 
     @Bean
     public SHACLGetClassRelationsUseCase shaclGetClassRelationsUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 
     @Bean
     public SHACLGetShapeUseCase shaclGetShapeUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 
     @Bean
     public SHACLReplaceShapeUseCase shaclReplaceShapeUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 
     @Bean
     public SHACLExportUseCase shaclExportUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 
     @Bean
     public SHACLDeleteShapeUseCase shaclDeleteShapeUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 
     @Bean
     public SHACLUpdateUseCase shaclUpdateUseCase(DatabasePort databasePort) {
-        return new SingletonPrimitiveSHACLStoringService(databasePort);
+        return new SHACLStoringService(databasePort);
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/database/inmemory/GraphWithContext.java
+++ b/backend/src/main/java/org/rdfarchitect/database/inmemory/GraphWithContext.java
@@ -20,6 +20,7 @@ package org.rdfarchitect.database.inmemory;
 import lombok.Getter;
 import lombok.Setter;
 
+import org.apache.jena.rdf.model.Model;
 import org.rdfarchitect.rdf.graph.wrapper.DiagramLayout;
 import org.rdfarchitect.rdf.graph.wrapper.GraphRewindableWithUUIDs;
 
@@ -31,6 +32,8 @@ public class GraphWithContext {
 
     @Getter private final GraphRewindableWithUUIDs rdfGraph;
     @Getter @Setter private DiagramLayout diagramLayout;
+
+    @Getter @Setter private Model customSHACL;
 
     public GraphWithContext(GraphRewindableWithUUIDs rdfGraph) {
         this.rdfGraph = rdfGraph;

--- a/backend/src/main/java/org/rdfarchitect/rdf/graph/source/implementations/GraphStringSourceImpl.java
+++ b/backend/src/main/java/org/rdfarchitect/rdf/graph/source/implementations/GraphStringSourceImpl.java
@@ -45,7 +45,7 @@ public class GraphStringSourceImpl implements GraphSource {
     @Override
     public Graph graph() {
         var model = ModelFactory.createDefaultModel();
-        try (StringReader reader = new StringReader(graphString)) {
+        try (StringReader reader = new StringReader(graphString.trim())) {
             model.read(reader, null, Lang.TURTLE.getName());
         }
         return model.getGraph();

--- a/backend/src/main/java/org/rdfarchitect/services/shacl/SHACLExportUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/shacl/SHACLExportUseCase.java
@@ -59,21 +59,22 @@ public interface SHACLExportUseCase {
     ByteArrayOutputStream exportGeneratedSHACLGraph(Graph graph, RDFFormat format);
 
     /**
-     * Export the SHACL graph for a given graph identifier with a specific shape URI.
+     * Export the custom SHACL namespaces for a given graph identifier.
      *
-     * @param graphIdentifier The identifier of the graph to export SHACL for.
-     * @return A ByteArrayOutputStream containing the exported SHACL graph.
+     * @param graphIdentifier The identifier of the graph to export SHACL namespaces for.
+     * @param format The format to export the SHACL namespaces in.
+     * @return A ByteArrayOutputStream containing the exported SHACL namespaces.
      */
-    ByteArrayOutputStream exportCustomSHACLPrefixes(
+    ByteArrayOutputStream exportCustomSHACLNamespaces(
             GraphIdentifier graphIdentifier, RDFFormat format);
 
     /**
-     * Export the generated SHACL prefixes for a given graph identifier.
+     * Export the generated SHACL namespaces for a given graph identifier.
      *
-     * @param graphIdentifier The identifier of the graph to export SHACL prefixes for.
-     * @param format The format to export the SHACL prefixes in.
-     * @return A ByteArrayOutputStream containing the exported SHACL prefixes.
+     * @param graphIdentifier The identifier of the graph to export SHACL namespaces for.
+     * @param format The format to export the SHACL namespaces in.
+     * @return A ByteArrayOutputStream containing the exported SHACL namespaces.
      */
-    ByteArrayOutputStream exportGeneratedSHACLPrefixes(
+    ByteArrayOutputStream exportGeneratedSHACLNamespaces(
             GraphIdentifier graphIdentifier, RDFFormat format);
 }

--- a/backend/src/main/java/org/rdfarchitect/services/shacl/SHACLGetClassRelationsUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/shacl/SHACLGetClassRelationsUseCase.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 public interface SHACLGetClassRelationsUseCase {
 
     /**
-     * Get shacl shapes with they relations to a class.
+     * Get shacl shapes with their relations to a class.
      *
      * @param graphIdentifier The graph identifier of the graph.
      * @param classUUID The uri of the class.

--- a/backend/src/main/java/org/rdfarchitect/services/shacl/SHACLStoringService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/shacl/SHACLStoringService.java
@@ -47,12 +47,15 @@ import org.rdfarchitect.shacl.dto.NodeShape;
 import org.rdfarchitect.shacl.dto.PropertyShape;
 import org.rdfarchitect.shacl.dto.PropertyShapesWrapper;
 import org.rdfarchitect.shacl.dto.SHACLToClassRelations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -61,7 +64,7 @@ import java.util.UUID;
  * the core concept of storing multiple shacl files.
  */
 @RequiredArgsConstructor
-public class SingletonPrimitiveSHACLStoringService
+public class SHACLStoringService
         implements SHACLInsertUseCase,
                 SHACLExportUseCase,
                 SHACLGetClassRelationsUseCase,
@@ -69,6 +72,8 @@ public class SingletonPrimitiveSHACLStoringService
                 SHACLReplaceShapeUseCase,
                 SHACLDeleteShapeUseCase,
                 SHACLUpdateUseCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(SHACLStoringService.class);
 
     public static final PrefixEntry SHACL_NAMESPACE =
             PrefixEntry.create(RDFA.NS_PREFIX_SHACL, RDFA.NS_URI_SHACL);
@@ -88,8 +93,9 @@ public class SingletonPrimitiveSHACLStoringService
         try (var outStream = new ByteArrayOutputStream()) {
             customSHACL.write(outStream, format.getLang().getName());
             return outStream;
-        } catch (IOException e) {
-            throw new DataAccessException("Error while writing SHACL graph to output stream", e);
+        } catch (Exception e) {
+            logger.warn("Error while writing SHACL graph to output stream", e);
+            return new ByteArrayOutputStream();
         }
     }
 
@@ -161,21 +167,25 @@ public class SingletonPrimitiveSHACLStoringService
     }
 
     @Override
-    public ByteArrayOutputStream exportCustomSHACLPrefixes(
+    public ByteArrayOutputStream exportCustomSHACLNamespaces(
             GraphIdentifier graphIdentifier, RDFFormat format) {
         var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
+        if (customSHACL == null) {
+            return new ByteArrayOutputStream();
+        }
         try (var outStream = new ByteArrayOutputStream()) {
             var prefixModel = ModelFactory.createDefaultModel();
             prefixModel.setNsPrefixes(customSHACL.getNsPrefixMap());
             prefixModel.write(outStream, format.getLang().getName());
             return outStream;
-        } catch (IOException e) {
-            throw new DataAccessException("Error while writing SHACL prefixes to output stream", e);
+        } catch (Exception e) {
+            logger.warn("Error while writing SHACL prefixes to output stream", e);
+            return new ByteArrayOutputStream();
         }
     }
 
     @Override
-    public ByteArrayOutputStream exportGeneratedSHACLPrefixes(
+    public ByteArrayOutputStream exportGeneratedSHACLNamespaces(
             GraphIdentifier graphIdentifier, RDFFormat format) {
         try (var outStream = new ByteArrayOutputStream()) {
             var prefixModel = ModelFactory.createDefaultModel();
@@ -183,8 +193,9 @@ public class SingletonPrimitiveSHACLStoringService
             prefixModel.setNsPrefix(SHACL_NAMESPACE.getPrefix(), SHACL_NAMESPACE.getUri());
             prefixModel.write(outStream, format.getLang().getName());
             return outStream;
-        } catch (IOException e) {
-            throw new DataAccessException("Error while writing SHACL prefixes to output stream", e);
+        } catch (Exception e) {
+            logger.warn("Error while writing SHACL prefixes to output stream", e);
+            return new ByteArrayOutputStream();
         }
     }
 
@@ -203,7 +214,10 @@ public class SingletonPrimitiveSHACLStoringService
                     new SHACLFromCIMGenerator(ontologyModel, SHACL_NAMESPACE, true)
                             .generateForClassOnly(classUUID);
             var shaclResult = new CustomAndGeneratedTuple<SHACLToClassRelations>();
-            shaclResult.setCustom(getSHACLToClassRelations(ontologyModel, customSHACL, classUUID));
+            if (customSHACL != null) {
+                shaclResult.setCustom(
+                        getSHACLToClassRelations(ontologyModel, customSHACL, classUUID));
+            }
             shaclResult.setGenerated(
                     getSHACLToClassRelations(ontologyModel, generatedSHACL, classUUID));
             return shaclResult;
@@ -227,7 +241,7 @@ public class SingletonPrimitiveSHACLStoringService
         var shaclShapesFetcher = new SHACLShapesFetcher(shaclModel);
         var shaclToClassAssigner = new PropertyShapeToClassAssigner(shaclModel, ontologyModel);
         return SHACLToClassRelations.builder()
-                .prefixes(prefixMappingToTtlString(prefixMapping))
+                .namespaces(prefixMappingToTtlString(prefixMapping))
                 .nodeShapes(shaclShapesFetcher.getNodeShapesOfClass(classUri))
                 .propertyShapes(shaclToClassAssigner.getPropertyShapes(classUUID))
                 .derivedPropertyShapes(
@@ -276,9 +290,13 @@ public class SingletonPrimitiveSHACLStoringService
             var generatedShacl =
                     new SHACLFromCIMGenerator(ontologyModel, SHACL_NAMESPACE, true)
                             .generateForClassOnly(UUID.fromString(classUUID));
-            var customPropertyShapes =
-                    new SHACLShapesFetcher(customSHACL)
-                            .getPropertyShapesOfProperty(ontologyModel, property.getURI());
+
+            List<PropertyShape> customPropertyShapes = Collections.emptyList();
+            if (customSHACL != null) {
+                customPropertyShapes =
+                        new SHACLShapesFetcher(customSHACL)
+                                .getPropertyShapesOfProperty(ontologyModel, property.getURI());
+            }
             var generatedPropertyShapes =
                     new SHACLShapesFetcher(generatedShacl)
                             .getPropertyShapesOfProperty(ontologyModel, property.getURI());

--- a/backend/src/main/java/org/rdfarchitect/services/shacl/SingletonPrimitiveSHACLStoringService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/shacl/SingletonPrimitiveSHACLStoringService.java
@@ -72,20 +72,21 @@ public class SingletonPrimitiveSHACLStoringService
 
     public static final PrefixEntry SHACL_NAMESPACE =
             PrefixEntry.create(RDFA.NS_PREFIX_SHACL, RDFA.NS_URI_SHACL);
-    private static Model customSHACLFile = ModelFactory.createDefaultModel();
 
     private final DatabasePort databasePort;
 
     @Override
     public void replaceCustomSHACLGraph(GraphIdentifier graphIdentifier, Graph shacl) {
-        customSHACLFile = ModelFactory.createModelForGraph(shacl);
+        var customSHACL = ModelFactory.createModelForGraph(shacl);
+        databasePort.getGraphWithContext(graphIdentifier).setCustomSHACL(customSHACL);
     }
 
     @Override
     public ByteArrayOutputStream exportCustomSHACLGraph(
             GraphIdentifier graphIdentifier, RDFFormat format) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         try (var outStream = new ByteArrayOutputStream()) {
-            customSHACLFile.write(outStream, format.getLang().getName());
+            customSHACL.write(outStream, format.getLang().getName());
             return outStream;
         } catch (IOException e) {
             throw new DataAccessException("Error while writing SHACL graph to output stream", e);
@@ -132,9 +133,11 @@ public class SingletonPrimitiveSHACLStoringService
     @Override
     public ByteArrayOutputStream exportCombinedSHACLGraph(
             GraphIdentifier graphIdentifier, RDFFormat format) {
+        var graphContext = databasePort.getGraphWithContext(graphIdentifier);
+        var customSHACL = graphContext.getCustomSHACL();
         GraphRewindable ontologyGraph = null;
         try {
-            ontologyGraph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
+            ontologyGraph = graphContext.getRdfGraph();
             ontologyGraph.begin(TxnType.READ);
             var ontologyModel = ModelFactory.createModelForGraph(ontologyGraph);
             ontologyModel.setNsPrefixes(
@@ -142,8 +145,7 @@ public class SingletonPrimitiveSHACLStoringService
             var generatedShacl =
                     new SHACLFromCIMGenerator(ontologyModel, SHACL_NAMESPACE, true).generate();
 
-            var mergedModel =
-                    new ModelResourceExclusiveMerge().merge(customSHACLFile, generatedShacl);
+            var mergedModel = new ModelResourceExclusiveMerge().merge(customSHACL, generatedShacl);
             try (var outStream = new ByteArrayOutputStream()) {
                 mergedModel.write(outStream, format.getLang().getName());
                 return outStream;
@@ -161,9 +163,10 @@ public class SingletonPrimitiveSHACLStoringService
     @Override
     public ByteArrayOutputStream exportCustomSHACLPrefixes(
             GraphIdentifier graphIdentifier, RDFFormat format) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         try (var outStream = new ByteArrayOutputStream()) {
             var prefixModel = ModelFactory.createDefaultModel();
-            prefixModel.setNsPrefixes(customSHACLFile.getNsPrefixMap());
+            prefixModel.setNsPrefixes(customSHACL.getNsPrefixMap());
             prefixModel.write(outStream, format.getLang().getName());
             return outStream;
         } catch (IOException e) {
@@ -189,6 +192,7 @@ public class SingletonPrimitiveSHACLStoringService
     public CustomAndGeneratedTuple<SHACLToClassRelations> getSHACLToClassRelations(
             GraphIdentifier graphIdentifier, UUID classUUID) {
         GraphRewindable ontologyGraph = null;
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         try {
             ontologyGraph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
             ontologyGraph.begin(TxnType.READ);
@@ -199,8 +203,7 @@ public class SingletonPrimitiveSHACLStoringService
                     new SHACLFromCIMGenerator(ontologyModel, SHACL_NAMESPACE, true)
                             .generateForClassOnly(classUUID);
             var shaclResult = new CustomAndGeneratedTuple<SHACLToClassRelations>();
-            shaclResult.setCustom(
-                    getSHACLToClassRelations(ontologyModel, customSHACLFile, classUUID));
+            shaclResult.setCustom(getSHACLToClassRelations(ontologyModel, customSHACL, classUUID));
             shaclResult.setGenerated(
                     getSHACLToClassRelations(ontologyModel, generatedSHACL, classUUID));
             return shaclResult;
@@ -254,6 +257,7 @@ public class SingletonPrimitiveSHACLStoringService
 
     private CustomAndGeneratedTuple<List<PropertyShape>> getSHACLShapesByProperty(
             GraphIdentifier graphIdentifier, UUID propertyUUID) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         GraphRewindable ontologyGraph = null;
         try {
             ontologyGraph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
@@ -273,7 +277,7 @@ public class SingletonPrimitiveSHACLStoringService
                     new SHACLFromCIMGenerator(ontologyModel, SHACL_NAMESPACE, true)
                             .generateForClassOnly(UUID.fromString(classUUID));
             var customPropertyShapes =
-                    new SHACLShapesFetcher(customSHACLFile)
+                    new SHACLShapesFetcher(customSHACL)
                             .getPropertyShapesOfProperty(ontologyModel, property.getURI());
             var generatedPropertyShapes =
                     new SHACLShapesFetcher(generatedShacl)
@@ -291,6 +295,7 @@ public class SingletonPrimitiveSHACLStoringService
     @Override
     public CustomAndGeneratedTuple<List<NodeShape>> getNodeShapesForClass(
             GraphIdentifier graphIdentifier, UUID classUUID) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         GraphRewindable ontologyGraph = null;
         try {
             ontologyGraph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
@@ -303,7 +308,7 @@ public class SingletonPrimitiveSHACLStoringService
                             .next()
                             .getURI();
             var customNodeShapes =
-                    new SHACLShapesFetcher(customSHACLFile).getNodeShapesOfClass(classUri);
+                    new SHACLShapesFetcher(customSHACL).getNodeShapesOfClass(classUri);
             var generatedShacl =
                     new SHACLFromCIMGenerator(ontologyModel, SHACL_NAMESPACE, true)
                             .generateForClassOnly(classUUID);
@@ -322,13 +327,14 @@ public class SingletonPrimitiveSHACLStoringService
     @Override
     public List<PropertyShapesWrapper> getPropertyShapes(
             GraphIdentifier graphIdentifier, UUID classUUID) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         GraphRewindable ontologyGraph = null;
         try {
             ontologyGraph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
             ontologyGraph.begin(TxnType.READ);
             var shaclToClassAssigner =
                     new PropertyShapeToClassAssigner(
-                            customSHACLFile, ModelFactory.createModelForGraph(ontologyGraph));
+                            customSHACL, ModelFactory.createModelForGraph(ontologyGraph));
             return shaclToClassAssigner.getPropertyShapes(classUUID);
         } finally {
             if (ontologyGraph != null) {
@@ -339,22 +345,24 @@ public class SingletonPrimitiveSHACLStoringService
 
     @Override
     public void deleteSHACLShape(GraphIdentifier graphIdentifier, String shaclShapeURI) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         var deleteModel = ModelFactory.createDefaultModel();
         copySHACLShapeToNewModel(
-                customSHACLFile, deleteModel, ResourceFactory.createResource(shaclShapeURI));
-        customSHACLFile.remove(deleteModel);
+                customSHACL, deleteModel, ResourceFactory.createResource(shaclShapeURI));
+        customSHACL.remove(deleteModel);
     }
 
     @Override
     public void replaceSHACLShape(
             GraphIdentifier graphIdentifier, String shaclShapeURI, String shaclToInsert) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         Model insertModel = parseTriplesToModel(shaclToInsert);
         Model deleteModel = ModelFactory.createDefaultModel();
         copySHACLShapeToNewModel(
-                customSHACLFile, deleteModel, ResourceFactory.createResource(shaclShapeURI));
+                customSHACL, deleteModel, ResourceFactory.createResource(shaclShapeURI));
 
-        customSHACLFile.remove(deleteModel);
-        customSHACLFile.add(insertModel);
+        customSHACL.remove(deleteModel);
+        customSHACL.add(insertModel);
     }
 
     private Model parseTriplesToModel(String triples) {
@@ -370,6 +378,7 @@ public class SingletonPrimitiveSHACLStoringService
     @Override
     public void updateClassSHACL(
             GraphIdentifier graphIdentifier, UUID classUUID, String ttlShaclString) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         GraphRewindable ontologyGraph = null;
         try {
             ontologyGraph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
@@ -377,12 +386,12 @@ public class SingletonPrimitiveSHACLStoringService
             var ontologyModel = ModelFactory.createModelForGraph(ontologyGraph);
 
             var insertModel = parseTriplesToModel(ttlShaclString);
-            var deleteModel = getClassShaclModel(ontologyModel, classUUID);
+            var deleteModel = getClassShaclModel(ontologyModel, customSHACL, classUUID);
 
-            customSHACLFile.remove(deleteModel);
-            customSHACLFile.clearNsPrefixMap();
-            customSHACLFile.setNsPrefixes(insertModel);
-            customSHACLFile.add(insertModel);
+            customSHACL.remove(deleteModel);
+            customSHACL.clearNsPrefixMap();
+            customSHACL.setNsPrefixes(insertModel);
+            customSHACL.add(insertModel);
         } finally {
             if (ontologyGraph != null) {
                 ontologyGraph.end();
@@ -393,39 +402,41 @@ public class SingletonPrimitiveSHACLStoringService
     @Override
     public void updatePropertyShacl(
             GraphIdentifier graphIdentifier, UUID propertyUUID, String ttlShaclString) {
+        var customSHACL = databasePort.getGraphWithContext(graphIdentifier).getCustomSHACL();
         var insertModel = parseTriplesToModel(ttlShaclString);
         var propertyShapesOfProperty = getSHACLShapesByProperty(graphIdentifier, propertyUUID);
         var deleteModel = ModelFactory.createDefaultModel();
         for (var propertyShape : propertyShapesOfProperty.getCustom()) {
             copySHACLShapeToNewModel(
-                    customSHACLFile,
+                    customSHACL,
                     deleteModel,
                     ResourceFactory.createResource(propertyShape.getId()));
         }
 
-        customSHACLFile.remove(deleteModel);
-        customSHACLFile.clearNsPrefixMap();
-        customSHACLFile.setNsPrefixes(insertModel);
-        customSHACLFile.add(insertModel);
+        customSHACL.remove(deleteModel);
+        customSHACL.clearNsPrefixMap();
+        customSHACL.setNsPrefixes(insertModel);
+        customSHACL.add(insertModel);
     }
 
     /**
      * Get all shacl shapes related to a class as a model.
      *
      * @param ontologyModel the ontology model
+     * @param customSHACL the model containing the custom SHACL shapes
      * @param classUUID the class uuid
      * @return a model containing all SHACL shapes related to the class
      */
-    private Model getClassShaclModel(Model ontologyModel, UUID classUUID) {
+    private Model getClassShaclModel(Model ontologyModel, Model customSHACL, UUID classUUID) {
         var classUri =
                 ontologyModel
                         .listSubjectsWithProperty(
                                 RDFA.uuid, ontologyModel.createLiteral(classUUID.toString()))
                         .next()
                         .getURI();
-        var nodeShapes = new SHACLShapesFetcher(customSHACLFile).getNodeShapesOfClass(classUri);
+        var nodeShapes = new SHACLShapesFetcher(customSHACL).getNodeShapesOfClass(classUri);
         var propertyShapeWrappers =
-                new PropertyShapeToClassAssigner(customSHACLFile, ontologyModel)
+                new PropertyShapeToClassAssigner(customSHACL, ontologyModel)
                         .getPropertyShapes(classUUID);
         // get all shape uris to remove
         var shapesToRemove = new ArrayList<String>();
@@ -440,7 +451,7 @@ public class SingletonPrimitiveSHACLStoringService
         Model deleteModel = ModelFactory.createDefaultModel();
         for (var shapeToRemove : shapesToRemove) {
             copySHACLShapeToNewModel(
-                    customSHACLFile, deleteModel, ResourceFactory.createResource(shapeToRemove));
+                    customSHACL, deleteModel, ResourceFactory.createResource(shapeToRemove));
         }
         return deleteModel;
     }

--- a/backend/src/main/java/org/rdfarchitect/shacl/SHACLShapesFetcher.java
+++ b/backend/src/main/java/org/rdfarchitect/shacl/SHACLShapesFetcher.java
@@ -29,6 +29,7 @@ import org.rdfarchitect.shacl.dto.PropertyShape;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SHACLShapesFetcher {
@@ -47,6 +48,9 @@ public class SHACLShapesFetcher {
      *     SHACL shapes referencing the property
      */
     public List<PropertyShape> getPropertyShapesOfProperty(Model ontology, String propertyUri) {
+        if (ontology == null) {
+            return Collections.emptyList();
+        }
         var query =
                 """
                 PREFIX  rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

--- a/backend/src/main/java/org/rdfarchitect/shacl/dto/SHACLToClassRelations.java
+++ b/backend/src/main/java/org/rdfarchitect/shacl/dto/SHACLToClassRelations.java
@@ -26,7 +26,7 @@ import java.util.List;
 @Data
 public class SHACLToClassRelations {
 
-    private String prefixes;
+    private String namespaces;
 
     private List<NodeShape> nodeShapes;
 

--- a/frontend/src/routes/shacl/SHACLFullViewDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLFullViewDialog.svelte
@@ -44,8 +44,8 @@
         }
     }
 
-    function fetchGeneratedShacl() {
-        fetch(
+    async function fetchGeneratedShacl() {
+        let res = await fetch(
             PUBLIC_BACKEND_URL +
                 "/datasets/" +
                 encodeURIComponent(editorState.selectedDataset.getValue()) +
@@ -56,21 +56,19 @@
                 method: "GET",
                 credentials: "include",
             },
-        )
-            .then(res => {
-                if (!res.ok) {
-                    return "No Constraints (SHACL) found.";
-                }
-                return res.text();
-            })
-            .then(res => (generatedShacl = res));
+        );
+        let text = await res.text();
+        if (!res.ok || text.trim() === "") {
+            text = "No Constraints (SHACL) found.";
+        }
+        generatedShacl = text;
     }
 
     /**
      * fetches the custom SHACL rules for the selected class.
      */
-    function fetchCustomShacl() {
-        fetch(
+    async function fetchCustomShacl() {
+        let res = await fetch(
             PUBLIC_BACKEND_URL +
                 "/datasets/" +
                 encodeURIComponent(editorState.selectedDataset.getValue()) +
@@ -81,17 +79,13 @@
                 method: "GET",
                 credentials: "include",
             },
-        )
-            .then(res => {
-                if (!res.ok) {
-                    return "No Constraints (SHACL) found.";
-                }
-                return res.text();
-            })
-            .then(res => {
-                customSHACL = res;
-                customSHACLBackup = res;
-            });
+        );
+        let text = await res.text();
+        if (!res.ok || text.trim() === "") {
+            text = "No Constraints (SHACL) found.";
+        }
+        customSHACL = text;
+        customSHACLBackup = text;
     }
 
     function submitChanges() {

--- a/frontend/src/routes/shacl/SHACLFullViewDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLFullViewDialog.svelte
@@ -27,7 +27,7 @@
     let customSHACL = $state();
     let customSHACLBackup = $state("");
     let readOnly = $state(false);
-    let generatedShacl = $state("");
+    let generatedShacl = $state();
     let showGeneratedShacl = $state(false);
 
     function onOpen() {
@@ -44,74 +44,101 @@
         }
     }
 
+    function onClose() {
+        customSHACL = undefined;
+        customSHACLBackup = "";
+        generatedShacl = undefined;
+    }
+
     async function fetchGeneratedShacl() {
-        let res = await fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(editorState.selectedDataset.getValue()) +
-                "/graphs/" +
-                encodeURIComponent(editorState.selectedGraph.getValue()) +
-                "/shacl/generate/string",
-            {
-                method: "GET",
-                credentials: "include",
-            },
-        );
-        let text = await res.text();
-        if (!res.ok || text.trim() === "") {
-            text = "No Constraints (SHACL) found.";
+        try {
+            let res = await fetch(
+                PUBLIC_BACKEND_URL +
+                    "/datasets/" +
+                    encodeURIComponent(editorState.selectedDataset.getValue()) +
+                    "/graphs/" +
+                    encodeURIComponent(editorState.selectedGraph.getValue()) +
+                    "/shacl/generate/string",
+                {
+                    method: "GET",
+                    credentials: "include",
+                },
+            );
+            let text = await res.text();
+            if (!res.ok || text.trim() === "") {
+                text = "No Constraints (SHACL) found.";
+            }
+            generatedShacl = text;
+        } catch (error) {
+            console.warn("Failed to fetch generated SHACL:", error);
+            generatedShacl = "Failed to load generated constraints.";
         }
-        generatedShacl = text;
     }
 
     /**
      * fetches the custom SHACL rules for the selected class.
      */
     async function fetchCustomShacl() {
-        let res = await fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(editorState.selectedDataset.getValue()) +
-                "/graphs/" +
-                encodeURIComponent(editorState.selectedGraph.getValue()) +
-                "/shacl/custom/string",
-            {
-                method: "GET",
-                credentials: "include",
-            },
-        );
-        let text = await res.text();
-        if (!res.ok || text.trim() === "") {
-            text = "No Constraints (SHACL) found.";
+        try {
+            let res = await fetch(
+                PUBLIC_BACKEND_URL +
+                    "/datasets/" +
+                    encodeURIComponent(editorState.selectedDataset.getValue()) +
+                    "/graphs/" +
+                    encodeURIComponent(editorState.selectedGraph.getValue()) +
+                    "/shacl/custom/string",
+                {
+                    method: "GET",
+                    credentials: "include",
+                },
+            );
+            let text = await res.text();
+            if (!res.ok || text.trim() === "") {
+                text = "No Constraints (SHACL) found.";
+            }
+            customSHACL = text;
+            customSHACLBackup = text;
+        } catch (error) {
+            console.warn("Failed to fetch custom SHACL:", error);
+            customSHACL = "Failed to load custom constraints.";
+            customSHACLBackup = customSHACL;
         }
-        customSHACL = text;
-        customSHACLBackup = text;
     }
 
-    function submitChanges() {
-        fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(editorState.selectedDataset.getValue()) +
-                "/graphs/" +
-                encodeURIComponent(editorState.selectedGraph.getValue()) +
-                "/shacl/custom/string",
-            {
-                method: "PUT",
-                body: customSHACL,
-                credentials: "include",
-            },
-        ).then(res => {
+    async function submitChanges() {
+        try {
+            let res = await fetch(
+                PUBLIC_BACKEND_URL +
+                    "/datasets/" +
+                    encodeURIComponent(editorState.selectedDataset.getValue()) +
+                    "/graphs/" +
+                    encodeURIComponent(editorState.selectedGraph.getValue()) +
+                    "/shacl/custom/string",
+                {
+                    method: "PUT",
+                    body: customSHACL ? customSHACL : " ",
+                    credentials: "include",
+                },
+            );
             if (res.ok) {
                 customSHACLBackup = customSHACL;
+            } else {
+                console.warn(
+                    "Failed to save custom SHACL:",
+                    res.status,
+                    res.statusText,
+                );
             }
-        });
+        } catch (error) {
+            console.warn("Failed to save custom SHACL:", error);
+        }
     }
 </script>
 
 <ActionDialog
     bind:showDialog
     {onOpen}
+    {onClose}
     size="w-2/3 h-4/5"
     title={`Constraints (SHACL) for: "${editorState.selectedDataset.getValue()}/${editorState.selectedGraph.getValue()}"`}
     primaryLabel={null}
@@ -140,14 +167,14 @@
         <!-- Scrollable content area -->
         <div class="min-h-0 flex-1 overflow-y-auto">
             {#if showGeneratedShacl}
-                {#if customSHACL !== undefined}
+                {#if generatedShacl !== undefined}
                     <TtlCodeEditor
                         bind:value={generatedShacl}
                         readOnly={true}
                     />
                 {/if}
             {:else}
-                {#if customSHACLBackup !== customSHACL}
+                {#if customSHACL !== undefined && customSHACLBackup !== customSHACL}
                     <div class="mb-2 h-8 w-fit">
                         <ButtonControl callOnClick={submitChanges}>
                             Save Changes

--- a/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
@@ -26,6 +26,11 @@
 
     let { showDialog = $bindable(), property } = $props();
 
+    let defaultShacl = () => ({
+        namespaces: "",
+        propertyShapes: [],
+    });
+
     let customShacl = $state(defaultShacl());
     let customShaclBackUp = $state("");
     let generatedShacl = $state(defaultShacl());
@@ -40,11 +45,6 @@
         editorState.selectedClassGraph.getValue() ??
             editorState.selectedGraph.getValue(),
     );
-
-    const defaultShacl = () => ({
-        namespaces: "",
-        propertyShapes: [],
-    });
 
     function onOpen() {
         if (!editorState.selectedClassUUID.getValue() || !property) {

--- a/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
@@ -26,17 +26,12 @@
 
     let { showDialog = $bindable(), property } = $props();
 
-    let customShacl = $state({
-        namespaces: "",
-        propertyShapes: [],
-    });
+    let customShacl = $state(defaultShacl());
     let customShaclBackUp = $state("");
-    let generatedShacl = $state({
-        namespaces: "",
-        propertyShapes: [],
-    });
+    let generatedShacl = $state(defaultShacl());
     let showGeneratedShacl = $state(false);
-    let showNamespaces = $state(false);
+    let showGeneratedNamespaces = $state(false);
+    let showCustomNamespaces = $state(false);
     let classDatasetName = $derived(
         editorState.selectedClassDataset.getValue() ??
             editorState.selectedDataset.getValue(),
@@ -46,6 +41,11 @@
             editorState.selectedGraph.getValue(),
     );
 
+    const defaultShacl = () => ({
+        namespaces: "",
+        propertyShapes: [],
+    });
+
     function onOpen() {
         if (!editorState.selectedClassUUID.getValue() || !property) {
             return;
@@ -54,6 +54,15 @@
             editorState.selectedClassUUID.getValue(),
             property.uuid.value,
         );
+    }
+
+    function onClose() {
+        customShacl = defaultShacl();
+        customShaclBackUp = "";
+        generatedShacl = defaultShacl();
+        showGeneratedShacl = false;
+        showGeneratedNamespaces = false;
+        showCustomNamespaces = false;
     }
 
     function getType() {
@@ -79,44 +88,77 @@
      * fetches the SHACL rules for the selected class.
      */
     async function fetchShacl(newViewedClassUUID, viewedPropertyUUID) {
-        const type = getType();
-        const res = await fetch(
-            buildBaseUrl() +
-                "/classes/" +
-                encodeURIComponent(newViewedClassUUID) +
-                "/" +
-                type +
-                "/" +
-                encodeURIComponent(viewedPropertyUUID) +
-                "/shacl",
-            {
-                method: "GET",
-                credentials: "include",
-            },
-        );
-        const data = await res.json();
-        customShacl.propertyShapes = data.custom;
-        generatedShacl.propertyShapes = data.generated;
-        console.log(data);
+        try {
+            const type = getType();
+            const res = await fetch(
+                buildBaseUrl() +
+                    "/classes/" +
+                    encodeURIComponent(newViewedClassUUID) +
+                    "/" +
+                    type +
+                    "/" +
+                    encodeURIComponent(viewedPropertyUUID) +
+                    "/shacl",
+                {
+                    method: "GET",
+                    credentials: "include",
+                },
+            );
+            if (!res.ok) {
+                console.warn(
+                    "Failed to fetch SHACL:",
+                    res.status,
+                    res.statusText,
+                );
+                return;
+            }
+            const data = await res.json();
+            customShacl.propertyShapes = data.custom;
+            generatedShacl.propertyShapes = data.generated;
 
-        await fetchFormattedNamespaces();
+            await fetchFormattedNamespaces();
+        } catch (error) {
+            console.warn("Failed to fetch SHACL:", error);
+        }
     }
 
     async function fetchFormattedNamespaces() {
-        const [generatedRes, customRes] = await Promise.all([
-            fetch(buildBaseUrl() + "/shacl/generated/namespaces/ttl", {
-                method: "GET",
-                credentials: "include",
-            }),
-            fetch(buildBaseUrl() + "/shacl/custom/namespaces/ttl", {
-                method: "GET",
-                credentials: "include",
-            }),
-        ]);
+        try {
+            const [generatedRes, customRes] = await Promise.all([
+                fetch(buildBaseUrl() + "/shacl/generated/namespaces/ttl", {
+                    method: "GET",
+                    credentials: "include",
+                }),
+                fetch(buildBaseUrl() + "/shacl/custom/namespaces/ttl", {
+                    method: "GET",
+                    credentials: "include",
+                }),
+            ]);
 
-        generatedShacl.namespaces = await generatedRes.text();
-        customShacl.namespaces = await customRes.text();
-        customShaclBackUp = buildTtlString(customShacl);
+            if (!generatedRes.ok) {
+                console.warn(
+                    "Failed to fetch generated namespaces:",
+                    generatedRes.status,
+                    generatedRes.statusText,
+                );
+            } else {
+                generatedShacl.namespaces = await generatedRes.text();
+            }
+
+            if (!customRes.ok) {
+                console.warn(
+                    "Failed to fetch custom namespaces:",
+                    customRes.status,
+                    customRes.statusText,
+                );
+            } else {
+                customShacl.namespaces = await customRes.text();
+            }
+
+            customShaclBackUp = buildTtlString(customShacl);
+        } catch (error) {
+            console.warn("Failed to fetch namespaces:", error);
+        }
     }
 
     async function saveChanges() {
@@ -140,11 +182,15 @@
                     credentials: "include",
                 },
             );
-            if (res.ok) {
-                console.log("successfully updated custom SHACL rules.");
-            } else {
-                console.log("failed to update custom SHACL rules.");
+            if (!res.ok) {
+                console.warn(
+                    "Failed to save custom SHACL:",
+                    res.status,
+                    res.statusText,
+                );
             }
+        } catch (error) {
+            console.warn("Failed to save custom SHACL:", error);
         } finally {
             await fetchShacl(
                 editorState.selectedClassUUID.getValue(),
@@ -168,6 +214,7 @@
 <ActionDialog
     bind:showDialog
     {onOpen}
+    {onClose}
     size="w-2/5 h-3/5"
     title={`Constraints (SHACL) for: "${property?.label?.value}"`}
     primaryLabel={null}
@@ -203,13 +250,14 @@
                             <button
                                 class="w-fit font-bold hover:cursor-pointer hover:underline"
                                 onclick={() => {
-                                    showNamespaces = !showNamespaces;
+                                    showGeneratedNamespaces =
+                                        !showGeneratedNamespaces;
                                 }}
                             >
                                 namespaces:
                             </button>
                         {/if}
-                        {#if showNamespaces}
+                        {#if showGeneratedNamespaces}
                             <TtlCodeEditor
                                 value={generatedShacl.namespaces}
                                 readOnly={true}
@@ -244,13 +292,14 @@
                             <button
                                 class="w-fit font-bold hover:underline"
                                 onclick={() => {
-                                    showNamespaces = !showNamespaces;
+                                    showCustomNamespaces =
+                                        !showCustomNamespaces;
                                 }}
                             >
                                 namespaces:
                             </button>
                         {/if}
-                        {#if showNamespaces}
+                        {#if showCustomNamespaces}
                             <TtlCodeEditor
                                 bind:value={customShacl.namespaces}
                                 readOnly={false}

--- a/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
@@ -65,17 +65,23 @@
         return "";
     }
 
+    function buildBaseUrl() {
+        return (
+            PUBLIC_BACKEND_URL +
+            "/datasets/" +
+            encodeURIComponent(classDatasetName) +
+            "/graphs/" +
+            encodeURIComponent(classGraphUri)
+        );
+    }
+
     /**
      * fetches the SHACL rules for the selected class.
      */
-    function fetchShacl(newViewedClassUUID, viewedPropertyUUID) {
-        let type = getType();
-        fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(classDatasetName) +
-                "/graphs/" +
-                encodeURIComponent(classGraphUri) +
+    async function fetchShacl(newViewedClassUUID, viewedPropertyUUID) {
+        const type = getType();
+        const res = await fetch(
+            buildBaseUrl() +
                 "/classes/" +
                 encodeURIComponent(newViewedClassUUID) +
                 "/" +
@@ -87,90 +93,66 @@
                 method: "GET",
                 credentials: "include",
             },
-        )
-            .then(res => res.json())
-            .then(res => {
-                customShacl.propertyShapes = res.custom;
-                generatedShacl.propertyShapes = res.generated;
-                console.log(res);
-            })
-            .then(() => {
-                fetchFormattedNamespaces();
-            });
+        );
+        const data = await res.json();
+        customShacl.propertyShapes = data.custom;
+        generatedShacl.propertyShapes = data.generated;
+        console.log(data);
+
+        await fetchFormattedNamespaces();
     }
 
-    function fetchFormattedNamespaces() {
-        fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(classDatasetName) +
-                "/graphs/" +
-                encodeURIComponent(classGraphUri) +
-                "/shacl/generated/namespaces/ttl",
-            {
+    async function fetchFormattedNamespaces() {
+        const [generatedRes, customRes] = await Promise.all([
+            fetch(buildBaseUrl() + "/shacl/generated/namespaces/ttl", {
                 method: "GET",
                 credentials: "include",
-            },
-        )
-            .then(res => res.text())
-            .then(res => {
-                generatedShacl.prefixes = res;
-            });
-        fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(classDatasetName) +
-                "/graphs/" +
-                encodeURIComponent(classGraphUri) +
-                "/shacl/custom/namespaces/ttl",
-            {
+            }),
+            fetch(buildBaseUrl() + "/shacl/custom/namespaces/ttl", {
                 method: "GET",
                 credentials: "include",
-            },
-        )
-            .then(res => res.text())
-            .then(res => {
-                customShacl.prefixes = res;
-            })
-            .then(() => (customShaclBackUp = buildTtlString(customShacl)));
+            }),
+        ]);
+
+        generatedShacl.namespaces = await generatedRes.text();
+        customShacl.namespaces = await customRes.text();
+        customShaclBackUp = buildTtlString(customShacl);
     }
 
-    function saveChanges() {
-        let ttlString = buildTtlString(customShacl);
-        let type = getType();
-        fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(classDatasetName) +
-                "/graphs/" +
-                encodeURIComponent(classGraphUri) +
-                "/classes/" +
-                encodeURIComponent(editorState.selectedClassUUID.getValue()) +
-                "/" +
-                type +
-                "/" +
-                encodeURIComponent(property.uuid.value) +
-                "/shacl",
-            {
-                method: "PUT",
-                body: ttlString,
-                credentials: "include",
-            },
-        )
-            .then(res => {
-                if (res.ok) {
-                    console.log("successfully updated custom SHACL rules.");
-                } else {
-                    console.log("failed to update custom SHACL rules.");
-                }
-            })
-            .finally(() => {
-                fetchShacl(
-                    editorState.selectedClassUUID.getValue(),
-                    property.uuid.value,
-                );
-            });
+    async function saveChanges() {
+        const ttlString = buildTtlString(customShacl);
+        const type = getType();
+        try {
+            const res = await fetch(
+                buildBaseUrl() +
+                    "/classes/" +
+                    encodeURIComponent(
+                        editorState.selectedClassUUID.getValue(),
+                    ) +
+                    "/" +
+                    type +
+                    "/" +
+                    encodeURIComponent(property.uuid.value) +
+                    "/shacl",
+                {
+                    method: "PUT",
+                    body: ttlString,
+                    credentials: "include",
+                },
+            );
+            if (res.ok) {
+                console.log("successfully updated custom SHACL rules.");
+            } else {
+                console.log("failed to update custom SHACL rules.");
+            }
+        } finally {
+            await fetchShacl(
+                editorState.selectedClassUUID.getValue(),
+                property.uuid.value,
+            );
+        }
     }
+
     function buildTtlString(shacl) {
         let ttlString = "";
         if (shacl.namespaces) {

--- a/frontend/src/routes/shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte
+++ b/frontend/src/routes/shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte
@@ -31,45 +31,62 @@
         showDialog = $bindable(),
     } = $props();
 
-    let customShacl = $state({
-        namespaces: "",
-        nodeShapes: [],
-        propertyShapes: [],
-        derivedPropertyShapes: [],
-    });
-    let generatedShacl = $state({
-        namespaces: "",
-        nodeShapes: [],
-        propertyShapes: [],
-        derivedPropertyShapes: [],
-    });
+    let customShacl = $state(defaultShacl());
+    let generatedShacl = $state(defaultShacl());
     let showGeneratedShacl = $state(false);
+    let fetchKey = $state(0);
+
+    const defaultShacl = () => ({
+        namespaces: "",
+        nodeShapes: [],
+        propertyShapes: [],
+        derivedPropertyShapes: [],
+    });
 
     function onOpen() {
         fetchShacl();
+    }
+
+    function onClose() {
+        customShacl = defaultShacl();
+        generatedShacl = defaultShacl();
+        fetchKey = 0;
     }
 
     /**
      * fetches the SHACL rules for the selected class.
      */
     async function fetchShacl() {
-        const res = await fetch(
-            PUBLIC_BACKEND_URL +
-                "/datasets/" +
-                encodeURIComponent(datasetName) +
-                "/graphs/" +
-                encodeURIComponent(graphUri) +
-                "/classes/" +
-                encodeURIComponent(reactiveClass.uuid.value) +
-                "/shacl",
-            {
-                method: "GET",
-                credentials: "include",
-            },
-        );
-        const resultObj = JSON.parse(await res.text());
-        customShacl = resultObj.custom;
-        generatedShacl = resultObj.generated;
+        try {
+            const res = await fetch(
+                PUBLIC_BACKEND_URL +
+                    "/datasets/" +
+                    encodeURIComponent(datasetName) +
+                    "/graphs/" +
+                    encodeURIComponent(graphUri) +
+                    "/classes/" +
+                    encodeURIComponent(reactiveClass.uuid.value) +
+                    "/shacl",
+                {
+                    method: "GET",
+                    credentials: "include",
+                },
+            );
+            if (!res.ok) {
+                console.warn(
+                    "Failed to fetch SHACL:",
+                    res.status,
+                    res.statusText,
+                );
+                return;
+            }
+            const resultObj = JSON.parse(await res.text());
+            customShacl = resultObj.custom;
+            generatedShacl = resultObj.generated;
+            fetchKey++;
+        } catch (error) {
+            console.warn("Failed to fetch SHACL:", error);
+        }
     }
 
     function goToClass(classUUID) {
@@ -83,6 +100,7 @@
 <ActionDialog
     bind:showDialog
     {onOpen}
+    {onClose}
     size="w-3/5 h-4/5"
     title={`Constraints (SHACL) for: "${reactiveClass.label.value}"`}
     primaryLabel={null}
@@ -114,7 +132,7 @@
 
                 <!-- scrollable content area -->
                 <div class="min-h-0 w-full flex-1 overflow-y-auto">
-                    {#key generatedShacl || customShacl}
+                    {#key fetchKey}
                         {#if showGeneratedShacl}
                             <SHACLShapeTtlRenderer
                                 namespaces={generatedShacl.namespaces}

--- a/frontend/src/routes/shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte
+++ b/frontend/src/routes/shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte
@@ -52,8 +52,8 @@
     /**
      * fetches the SHACL rules for the selected class.
      */
-    function fetchShacl() {
-        fetch(
+    async function fetchShacl() {
+        const res = await fetch(
             PUBLIC_BACKEND_URL +
                 "/datasets/" +
                 encodeURIComponent(datasetName) +
@@ -66,13 +66,10 @@
                 method: "GET",
                 credentials: "include",
             },
-        )
-            .then(res => res.text())
-            .then(res => {
-                let resultObj = JSON.parse(res);
-                customShacl = resultObj.custom;
-                generatedShacl = resultObj.generated;
-            });
+        );
+        const resultObj = JSON.parse(await res.text());
+        customShacl = resultObj.custom;
+        generatedShacl = resultObj.generated;
     }
 
     function goToClass(classUUID) {

--- a/frontend/src/routes/shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte
+++ b/frontend/src/routes/shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte
@@ -31,17 +31,17 @@
         showDialog = $bindable(),
     } = $props();
 
-    let customShacl = $state(defaultShacl());
-    let generatedShacl = $state(defaultShacl());
-    let showGeneratedShacl = $state(false);
-    let fetchKey = $state(0);
-
-    const defaultShacl = () => ({
+    let defaultShacl = () => ({
         namespaces: "",
         nodeShapes: [],
         propertyShapes: [],
         derivedPropertyShapes: [],
     });
+
+    let customShacl = $state(defaultShacl());
+    let generatedShacl = $state(defaultShacl());
+    let showGeneratedShacl = $state(false);
+    let fetchKey = $state(0);
 
     function onOpen() {
         fetchShacl();


### PR DESCRIPTION
## Description

Custom/imported shacl files are now graph specific.
Also fixed a few bugs, where the shacl dialogs caused the website to freeze and a bug where namespaces didn't load for shacl

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
