### PR TITLE
feat(test): use ENTSO-E application-profiles-library as submodule (RDFA-437)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
+          submodules: true
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/entsoe-application-profiles-library"]
+	path = external/entsoe-application-profiles-library
+	url = https://github.com/entsoe/application-profiles-library.git

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ For the complete documentation, see the [docs site](https://rdfarchitect.soptim.
   - `/` routes to frontend
   - `/api` routes to backend
 
+## External Data
+
+This repository includes the [ENTSO-E application-profiles-library](https://github.com/entsoe/application-profiles-library) as a git submodule under `external/entsoe-application-profiles-library`. It provides the official RDFS / SHACL artifacts for CGMES and NC profiles, and is used by backend tests as realistic input data. The library is published by ENTSO-E under the Apache License 2.0 (see `external/entsoe-application-profiles-library/LICENSE.txt` and `NOTICE.txt`).
+
+When cloning this repository, initialize the submodule with:
+
+```bash
+git submodule update --init --recursive
+```
+
 ## Prerequisites
 
 - Java 25 or higher

--- a/backend/src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/GraphToCIMCollectionConverterImplNoFilterTest.java
+++ b/backend/src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/GraphToCIMCollectionConverterImplNoFilterTest.java
@@ -60,9 +60,13 @@ class GraphToCIMCollectionConverterImplNoFilterTest {
     private static final String PATH =
             "src/test/java/org/rdfarchitect/cim/data/GraphToCIMCollectionConverterImpl/";
 
+    private static final String ENTSOE_RDFS_PATH =
+            "../external/entsoe-application-profiles-library/CGMES/CurrentRelease/RDFS/";
+
     private final Map<String, String> prefixMapping =
             Map.of(
                     "cim", "http://iec.ch/TC57/2013/CIM-schema-cim16#",
+                    "cim100", "http://iec.ch/TC57/CIM100#",
                     "cims", "http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#",
                     "example", "http://example.com#",
                     "rdfs", "http://www.w3.org/2000/01/rdf-schema#",
@@ -87,7 +91,8 @@ class GraphToCIMCollectionConverterImplNoFilterTest {
         try {
             var graph = GraphFactory.createDefaultGraph();
             InputStream in = Files.newInputStream(Path.of(fileName));
-            RDFDataMgr.read(graph, in, Lang.TTL);
+            Lang lang = fileName.endsWith(".rdf") ? Lang.RDFXML : Lang.TTL;
+            RDFDataMgr.read(graph, in, lang);
             graphRewindable = database.begin(graphIdentifier, TxnType.WRITE);
             for (var triple : graph.find().toList()) {
                 graphRewindable.add(triple);
@@ -103,9 +108,8 @@ class GraphToCIMCollectionConverterImplNoFilterTest {
     @Test
     void convert_onlyPackage_collectionWithOnlyOnePackage() throws IOException {
         // Arrange
-        addFileGraphToDatabase(PATH + "package.ttl");
+        addFileGraphToDatabase(ENTSOE_RDFS_PATH + "61970-600-2_Header-AP-Voc-RDFS2020.rdf");
         var filter = new GraphFilter(true);
-        filter.setPackageUUID("123e4567-e89b-12d3-a456-426614174000");
 
         // Act
         var cimCollection = converter.convert(graphIdentifier, filter);
@@ -117,9 +121,11 @@ class GraphToCIMCollectionConverterImplNoFilterTest {
         assertThat(cimCollection.getEnumEntries()).isEmpty();
         assertThat(cimCollection.getClasses()).isEmpty();
 
-        assertThat(cimCollection.getPackages()).hasSize(1);
-        assertThat(cimCollection.getPackages().iterator().next().getUri())
-                .isEqualTo(new URI(prefixMapping.get("cim") + "Package_Infrastruktur"));
+        assertThat(cimCollection.getPackages())
+                .extracting(p -> p.getUri().toString())
+                .containsExactlyInAnyOrder(
+                        prefixMapping.get("cim100") + "Package_FileHeaderProfile",
+                        prefixMapping.get("cim100") + "Package_DomainProfile");
     }
 
     @Test


### PR DESCRIPTION
## Summary
Add [entsoe/application-profiles-library](https://github.com/entsoe/application-profiles-library) (Apache 2.0) as a git submodule at `external/entsoe-application-profiles-library` so backend tests can run against the official CGMES / NC RDFS artifacts instead of hand-crafted fixtures.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
