### PR TITLE
fix(diagram): class context menu actions (RDFA-529)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/AllClassesRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/AllClassesRESTController.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 import org.rdfarchitect.api.dto.ClassUMLAdaptedDTO;
+import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.services.ExpandURIUseCase;
@@ -65,9 +66,13 @@ public class AllClassesRESTController {
      *     added
      * @param classURIPrefix URI Prefix of the new class
      * @param className Label of the new class
+     * @param classLayoutPosition Initial position of the new class in the diagram
      */
     public record AddNewClassRequest(
-            PackageDTO packageDTO, String classURIPrefix, String className) {}
+            PackageDTO packageDTO,
+            String classURIPrefix,
+            String className,
+            ClassLayoutPositionDTO classLayoutPosition) {}
 
     @Operation(
             summary = "create new class",
@@ -112,7 +117,8 @@ public class AllClassesRESTController {
                         graphIdentifier,
                         addNewClassRequest.packageDTO,
                         extendedClassURIPrefix,
-                        addNewClassRequest.className);
+                        addNewClassRequest.className,
+                        addNewClassRequest.classLayoutPosition);
 
         logger.info(
                 "Sending response to POST request: \"/api/datasets/{{}}/graphs/{{}}/classes\" to \"{}\".",

--- a/backend/src/main/java/org/rdfarchitect/api/dto/dl/ClassLayoutPositionDTO.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/dl/ClassLayoutPositionDTO.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.dto.dl;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ClassLayoutPositionDTO {
+
+    private float xPosition;
+
+    private float yPosition;
+}

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/DiagramLayoutServiceUtils.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/DiagramLayoutServiceUtils.java
@@ -84,6 +84,19 @@ public class DiagramLayoutServiceUtils {
      * @param diagramObjectMRID the mRID of the diagram object the point belongs to
      */
     public void insertDiagramObjectPoint(Model diagramLayoutModel, MRID diagramObjectMRID) {
+        insertDiagramObjectPoint(diagramLayoutModel, diagramObjectMRID, 0, 0);
+    }
+
+    /**
+     * Helper method for creating and inserting a {@link DiagramObjectPoint} at a given position.
+     *
+     * @param diagramLayoutModel the model into which the diagram object point is inserted
+     * @param diagramObjectMRID the mRID of the diagram object the point belongs to
+     * @param xPosition the x position of the diagram object point
+     * @param yPosition the y position of the diagram object point
+     */
+    public void insertDiagramObjectPoint(
+            Model diagramLayoutModel, MRID diagramObjectMRID, float xPosition, float yPosition) {
         var maxZPosition =
                 diagramLayoutModel.listObjectsOfProperty(DL.zPosition).toSet().stream()
                         .max(
@@ -97,7 +110,7 @@ public class DiagramLayoutServiceUtils {
         var diagramObjectPoint =
                 DiagramObjectPoint.builder()
                         .mRID(new MRID(UUID.randomUUID()))
-                        .position(new XYZPosition(0, 0, maxZPosition + 1))
+                        .position(new XYZPosition(xPosition, yPosition, maxZPosition + 1))
                         .belongsToDiagramObject(diagramObjectMRID)
                         .build();
         DLUpdates.insertDiagramObjectPoint(diagramLayoutModel, diagramObjectPoint);

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/CreateClassLayoutDataUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/CreateClassLayoutDataUseCase.java
@@ -17,6 +17,7 @@
 
 package org.rdfarchitect.services.dl.update.classlayout;
 
+import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.database.GraphIdentifier;
 
@@ -25,16 +26,20 @@ import java.util.UUID;
 public interface CreateClassLayoutDataUseCase {
 
     /**
-     * Creates the diagram layout data for a newly created class
+     * Creates the diagram layout data for a newly created class, optionally at a given initial
+     * position.
      *
      * @param graphIdentifier the identifier of the graph
      * @param packageDTO the DTO used for creating the new class
      * @param className the name of the newly created class
      * @param classUUID the UUID of the newly created class
+     * @param classLayoutPosition the initial diagram position of the newly created class, or {@code
+     *     null} to place the class at the origin
      */
     void createClassLayoutData(
             GraphIdentifier graphIdentifier,
             PackageDTO packageDTO,
             String className,
-            UUID classUUID);
+            UUID classUUID,
+            ClassLayoutPositionDTO classLayoutPosition);
 }

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/UpdateClassLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/UpdateClassLayoutService.java
@@ -19,6 +19,7 @@ package org.rdfarchitect.services.dl.update.classlayout;
 
 import lombok.RequiredArgsConstructor;
 
+import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.dl.ClassPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.api.dto.packages.PackageMapper;
@@ -50,7 +51,8 @@ public class UpdateClassLayoutService
             GraphIdentifier graphIdentifier,
             PackageDTO packageDTO,
             String className,
-            UUID classUUID) {
+            UUID classUUID,
+            ClassLayoutPositionDTO classLayoutPosition) {
         var diagramLayout = databasePort.getGraphWithContext(graphIdentifier).getDiagramLayout();
         var diagramLayoutModel = diagramLayout.getDiagramLayoutModel();
         UUID packageUUID;
@@ -65,7 +67,10 @@ public class UpdateClassLayoutService
         MRID doMRID =
                 DiagramLayoutServiceUtils.insertDiagramObject(
                         diagramLayoutModel, packageUUID, className, classUUID);
-        DiagramLayoutServiceUtils.insertDiagramObjectPoint(diagramLayoutModel, doMRID);
+        float xPosition = classLayoutPosition != null ? classLayoutPosition.getXPosition() : 0;
+        float yPosition = classLayoutPosition != null ? classLayoutPosition.getYPosition() : 0;
+        DiagramLayoutServiceUtils.insertDiagramObjectPoint(
+                diagramLayoutModel, doMRID, xPosition, yPosition);
     }
 
     @Override

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/AddClassUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/AddClassUseCase.java
@@ -17,6 +17,7 @@
 
 package org.rdfarchitect.services.update.classes;
 
+import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.database.GraphIdentifier;
 
@@ -25,19 +26,21 @@ import java.util.UUID;
 public interface AddClassUseCase {
 
     /**
-     * Constructs a new class and adds it to the specified graph. All optional parameters are set to
-     * null. The label of the class is set to NewClass with an index number appended if a NewClass
-     * already exists in the graph.
+     * Constructs a new class and adds it to the specified graph, optionally at a given initial
+     * diagram layout position.
      *
      * @param graphIdentifier The graph URI and database name of the graph to add the class to.
      * @param packageDTO The Package to which the class will be added.
      * @param classURIPrefix The prefix of the class to be added.
      * @param className The name of the class to be added.
+     * @param classLayoutPosition The initial diagram position of the class, or {@code null} to
+     *     place the class at the origin.
      * @return The UUID of the newly created class.
      */
     UUID addClass(
             GraphIdentifier graphIdentifier,
             PackageDTO packageDTO,
             String classURIPrefix,
-            String className);
+            String className,
+            ClassLayoutPositionDTO classLayoutPosition);
 }

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
@@ -21,6 +21,7 @@ import org.apache.jena.query.TxnType;
 import org.apache.jena.vocabulary.RDF;
 import org.rdfarchitect.api.dto.ClassUMLAdaptedDTO;
 import org.rdfarchitect.api.dto.ClassUMLAdaptedMapper;
+import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.api.dto.packages.PackageMapper;
 import org.rdfarchitect.database.DatabasePort;
@@ -110,7 +111,8 @@ public class UpdateClassService
             GraphIdentifier graphIdentifier,
             PackageDTO packageDTO,
             String classURIPrefix,
-            String className) {
+            String className,
+            ClassLayoutPositionDTO classLayoutPosition) {
         var cimPackage = packageMapper.toCIMObject(packageDTO);
         GraphRewindableWithUUIDs graph = null;
         UUID newClassUUID;
@@ -133,7 +135,7 @@ public class UpdateClassService
         }
 
         createClassLayoutDataUseCase.createClassLayoutData(
-                graphIdentifier, packageDTO, className, newClassUUID);
+                graphIdentifier, packageDTO, className, newClassUUID, classLayoutPosition);
 
         changeLogUseCase.recordChange(
                 graphIdentifier,

--- a/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateClassLayoutServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateClassLayoutServiceTest.java
@@ -20,6 +20,7 @@ package org.rdfarchitect.services.dl.update;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.dl.ClassPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.dl.data.DLUtils;
@@ -51,10 +52,34 @@ class UpdateClassLayoutServiceTest extends DiagramLayoutServicesTestBase {
                         .label(PACKAGE_A_LABEL)
                         .prefix("ex")
                         .build();
-        service.createClassLayoutData(graphIdentifier, packageDTO, CLASS_A_LABEL, CLASS_A_UUID);
+        service.createClassLayoutData(
+                graphIdentifier, packageDTO, CLASS_A_LABEL, CLASS_A_UUID, null);
 
         // Assert
         assertInitialClassLayoutData(CLASS_A_UUID, PACKAGE_A_UUID, CLASS_A_LABEL);
+    }
+
+    @Test
+    void createClassLayoutData_withInitialPosition_createsClassLayoutDataAtPosition() {
+        // Arrange
+        addGraphFromFile("package.ttl");
+        var packageDTO =
+                PackageDTO.builder()
+                        .uuid(PACKAGE_A_UUID)
+                        .label(PACKAGE_A_LABEL)
+                        .prefix("ex")
+                        .build();
+        var classLayoutPosition = new ClassLayoutPositionDTO();
+        classLayoutPosition.setXPosition(123.0F);
+        classLayoutPosition.setYPosition(456.0F);
+
+        // Act
+        service.createClassLayoutData(
+                graphIdentifier, packageDTO, CLASS_A_LABEL, CLASS_A_UUID, classLayoutPosition);
+
+        // Assert
+        assertDiagramObject(CLASS_A_UUID, PACKAGE_A_UUID, CLASS_A_LABEL);
+        assertDiagramObjectCoordinates(CLASS_A_UUID, 123.0F, 456.0F);
     }
 
     @Test

--- a/backend/src/test/java/org/rdfarchitect/services/update/UpdateClassServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/UpdateClassServiceTest.java
@@ -103,7 +103,7 @@ class UpdateClassServiceTest {
                         .label("default")
                         .build();
 
-        updateClassService.addClass(graphIdentifier, packageDTO, PREFIX, "newClass");
+        updateClassService.addClass(graphIdentifier, packageDTO, PREFIX, "newClass", null);
 
         var graph = databasePort.getGraphWithContext(graphIdentifier).getRdfGraph();
         try {
@@ -150,7 +150,11 @@ class UpdateClassServiceTest {
         assertThatThrownBy(
                         () ->
                                 updateClassService.addClass(
-                                        graphIdentifier, packageDTO, PREFIX, "packageCollision"))
+                                        graphIdentifier,
+                                        packageDTO,
+                                        PREFIX,
+                                        "packageCollision",
+                                        null))
                 .isInstanceOf(ResourceConflictException.class)
                 .hasMessageContaining("package with the same IRI");
 

--- a/frontend/src/lib/rendering/svelteflow/components/SvelteFlowPaneContextMenu.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/SvelteFlowPaneContextMenu.svelte
@@ -39,6 +39,7 @@
     let triggerRef = $state(null);
     let open = $state(false);
     let showNewClassDialog = $state(false);
+    let classLayoutPosition = $state(null);
 
     let triggerStyle = $derived(getContextMenuTriggerStyle(request));
 
@@ -56,6 +57,12 @@
     }
 
     function openNewClassDialog() {
+        classLayoutPosition = request?.flowPosition
+            ? {
+                  xPosition: request.flowPosition.x,
+                  yPosition: request.flowPosition.y,
+              }
+            : null;
         showNewClassDialog = true;
         onClose();
     }
@@ -83,5 +90,6 @@
     bind:showDialog={showNewClassDialog}
     {lockedDatasetName}
     {lockedGraphUri}
+    {classLayoutPosition}
     {onClassCreated}
 />

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -42,7 +42,6 @@
     import InheritanceEdge from "./components/InheritanceEdge.svelte";
     import SvelteFlowClassContextMenu from "./components/SvelteFlowClassContextMenu.svelte";
     import SvelteFlowPaneContextMenu from "./components/SvelteFlowPaneContextMenu.svelte";
-    import NewClassDialog from "../../../routes/NewClassDialog.svelte";
 
     let {
         nodes: inputNodes,
@@ -65,12 +64,9 @@
     let nodes = $state.raw([...inputNodes]);
     let edges = $state.raw([...inputEdges]);
     let isDatasetReadOnly = $state();
-    let contextMenuFlowPosition = $state({ x: 0, y: 0 });
     let paneContextMenuRequest = $state(null);
     let classContextMenuRequest = $state(null);
     let contextMenuClass = $state(null);
-    let showNewClassDialog = $state(false);
-    let pendingNewClassPlacement = null;
 
     // Ordered list of node IDs from back (index 0) to front (index n-1).
     // Each node's zIndex equals its position in this array.
@@ -186,86 +182,13 @@
     }
 
     function syncDiagramElements() {
-        const nextNodes = syncDiagramNodes();
+        const nextNodes = [...inputNodes];
         const nextHasDefaultLayout = hasDefaultNodeLayout(nextNodes);
 
         syncNodeOrder(nextNodes);
         nodes = applyZIndicesFromOrder(nextNodes);
         edges = buildDiagramEdges();
         resetDiagramSyncState(nextHasDefaultLayout);
-    }
-
-    function syncDiagramNodes() {
-        let nextNodes = [...inputNodes];
-        if (shouldApplyPendingNewClassPlacement()) {
-            const addedNode = findAddedNodeForPlacement(nextNodes);
-            if (addedNode) {
-                persistPendingNewClassPosition(addedNode);
-                nextNodes = placePendingNewClassNode(nextNodes, addedNode);
-                pendingNewClassPlacement = null;
-            }
-        }
-        return nextNodes;
-    }
-
-    function shouldApplyPendingNewClassPlacement() {
-        return (
-            !!pendingNewClassPlacement &&
-            editorState.selectedPackageUUID.getValue() ===
-                pendingNewClassPlacement.packageUUID
-        );
-    }
-
-    function findAddedNodeForPlacement(diagramNodes) {
-        const addedNodes = diagramNodes.filter(
-            node => !pendingNewClassPlacement.existingNodeIds.has(node.id),
-        );
-
-        return (
-            addedNodes.find(
-                node =>
-                    node.data?.label === pendingNewClassPlacement.className &&
-                    node.position.x === 0 &&
-                    node.position.y === 0,
-            ) ??
-            addedNodes.find(
-                node => node.data?.label === pendingNewClassPlacement.className,
-            ) ??
-            (addedNodes.length === 1 ? addedNodes[0] : null)
-        );
-    }
-
-    function placePendingNewClassNode(diagramNodes, addedNode) {
-        const { x, y } = pendingNewClassPlacement.position;
-        return diagramNodes.map(node =>
-            node.id === addedNode.id
-                ? {
-                      ...node,
-                      position: { x, y },
-                  }
-                : node,
-        );
-    }
-
-    function persistPendingNewClassPosition(addedNode) {
-        const { x, y } = pendingNewClassPlacement.position;
-        bec.updateClassPositions(
-            pendingNewClassPlacement.datasetName,
-            pendingNewClassPlacement.graphURI,
-            pendingNewClassPlacement.packageUUID,
-            [
-                {
-                    classUUID: addedNode.id,
-                    xPosition: x,
-                    yPosition: y,
-                },
-            ],
-        ).catch(error => {
-            console.error(
-                "Could not persist newly created class position:",
-                error,
-            );
-        });
     }
 
     function buildDiagramEdges() {
@@ -407,15 +330,15 @@
 
         contextMenuClass = null;
         if (!svelteFlowAPI?.svelteFlow) {
-            contextMenuFlowPosition = { x: 0, y: 0 };
             paneContextMenuRequest = {
                 x: event.clientX,
                 y: event.clientY,
+                flowPosition: { x: 0, y: 0 },
             };
             return;
         }
 
-        contextMenuFlowPosition = svelteFlowAPI.svelteFlow.screenToFlowPosition(
+        const flowPosition = svelteFlowAPI.svelteFlow.screenToFlowPosition(
             {
                 x: event.clientX,
                 y: event.clientY,
@@ -425,6 +348,7 @@
         paneContextMenuRequest = {
             x: event.clientX,
             y: event.clientY,
+            flowPosition,
         };
     }
 
@@ -448,25 +372,6 @@
         classContextMenuRequest = {
             x: event.clientX,
             y: event.clientY,
-        };
-    }
-
-    function handleClassCreated({
-        datasetName,
-        graphURI,
-        packageUUID,
-        className,
-    }) {
-        pendingNewClassPlacement = {
-            datasetName,
-            graphURI,
-            packageUUID,
-            className,
-            existingNodeIds: new Set(nodes.map(node => node.id)),
-            position: {
-                x: contextMenuFlowPosition.x,
-                y: contextMenuFlowPosition.y,
-            },
         };
     }
 
@@ -694,7 +599,6 @@
         disabled={isDatasetReadOnly}
         lockedDatasetName={editorState.selectedDataset.getValue()}
         lockedGraphUri={editorState.selectedGraph.getValue()}
-        onClassCreated={handleClassCreated}
         onClose={closeContextMenus}
     />
     <SvelteFlowClassContextMenu
@@ -711,10 +615,3 @@
         onPersistLayer={handlePersistLayer}
     />
 </div>
-
-<NewClassDialog
-    bind:showDialog={showNewClassDialog}
-    lockedDatasetName={editorState.selectedDataset.getValue()}
-    lockedGraphUri={editorState.selectedGraph.getValue()}
-    onClassCreated={handleClassCreated}
-/>

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -42,7 +42,6 @@
     import InheritanceEdge from "./components/InheritanceEdge.svelte";
     import SvelteFlowClassContextMenu from "./components/SvelteFlowClassContextMenu.svelte";
     import SvelteFlowPaneContextMenu from "./components/SvelteFlowPaneContextMenu.svelte";
-    import DeleteDependenciesDialog from "../../../routes/delete-relations-dialog/DeleteDependenciesDialog.svelte";
     import NewClassDialog from "../../../routes/NewClassDialog.svelte";
 
     let {
@@ -70,8 +69,6 @@
     let paneContextMenuRequest = $state(null);
     let classContextMenuRequest = $state(null);
     let contextMenuClass = $state(null);
-    let deleteClassTarget = $state(null);
-    let showDeleteDependenciesDialog = $state(false);
     let showNewClassDialog = $state(false);
     let pendingNewClassPlacement = null;
 
@@ -505,10 +502,6 @@
             // All indices up to and including original idx shifted
             changedIds = next.slice(0, idx + 1);
         }
-        deleteClassTarget = contextMenuClass;
-        showDeleteDependenciesDialog = true;
-        closeContextMenus();
-
         nodeOrder = next;
         nodes = applyZIndicesFromOrder(nodes);
 
@@ -724,11 +717,4 @@
     lockedDatasetName={editorState.selectedDataset.getValue()}
     lockedGraphUri={editorState.selectedGraph.getValue()}
     onClassCreated={handleClassCreated}
-/>
-
-<DeleteDependenciesDialog
-    datasetName={editorState.selectedDataset.getValue()}
-    graphUri={editorState.selectedGraph.getValue()}
-    resourceUuid={deleteClassTarget?.uuid}
-    bind:showDialog={showDeleteDependenciesDialog}
 />

--- a/frontend/src/routes/NewClassDialog.svelte
+++ b/frontend/src/routes/NewClassDialog.svelte
@@ -42,6 +42,7 @@
         lockedDatasetName,
         lockedGraphUri,
         lockedPackage,
+        classLayoutPosition = null,
         onClassCreated = () => {},
     } = $props();
 
@@ -198,6 +199,14 @@
         const classURINamespaceLocal = classURINamespace;
         const selectedPackageUUID = classPackage?.uuid ?? "default";
         let packageDTO = classPackage?.uuid === "default" ? null : classPackage;
+        const requestBody = {
+            packageDTO,
+            classURIPrefix: classURINamespaceLocal?.value,
+            className: classNameLocal?.value,
+        };
+        if (classLayoutPosition) {
+            requestBody.classLayoutPosition = classLayoutPosition;
+        }
 
         try {
             const res = await fetch(
@@ -212,11 +221,7 @@
                     headers: new Headers({
                         "Content-Type": "application/json",
                     }),
-                    body: JSON.stringify({
-                        packageDTO,
-                        classURIPrefix: classURINamespaceLocal?.value,
-                        className: classNameLocal?.value,
-                    }),
+                    body: JSON.stringify(requestBody),
                     credentials: "include",
                 },
             );
@@ -224,6 +229,7 @@
                 const uuid = await res.text();
                 console.log("successfully added class");
                 onClassCreated({
+                    classUUID: uuid,
                     datasetName: datasetNameLocal,
                     graphURI: graphURILocal,
                     packageUUID: selectedPackageUUID,


### PR DESCRIPTION
## Description
- Fixed the issue that the class zindex move actions are opening the delete dialog.
- Fixed the initial class diagram positioning logic
  - The old logic was no longer functional. Implemented a proper class layout position dto.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
