### PR TITLE
feat(changelog): add workflow to automate changelog updates (RDFA-419)

### DIFF
--- a/.github/scripts/update_changelog.py
+++ b/.github/scripts/update_changelog.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Update CHANGELOG.md by promoting [Unreleased] to a new release section.
+
+Parses git history since the previous version tag, categorizes commits via
+conventional-commit prefixes, and writes entries in the project's existing
+format (RDFA-XXX prefix when present, with linked short SHA and PR number).
+
+Usage:
+    update_changelog.py --version 1.1.0 [--date 2026-05-07] [--repo SOPTIM/RDFArchitect]
+                        [--from-ref vX.Y.Z] [--to-ref HEAD] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# Conventional commit type → changelog section.
+TYPE_TO_SECTION = {
+    "feat": "Added",
+    "fix": "Fixed",
+    "perf": "Changed",
+    "refactor": "Changed",
+    "revert": "Changed",
+    "style": "Changed",
+    "build": "Changed",
+    "ci": "Changed",
+    "chore": "Changed",
+    "docs": "Changed",
+    "test": "Changed",
+}
+SECTION_ORDER = ["Breaking Changes", "Added", "Changed", "Fixed"]
+
+# Skip dependency bumps and similar noise from the changelog by default.
+SKIP_SCOPES = {"deps", "deps-dev"}
+
+COMMIT_RE = re.compile(
+    r"^(?P<type>[a-zA-Z]+)(?:\((?P<scope>[^)]+)\))?(?P<bang>!)?:\s*(?P<subject>.+)$"
+)
+META_RE = re.compile(r"\(([^()]*#\d+[^()]*)\)\s*$")
+PR_RE = re.compile(r"#(\d+)")
+JIRA_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+
+
+def run(*args: str) -> str:
+    return subprocess.check_output(args, cwd=REPO_ROOT, text=True).strip()
+
+
+def previous_tag() -> str | None:
+    try:
+        return run("git", "describe", "--tags", "--abbrev=0",
+                   "--match", "v[0-9]*.[0-9]*.[0-9]*")
+    except subprocess.CalledProcessError:
+        return None
+
+
+def detect_repo_slug() -> str:
+    url = run("git", "config", "--get", "remote.origin.url")
+    m = re.search(r"github\.com[:/]([^/]+/[^/.]+)", url)
+    if not m:
+        raise SystemExit(f"Cannot derive repo slug from remote URL: {url}")
+    return m.group(1)
+
+
+def collect_commits(from_ref: str | None, to_ref: str) -> list[tuple[str, str]]:
+    rev_range = f"{from_ref}..{to_ref}" if from_ref else to_ref
+    out = run("git", "log", rev_range, "--no-merges",
+              "--pretty=format:%H%x09%s")
+    commits = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        sha, _, subject = line.partition("\t")
+        commits.append((sha, subject))
+    return commits
+
+
+def classify(subject: str) -> tuple[str, str, str | None] | None:
+    m = COMMIT_RE.match(subject)
+    if not m:
+        return None
+    ctype = m.group("type").lower()
+    scope = (m.group("scope") or "").lower()
+    bang = m.group("bang")
+    body = m.group("subject").strip()
+
+    if scope in SKIP_SCOPES:
+        return None
+
+    section = "Breaking Changes" if bang else TYPE_TO_SECTION.get(ctype)
+    if section is None:
+        return None
+    return section, body, scope or None
+
+
+def format_entry(sha: str, subject_body: str, repo: str) -> str:
+    meta_match = META_RE.search(subject_body)
+    refs_text = ""
+    pr_number: str | None = None
+    jira: str | None = None
+    description = subject_body
+
+    if meta_match:
+        refs_text = meta_match.group(1)
+        description = subject_body[: meta_match.start()].rstrip()
+        pr_m = PR_RE.search(refs_text)
+        if pr_m:
+            pr_number = pr_m.group(1)
+        jira_m = JIRA_RE.search(refs_text)
+        if jira_m:
+            jira = jira_m.group(1)
+
+    # Also scan the description itself for a JIRA id (e.g. "RDFA-123: foo").
+    if not jira:
+        jira_m = JIRA_RE.search(description)
+        if jira_m:
+            jira = jira_m.group(1)
+            description = JIRA_RE.sub("", description, count=1)
+            description = re.sub(r"^\s*[:\-]\s*", "", description).strip()
+
+    description = description[:1].upper() + description[1:] if description else description
+
+    short_sha = sha[:8]
+    parts = [f"[{short_sha}](https://github.com/{repo}/commit/{short_sha})"]
+    if pr_number:
+        parts.append(f"[#{pr_number}](https://github.com/{repo}/pull/{pr_number})")
+    refs = ", ".join(parts)
+
+    prefix = f"{jira}: " if jira else ""
+    return f"- {prefix}{description} ({refs})"
+
+
+def build_section(version: str, date: str, sections: "OrderedDict[str, list[str]]") -> str:
+    lines = [f"## [{version}] - {date}", ""]
+    for name in SECTION_ORDER:
+        entries = sections.get(name)
+        if not entries:
+            continue
+        lines.append(f"### {name}")
+        lines.append("")
+        lines.extend(entries)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def update_file(new_block: str, version: str) -> None:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    if f"## [{version}]" in text:
+        raise SystemExit(f"CHANGELOG.md already contains section for {version}")
+    if "## [Unreleased]" not in text:
+        raise SystemExit("CHANGELOG.md is missing the [Unreleased] section")
+    replacement = "## [Unreleased]\n\n" + new_block
+    new_text = text.replace("## [Unreleased]", replacement, 1)
+    # Collapse any accidental triple newline at the boundary.
+    new_text = re.sub(r"\n{3,}", "\n\n", new_text)
+    if not new_text.endswith("\n"):
+        new_text += "\n"
+    CHANGELOG.write_text(new_text, encoding="utf-8")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--version", required=True, help="New version, e.g. 1.1.0")
+    p.add_argument("--date", default=dt.date.today().isoformat())
+    p.add_argument("--repo", default=None, help="owner/name; auto-detected from origin")
+    p.add_argument("--from-ref", default=None, help="Defaults to last v* tag")
+    p.add_argument("--to-ref", default="HEAD")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    if not re.fullmatch(r"\d+\.\d+\.\d+", args.version):
+        raise SystemExit(f"--version must be semver X.Y.Z, got {args.version!r}")
+
+    repo = args.repo or detect_repo_slug()
+    from_ref = args.from_ref or previous_tag()
+
+    sections: "OrderedDict[str, list[str]]" = OrderedDict()
+    for sha, subject in collect_commits(from_ref, args.to_ref):
+        classified = classify(subject)
+        if classified is None:
+            continue
+        section, body, _scope = classified
+        sections.setdefault(section, []).append(format_entry(sha, body, repo))
+
+    if not any(sections.values()):
+        raise SystemExit("No changelog-worthy commits found in range")
+
+    block = build_section(args.version, args.date, sections)
+
+    if args.dry_run:
+        sys.stdout.write(block)
+        return 0
+
+    update_file(block, args.version)
+    sys.stdout.write(block)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,79 @@
+name: Update Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (semver, no leading v), e.g. 1.1.0"
+        required: true
+        type: string
+      date:
+        description: "Release date (YYYY-MM-DD). Defaults to today."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Validate version
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be semver X.Y.Z"
+            exit 1
+          fi
+
+      - name: Update CHANGELOG.md
+        id: changelog
+        run: |
+          set -euo pipefail
+          DATE_ARG=()
+          if [[ -n "${{ inputs.date }}" ]]; then
+            DATE_ARG=(--date "${{ inputs.date }}")
+          fi
+          {
+            echo 'notes<<__RELEASE_NOTES__'
+            python3 .github/scripts/update_changelog.py \
+              --version "${{ inputs.version }}" \
+              "${DATE_ARG[@]}"
+            echo '__RELEASE_NOTES__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          NOTES: ${{ steps.changelog.outputs.notes }}
+          BASE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/changelog-v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "chore(changelog): prepare v${VERSION}"
+          git push --force-with-lease origin "$BRANCH"
+
+          if existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number'); [[ -n "$existing" ]]; then
+            gh pr edit "$existing" --title "chore(changelog): prepare v${VERSION}" --body "$NOTES"
+            echo "Updated existing PR #$existing"
+          else
+            gh pr create \
+              --base "$BASE_REF" \
+              --head "$BRANCH" \
+              --title "chore(changelog): prepare v${VERSION}" \
+              --body "$NOTES"
+          fi


### PR DESCRIPTION
Added script and workflow to auto update changelog.

<details>
<summary>How the changelog looks like after running the script</summary>
## [Unreleased]

## [1.1.0] - 2026-05-07

### Added

- Add workflow to automate changelog updates ([30ec4fbc](https://github.com/SOPTIM/RDFArchitect/commit/30ec4fbc))
- RDFA-504: Added config to set default stereotypes and namspaces ([78305671](https://github.com/SOPTIM/RDFArchitect/commit/78305671), [#106](https://github.com/SOPTIM/RDFArchitect/pull/106))
- RDFA-321: Support RDF blank nodes in attribute editor for fixed and default values ([839bd5e1](https://github.com/SOPTIM/RDFArchitect/commit/839bd5e1), [#22](https://github.com/SOPTIM/RDFArchitect/pull/22))
- RDFA-136: Show references on delete and allow selective deleting ([ef1d6ada](https://github.com/SOPTIM/RDFArchitect/commit/ef1d6ada), [#82](https://github.com/SOPTIM/RDFArchitect/pull/82))
- RDFA-434: Z-index for svelteflow Diagram ([b4bf26d4](https://github.com/SOPTIM/RDFArchitect/commit/b4bf26d4), [#83](https://github.com/SOPTIM/RDFArchitect/pull/83))

### Changed

- RDFA-410: Add Developer Certificate of Origin ([8ddfd6f2](https://github.com/SOPTIM/RDFArchitect/commit/8ddfd6f2), [#108](https://github.com/SOPTIM/RDFArchitect/pull/108))
- RDFA-501: Enhance documentation ([ef7203ff](https://github.com/SOPTIM/RDFArchitect/commit/ef7203ff), [#101](https://github.com/SOPTIM/RDFArchitect/pull/101))
- RDFA-439: Remove uuids from frontend ([770d11a6](https://github.com/SOPTIM/RDFArchitect/commit/770d11a6), [#84](https://github.com/SOPTIM/RDFArchitect/pull/84))
- Add bachelors thesis to repo ([6dd16b23](https://github.com/SOPTIM/RDFArchitect/commit/6dd16b23), [#94](https://github.com/SOPTIM/RDFArchitect/pull/94))
- Fix deploy workflow ([e15569aa](https://github.com/SOPTIM/RDFArchitect/commit/e15569aa), [#96](https://github.com/SOPTIM/RDFArchitect/pull/96))
- RDFA-497: Add documentation website ([c23ee085](https://github.com/SOPTIM/RDFArchitect/commit/c23ee085), [#95](https://github.com/SOPTIM/RDFArchitect/pull/95))
- Add GitHub PR validation workflows ([0d900d61](https://github.com/SOPTIM/RDFArchitect/commit/0d900d61), [#86](https://github.com/SOPTIM/RDFArchitect/pull/86))

### Fixed

- Update empty state text for schema import prompt ([873bda7e](https://github.com/SOPTIM/RDFArchitect/commit/873bda7e), [#110](https://github.com/SOPTIM/RDFArchitect/pull/110))
- RDFA-450: Render associations on the same class ([2e5b1719](https://github.com/SOPTIM/RDFArchitect/commit/2e5b1719), [#104](https://github.com/SOPTIM/RDFArchitect/pull/104))
- RDFA-502: Add custom shacl to graph context ([54c29adb](https://github.com/SOPTIM/RDFArchitect/commit/54c29adb), [#105](https://github.com/SOPTIM/RDFArchitect/pull/105))
- RDFA-481: Support packages without Package_ prefix ([e3740973](https://github.com/SOPTIM/RDFArchitect/commit/e3740973), [#78](https://github.com/SOPTIM/RDFArchitect/pull/78))
- RDFA-449: Association IRI violation checks ([353d8e42](https://github.com/SOPTIM/RDFArchitect/commit/353d8e42), [#75](https://github.com/SOPTIM/RDFArchitect/pull/75))
- Diagram reload UX and removed deprecated file database backend ([87852733](https://github.com/SOPTIM/RDFArchitect/commit/87852733), [#102](https://github.com/SOPTIM/RDFArchitect/pull/102))
- RDFA-96: Classes are now opened in the class editor on creation ([ad5e4450](https://github.com/SOPTIM/RDFArchitect/commit/ad5e4450), [#92](https://github.com/SOPTIM/RDFArchitect/pull/92))

## [1.0.0] - 2026-04-24

### Added

- RDFA-459: Added Maven-based backend linting ([10107dc2](https://github.com/SOPTIM/RDFArchitect/commit/10107dc2), [#67](https://github.com/SOPTIM/RDFArchitect/pull/67))

### Fixed

- Handle whitespace normalization for RDF comments in compare ([d4c5192e](https://github.com/SOPTIM/RDFArchitect/commit/d4c5192e), [#40](https://github.com/SOPTIM/RDFArchitect/pull/40))
</details>