### PR TITLE
fix: Fixed SearchableSelect valid input behaviour and state handling

### DIFF
--- a/frontend/src/lib/GraphExport.svelte
+++ b/frontend/src/lib/GraphExport.svelte
@@ -88,6 +88,7 @@
                 ontologyJSON.uuid,
                 ontologyJSON.namespace,
                 ontologyJSON.entries,
+                namespaces,
             );
         }
     });

--- a/frontend/src/lib/components/SearchableSelect.svelte
+++ b/frontend/src/lib/components/SearchableSelect.svelte
@@ -41,7 +41,7 @@
         buttons = [],
     } = $props();
 
-    let lastValidInput = $state(value);
+    let lastValidInput = value;
     let datalistID = crypto.randomUUID();
 
     $effect(() => {

--- a/frontend/src/lib/components/SearchableSelect.svelte
+++ b/frontend/src/lib/components/SearchableSelect.svelte
@@ -41,8 +41,21 @@
         buttons = [],
     } = $props();
 
-    let lastSavedValue = value;
+    let lastValidInput = $state(value);
     let datalistID = crypto.randomUUID();
+
+    $effect(() => {
+        if (!value) {
+            lastValidInput = value;
+            return;
+        }
+        for (let optionObj of optionObjectList) {
+            if (accessDisplayData(optionObj) === value) {
+                lastValidInput = accessDisplayData(optionObj);
+                return;
+            }
+        }
+    });
 
     function verifyInput() {
         if (!value) {
@@ -52,13 +65,13 @@
         }
         for (let optionObj of optionObjectList) {
             if (accessIdentifier(optionObj) === value) {
-                lastSavedValue = accessDisplayData(optionObj);
-                value = lastSavedValue;
+                lastValidInput = accessDisplayData(optionObj);
+                value = lastValidInput;
                 callOnValidChange(optionObj);
                 return;
             }
         }
-        value = lastSavedValue;
+        value = lastValidInput;
     }
 </script>
 

--- a/frontend/src/lib/components/SearchableSelect.svelte
+++ b/frontend/src/lib/components/SearchableSelect.svelte
@@ -22,7 +22,7 @@
         label,
         placeholder = "",
         value,
-        callOnValidChange = () => {},
+        callOnChange = () => {},
         //accessDisplayData: how an option is displayed
         accessDisplayData = value => {
             return value;
@@ -41,37 +41,22 @@
         buttons = [],
     } = $props();
 
-    let lastValidInput = value;
     let datalistID = crypto.randomUUID();
-
-    $effect(() => {
-        if (!value) {
-            lastValidInput = value;
-            return;
-        }
-        for (let optionObj of optionObjectList) {
-            if (accessDisplayData(optionObj) === value) {
-                lastValidInput = accessDisplayData(optionObj);
-                return;
-            }
-        }
-    });
 
     function verifyInput() {
         if (!value) {
             value = null;
-            callOnValidChange(value);
+            callOnChange(value);
             return;
         }
         for (let optionObj of optionObjectList) {
             if (accessIdentifier(optionObj) === value) {
-                lastValidInput = accessDisplayData(optionObj);
-                value = lastValidInput;
-                callOnValidChange(optionObj);
+                value = accessDisplayData(optionObj);
+                callOnChange(optionObj);
                 return;
             }
         }
-        value = lastValidInput;
+        callOnChange(value);
     }
 </script>
 

--- a/frontend/src/lib/models/reactive/mapper/map-dto-to-reactive-object.js
+++ b/frontend/src/lib/models/reactive/mapper/map-dto-to-reactive-object.js
@@ -20,14 +20,14 @@ import { ReactiveClass } from "$lib/models/reactive/models/reactive-class.svelte
 /**
  * Maps a class DTO to a ReactiveClass instance
  * @param {Object} classDto - The class data transfer object from the API
- * @param {Array} classes - Array of existing classes for resolving references
+ * @param {Array} context - Mixed context data required for resolving references (e.g. classes, namespaces, etc.)
  * @param {function} getClassByUuid - A function that returns the class with the given uuid
  * @returns {ReactiveClass} The reactive class instance
  */
-export function mapClassDtoToReactiveClass(classDto, classes, getClassByUuid) {
+export function mapClassDtoToReactiveClass(classDto, context, getClassByUuid) {
     let superClass = null;
     if (classDto.superClass) {
-        superClass = classes.find(
+        superClass = context.classes.find(
             cls =>
                 cls.prefix + cls.label ===
                 classDto.superClass.prefix + classDto.superClass.label,
@@ -39,7 +39,7 @@ export function mapClassDtoToReactiveClass(classDto, classes, getClassByUuid) {
     );
     const associations = mapAssociationDtoListToReactiveAssociationList(
         classDto.associationPairs,
-        classes,
+        context.classes,
     );
 
     const enumEntries = mapEnumEntryListToReactiveEnumEntryList(
@@ -57,7 +57,7 @@ export function mapClassDtoToReactiveClass(classDto, classes, getClassByUuid) {
         associations,
         enumEntries,
         getClassByUuid,
-        classes,
+        context,
     );
 }
 

--- a/frontend/src/lib/models/reactive/models/ontology/reactive-ontology.svelte.js
+++ b/frontend/src/lib/models/reactive/models/ontology/reactive-ontology.svelte.js
@@ -24,11 +24,10 @@ import {
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
 
 export class ReactiveOntology {
-    constructor(uuid = null, namespace = "", entries = []) {
+    constructor(uuid = null, namespace = "", entries = [], namespaces = []) {
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
-        this.namespace = new ReactiveValueWrapper(
-            namespace,
-            isInvalidNamespace,
+        this.namespace = new ReactiveValueWrapper(namespace, namespace =>
+            isInvalidNamespace(namespace, namespaces),
         );
         this.entries = new ReactiveObjectsArrayWrapper(
             entries,

--- a/frontend/src/lib/models/reactive/models/ontology/reactive-ontology.svelte.js
+++ b/frontend/src/lib/models/reactive/models/ontology/reactive-ontology.svelte.js
@@ -35,6 +35,10 @@ export class ReactiveOntology {
         );
     }
 
+    static empty(namespaces = []) {
+        return new ReactiveOntology(null, "", [], namespaces);
+    }
+
     /**
      * The UUID of this ontology
      * @type {ReactiveValueWrapper<string>}

--- a/frontend/src/lib/models/reactive/models/reactive-association.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-association.svelte.js
@@ -18,7 +18,6 @@ import { ReactiveValueWrapper } from "$lib/models/reactive/reactive-wrappers/rea
 import {
     isInvalidMultiplicityLowerBound,
     isInvalidMultiplicityUpperBound,
-    isInvalidNamespace,
     isInvalidTarget,
     isInvalidUuid,
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
@@ -50,10 +49,7 @@ export class ReactiveAssociation {
         // Set top-level properties
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
         this.label = new ReactiveValueWrapper(label);
-        this.namespace = new ReactiveValueWrapper(
-            namespace,
-            isInvalidNamespace,
-        );
+        this.namespace = new ReactiveValueWrapper(namespace);
         this.domain = new ReactiveValueWrapper(domain, isInvalidUuid);
         this.target = new ReactiveValueWrapper(target, isInvalidTarget);
         this.multiplicityLowerBound = new ReactiveValueWrapper(
@@ -79,10 +75,7 @@ export class ReactiveAssociation {
         this.inverse = {
             uuid: new ReactiveValueWrapper(inverseUuid, isInvalidUuid),
             label: new ReactiveValueWrapper(inverseLabel),
-            namespace: new ReactiveValueWrapper(
-                inverseNamespace,
-                isInvalidNamespace,
-            ),
+            namespace: new ReactiveValueWrapper(inverseNamespace),
             multiplicityLowerBound: new ReactiveValueWrapper(
                 inverseLowerBound,
                 lowerBound =>

--- a/frontend/src/lib/models/reactive/models/reactive-attribute.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-attribute.svelte.js
@@ -20,9 +20,7 @@ import {
     isInvalidLabel,
     isInvalidMultiplicityLowerBound,
     isInvalidMultiplicityUpperBound,
-    isInvalidNamespace,
     isInvalidUuid,
-    isInvalidDatatypeUri,
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
 
 export class ReactiveAttribute {
@@ -39,10 +37,7 @@ export class ReactiveAttribute {
     } = {}) {
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
         this.label = new ReactiveValueWrapper(label, isInvalidLabel);
-        this.namespace = new ReactiveValueWrapper(
-            namespace,
-            isInvalidNamespace,
-        );
+        this.namespace = new ReactiveValueWrapper(namespace);
         this.multiplicityLowerBound = new ReactiveValueWrapper(
             multiplicityLowerBound,
             lowerBound =>
@@ -59,10 +54,7 @@ export class ReactiveAttribute {
                     this.multiplicityLowerBound.value,
                 ),
         );
-        this.datatype = new ReactiveValueWrapper(
-            datatype,
-            isInvalidDatatypeUri,
-        );
+        this.datatype = new ReactiveValueWrapper(datatype);
         this.comment = new ReactiveValueWrapper(comment);
         this.fixedValue = new ReactiveValueWrapper(fixedValue);
         this.defaultValue = new ReactiveValueWrapper(defaultValue);

--- a/frontend/src/lib/models/reactive/models/reactive-class.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-class.svelte.js
@@ -29,6 +29,9 @@ import {
     isInvalidNamespace,
     isInvalidStereotype,
     isInvalidUuid,
+    isInvalidPackage,
+    isInvalidSuperClass,
+    isInvalidDatatypeUri,
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
 
 function initializeStereotypeViolationChecks(stereotype, stereotypesArray) {
@@ -37,10 +40,30 @@ function initializeStereotypeViolationChecks(stereotype, stereotypesArray) {
     );
 }
 
+function initializeAttributeViolationChecks(
+    attribute,
+    attributesArray,
+    namespaces,
+    datatypes,
+) {
+    attribute.label.violationChecks.push(label =>
+        hasUniqueIRI(label, attribute.namespace.value, attributesArray),
+    );
+
+    attribute.namespace.violationChecks.push(namespace =>
+        isInvalidNamespace(namespace, namespaces),
+    );
+
+    attribute.datatype.violationChecks.push(datatype =>
+        isInvalidDatatypeUri(datatype, datatypes),
+    );
+}
+
 function initializeAssociationViolationChecks(
     association,
     associationsArray,
     getClassByUuid,
+    compareNamespaces,
 ) {
     association.label.violationChecks.push(() =>
         isInvalidAssociationLabel(association, associationsArray),
@@ -48,11 +71,25 @@ function initializeAssociationViolationChecks(
     association.inverse.label.violationChecks.push(() =>
         isInvalidInverseAssociationLabel(association, getClassByUuid),
     );
+    association.namespace.violationChecks.push(namespace =>
+        isInvalidNamespace(namespace, compareNamespaces),
+    );
+    association.inverse.namespace.violationChecks.push(namespace =>
+        isInvalidNamespace(namespace, compareNamespaces),
+    );
 }
 
-function initializeUniqueLabelChecks(reactiveObject, enumEntriesArray) {
-    reactiveObject.label.violationChecks.push(label =>
+function initializeEnumEntryViolationChecks(
+    enumEntry,
+    enumEntriesArray,
+    namespaces,
+) {
+    enumEntry.label.violationChecks.push(label =>
         hasUniqueLabel(label, enumEntriesArray),
+    );
+
+    enumEntry.namespace.violationChecks.push(namespace =>
+        isInvalidNamespace(namespace, namespaces),
     );
 }
 
@@ -69,20 +106,22 @@ export class ReactiveClass {
         associations = [],
         enumEntries = [],
         getClassByUuid = () => undefined,
-        compareClasses = [],
+        context = [],
     ) {
-        compareClasses = compareClasses.filter(c => c.uuid !== uuid);
+        let compareClasses = context.classes.filter(c => c.uuid !== uuid);
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
-        this.namespace = new ReactiveValueWrapper(
-            namespace,
-            isInvalidNamespace,
+        this.namespace = new ReactiveValueWrapper(namespace, namespace =>
+            isInvalidNamespace(namespace, context.namespaces),
         );
         this.label = new ReactiveValueWrapper(label, label =>
             isInvalidClassLabel(label, this.namespace.value, compareClasses),
         );
 
-        this.package = new ReactiveValueWrapper(pack);
-        this.superClass = new ReactiveValueWrapper(superClass);
+        this.package = new ReactiveValueWrapper(pack, isInvalidPackage);
+        this.superClass = new ReactiveValueWrapper(
+            superClass,
+            isInvalidSuperClass,
+        );
         this.comment = new ReactiveValueWrapper(comment);
         this.stereotypes = new ReactiveObjectsArrayWrapper(
             stereotypes,
@@ -92,15 +131,13 @@ export class ReactiveClass {
         this.attributes = new ReactiveObjectsArrayWrapper(
             attributes,
             ReactiveAttribute,
-            (reactiveObject, entriesArray) => {
-                reactiveObject.label.violationChecks.push(label =>
-                    hasUniqueIRI(
-                        label,
-                        reactiveObject.namespace.value,
-                        entriesArray,
-                    ),
-                );
-            },
+            (attribute, attributesArray) =>
+                initializeAttributeViolationChecks(
+                    attribute,
+                    attributesArray,
+                    context.namespaces,
+                    context.datatypes,
+                ),
         );
         this.associations = new ReactiveObjectsArrayWrapper(
             associations,
@@ -110,12 +147,18 @@ export class ReactiveClass {
                     association,
                     associationsArray,
                     getClassByUuid,
+                    context.namespaces,
                 ),
         );
         this.enumEntries = new ReactiveObjectsArrayWrapper(
             enumEntries,
             ReactiveEnumEntry,
-            initializeUniqueLabelChecks,
+            (enumEntry, enumEntriesArray) =>
+                initializeEnumEntryViolationChecks(
+                    enumEntry,
+                    enumEntriesArray,
+                    context.namespaces,
+                ),
         );
     }
 

--- a/frontend/src/lib/models/reactive/models/reactive-enum-entry.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-enum-entry.svelte.js
@@ -18,7 +18,6 @@
 import { ReactiveValueWrapper } from "$lib/models/reactive/reactive-wrappers/reactive-value-wrapper.svelte.js";
 import {
     isInvalidLabel,
-    isInvalidNamespace,
     isInvalidUuid,
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
 
@@ -31,10 +30,7 @@ export class ReactiveEnumEntry {
         stereotype = null,
     } = {}) {
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
-        this.namespace = new ReactiveValueWrapper(
-            namespace,
-            isInvalidNamespace,
-        );
+        this.namespace = new ReactiveValueWrapper(namespace);
         this.label = new ReactiveValueWrapper(label, isInvalidLabel);
         this.comment = new ReactiveValueWrapper(comment);
         this.stereotype = new ReactiveValueWrapper(stereotype);

--- a/frontend/src/lib/models/reactive/models/reactive-package.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-package.svelte.js
@@ -28,12 +28,12 @@ export class ReactivePackage {
         label = "",
         namespace = "",
         comment = null,
+        compareNamespaces = [],
     } = {}) {
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
         this.label = new ReactiveValueWrapper(label, isInvalidLabel);
-        this.namespace = new ReactiveValueWrapper(
-            namespace,
-            isInvalidNamespace,
+        this.namespace = new ReactiveValueWrapper(namespace, namespace =>
+            isInvalidNamespace(namespace, compareNamespaces),
         );
         this.comment = new ReactiveValueWrapper(comment);
     }

--- a/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
+++ b/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
@@ -21,11 +21,15 @@ import { getNCNameViolations } from "$lib/rdf-syntax-grammar/namespace/prefix/in
 
 export function isInvalidUuid(uuid) {
     const violations = [];
-    if (uuid !== null && (!uuid || !uuidValidate(uuid))) {
+    if (validateUuid(uuid)) {
         // Allows null because uuids are not required
         violations.push("must be a valid UUID");
     }
     return violations;
+}
+
+function validateUuid(uuid) {
+    return uuid !== null && (!uuid || !uuidValidate(uuid));
 }
 
 export function isInvalidLabel(label) {
@@ -127,8 +131,18 @@ export function isInvalidInverseAssociationLabel(association, getClassByUuid) {
     return violations;
 }
 
-export function isInvalidNamespace(namespace) {
-    return isNotEmptyValidation(namespace);
+export function isInvalidNamespace(namespace, compareNamespaces) {
+    const violations = isNotEmptyValidation(namespace);
+    if (
+        violations.length === 0 &&
+        !compareNamespaces.some(
+            compareNamespace => compareNamespace.prefix === namespace,
+        )
+    ) {
+        violations.push("");
+    }
+
+    return violations;
 }
 
 export function isInvalidMultiplicityLowerBound(lowerBound, upperBound) {
@@ -163,15 +177,28 @@ export function isInvalidMultiplicityUpperBound(upperBound, lowerBound) {
     return violations;
 }
 
-export function isInvalidDatatypeUri(uri) {
-    return isNotEmptyValidation(uri);
+export function isInvalidDatatypeUri(uri, compareDatatypes) {
+    const violations = isNotEmptyValidation(uri);
+
+    if (
+        violations.length === 0 &&
+        !compareDatatypes.some(
+            datatype => datatype.prefix + datatype.label === uri,
+        )
+    ) {
+        violations.push("");
+    }
+
+    return violations;
 }
 
 export function isInvalidTarget(target) {
-    const violations = isInvalidUuid(target);
-    if (!target || target.trim() === "") {
-        violations.push("must not be empty");
+    const violations = isNotEmptyValidation(target);
+
+    if (violations.length === 0 && validateUuid(target)) {
+        violations.push("");
     }
+
     return violations;
 }
 
@@ -291,6 +318,26 @@ export function namespacePrefixesAreUnique(prefix, reactiveNamespacesArray) {
 
     if (matches.length > 1) {
         violations.push("must be unique");
+    }
+
+    return violations;
+}
+
+export function isInvalidPackage(pack) {
+    const violations = [];
+
+    if (validateUuid(pack)) {
+        violations.push("");
+    }
+
+    return violations;
+}
+
+export function isInvalidSuperClass(superClass) {
+    const violations = [];
+
+    if (validateUuid(superClass)) {
+        violations.push("");
     }
 
     return violations;

--- a/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
+++ b/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
@@ -132,13 +132,19 @@ export function isInvalidInverseAssociationLabel(association, getClassByUuid) {
 
 export function isInvalidNamespace(namespace, compareNamespaces) {
     const violations = isNotEmptyValidation(namespace);
-    if (
-        violations.length === 0 &&
-        !compareNamespaces.some(
-            compareNamespace => compareNamespace.prefix === namespace,
-        )
-    ) {
-        violations.push("must be a valid input");
+    if (violations.length > 0) return violations;
+
+    const isKnownPrefix = compareNamespaces.some(n => n.prefix === namespace);
+    const hasIriViolation = validateIri(
+        namespace,
+        IriValidationStrategy.Pragmatic,
+    );
+    const hasWrongEnding = !namespace.endsWith("#") && !namespace.endsWith("/");
+
+    if (!isKnownPrefix && hasIriViolation) {
+        violations.push("must be a valid input or IRI");
+    } else if (!isKnownPrefix && hasWrongEnding) {
+        violations.push('must end with "#" or "/"');
     }
 
     return violations;

--- a/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
+++ b/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
@@ -22,8 +22,7 @@ import { getNCNameViolations } from "$lib/rdf-syntax-grammar/namespace/prefix/in
 export function isInvalidUuid(uuid) {
     const violations = [];
     if (validateUuid(uuid)) {
-        // Allows null because uuids are not required
-        violations.push("must be a valid UUID");
+        violations.push("must be a valid input");
     }
     return violations;
 }
@@ -139,7 +138,7 @@ export function isInvalidNamespace(namespace, compareNamespaces) {
             compareNamespace => compareNamespace.prefix === namespace,
         )
     ) {
-        violations.push("");
+        violations.push("must be a valid input");
     }
 
     return violations;
@@ -186,7 +185,7 @@ export function isInvalidDatatypeUri(uri, compareDatatypes) {
             datatype => datatype.prefix + datatype.label === uri,
         )
     ) {
-        violations.push("");
+        violations.push("must be a valid input");
     }
 
     return violations;
@@ -196,7 +195,7 @@ export function isInvalidTarget(target) {
     const violations = isNotEmptyValidation(target);
 
     if (violations.length === 0 && validateUuid(target)) {
-        violations.push("");
+        violations.push("must be a valid input");
     }
 
     return violations;
@@ -324,21 +323,9 @@ export function namespacePrefixesAreUnique(prefix, reactiveNamespacesArray) {
 }
 
 export function isInvalidPackage(pack) {
-    const violations = [];
-
-    if (validateUuid(pack)) {
-        violations.push("");
-    }
-
-    return violations;
+    return isInvalidUuid(pack);
 }
 
 export function isInvalidSuperClass(superClass) {
-    const violations = [];
-
-    if (validateUuid(superClass)) {
-        violations.push("");
-    }
-
-    return violations;
+    return isInvalidUuid(superClass);
 }

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -160,7 +160,7 @@
         if (cancelled.cancelled) return;
         const newReactiveClass = mapClassDtoToReactiveClass(
             classDto,
-            context.classes,
+            context,
             uuid => context.targetClassInfos.find(cls => cls.uuid === uuid),
         );
         reactiveClass = adoptUnsavedClassChanges(

--- a/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Namespace.svelte
@@ -95,8 +95,8 @@
             optionObjectList={namespaces}
             accessDisplayData={namespace => namespace.substitutedPrefix}
             accessIdentifier={getNsPrefixNsUriString}
-            callOnValidChange={namespace =>
-                trickleDownNamespaceChange(namespace.prefix)}
+            callOnChange={namespace =>
+                trickleDownNamespaceChange(namespace?.prefix ?? namespace)}
             {readonly}
             buttons={getControlButtonsForReactiveObject(
                 namespace,

--- a/frontend/src/routes/mainpage/classEditor/components/Package.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Package.svelte
@@ -61,8 +61,9 @@
                 (pack.prefix
                     ? classEditorContext.getSubstitutedNamespace(pack.prefix)
                     : "") + pack.label}
-            callOnValidChange={newPack =>
-                (pack.value = newPack ? newPack.uuid : null)}
+            callOnChange={newPack =>
+                (pack.value =
+                    newPack?.uuid !== undefined ? newPack.uuid : newPack)}
             {readonly}
             buttons={getControlButtonsForReactiveObject(pack, readonly)}
         />

--- a/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/SuperClass.svelte
@@ -69,8 +69,11 @@
                 classEditorContext.getSubstitutedNamespace(cls.prefix) +
                 ":" +
                 cls.label}
-            callOnValidChange={newSuperClass =>
-                (superClass.value = newSuperClass.uuid)}
+            callOnChange={newSuperClass =>
+                (superClass.value =
+                    newSuperClass?.uuid !== undefined
+                        ? newSuperClass.uuid
+                        : newSuperClass)}
             {readonly}
             buttons={getControlButtonsForReactiveObject(superClass, readonly)}
         />

--- a/frontend/src/routes/mainpage/classEditor/components/associations/associationEditorDialog/Direct.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/associationEditorDialog/Direct.svelte
@@ -64,8 +64,11 @@
             optionObjectList={classEditorContext.namespaces}
             accessDisplayData={namespace => namespace.substitutedPrefix}
             accessIdentifier={getNsPrefixNsUriString}
-            callOnValidChange={newNamespace =>
-                (association.namespace.value = newNamespace?.prefix)}
+            callOnChange={newNamespace =>
+                (association.namespace.value =
+                    newNamespace?.prefix !== undefined
+                        ? newNamespace.prefix
+                        : newNamespace)}
             highlight={association.namespace.isModified}
             warn={!association.namespace.isValid}
             {readonly}
@@ -101,7 +104,7 @@
             label="Target:"
             placeholder="Target"
             value={classEditorContext.getClassByUuid(association.target.value)
-                ?.label}
+                ?.label ?? association.target.value}
             optionObjectList={classes}
             accessDisplayData={cls => {
                 return cls.label;
@@ -110,8 +113,9 @@
                 classEditorContext.getSubstitutedNamespace(cls.prefix) +
                 ":" +
                 cls.label}
-            callOnValidChange={newTarget =>
-                (association.target.value = newTarget.uuid)}
+            callOnChange={newTarget =>
+                (association.target.value =
+                    newTarget?.uuid !== undefined ? newTarget.uuid : newTarget)}
             highlight={association.target.isModified}
             warn={!association.target.isValid}
             {readonly}

--- a/frontend/src/routes/mainpage/classEditor/components/associations/associationEditorDialog/Inverse.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/associations/associationEditorDialog/Inverse.svelte
@@ -63,8 +63,11 @@
             optionObjectList={classEditorContext.namespaces}
             accessDisplayData={namespace => namespace.substitutedPrefix}
             accessIdentifier={getNsPrefixNsUriString}
-            callOnValidChange={newNamespace =>
-                (association.inverse.namespace.value = newNamespace?.prefix)}
+            callOnChange={newNamespace =>
+                (association.inverse.namespace.value =
+                    newNamespace?.prefix !== undefined
+                        ? newNamespace.prefix
+                        : newNamespace)}
             highlight={association.inverse.namespace.isModified}
             warn={!association.inverse.namespace.isValid}
             {readonly}

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/Attribute.svelte
@@ -82,10 +82,10 @@
                 classEditorContext.getSubstitutedNamespace(datatype.prefix) +
                 ":" +
                 datatype.label}
-            callOnValidChange={newDatatype =>
-                (attribute.datatype.value = newDatatype
+            callOnChange={newDatatype =>
+                (attribute.datatype.value = newDatatype?.prefix
                     ? newDatatype.prefix + newDatatype.label
-                    : null)}
+                    : (newDatatype ?? null))}
             {readonly}
             tooltip={attribute.datatype.value}
             buttons={getControlButtonsForReactiveObject(

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
@@ -125,8 +125,11 @@
                     optionObjectList={classEditorContext.namespaces}
                     accessDisplayData={namespace => namespace.substitutedPrefix}
                     accessIdentifier={getNsPrefixNsUriString}
-                    callOnValidChange={newNamespace =>
-                        (attribute.namespace.value = newNamespace?.prefix)}
+                    callOnChange={newNamespace =>
+                        (attribute.namespace.value =
+                            newNamespace?.prefix !== undefined
+                                ? newNamespace.prefix
+                                : newNamespace)}
                     highlight={attribute.namespace.isModified}
                     warn={!attribute.namespace.isValid}
                     {readonly}
@@ -172,10 +175,10 @@
                         ) +
                         ":" +
                         datatype.label}
-                    callOnValidChange={newDatatype =>
-                        (attribute.datatype.value = newDatatype
+                    callOnChange={newDatatype =>
+                        (attribute.datatype.value = newDatatype?.prefix
                             ? newDatatype.prefix + newDatatype.label
-                            : null)}
+                            : (newDatatype ?? null))}
                     highlight={attribute.datatype.isModified}
                     warn={!attribute.datatype.isValid}
                     {readonly}

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntryEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntryEditorDialog.svelte
@@ -117,8 +117,11 @@
                             : prefix;
                     }}
                     accessIdentifier={getNsPrefixNsUriString}
-                    callOnValidChange={newNamespace =>
-                        (enumEntry.namespace.value = newNamespace?.prefix)}
+                    callOnChange={newNamespace =>
+                        (enumEntry.namespace.value =
+                            newNamespace?.prefix !== undefined
+                                ? newNamespace.prefix
+                                : newNamespace)}
                     highlight={enumEntry.namespace.isModified}
                     warn={!enumEntry.namespace.isValid}
                     {readonly}

--- a/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntryEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/enum-entries/EnumEntryEditorDialog.svelte
@@ -110,7 +110,12 @@
                         enumEntry.namespace.value,
                     )}
                     optionObjectList={classEditorContext.namespaces}
-                    accessDisplayData={namespace => namespace.substitutedPrefix}
+                    accessDisplayData={namespace => {
+                        let prefix = namespace.substitutedPrefix;
+                        return prefix?.endsWith(":")
+                            ? prefix.slice(0, -1)
+                            : prefix;
+                    }}
                     accessIdentifier={getNsPrefixNsUriString}
                     callOnValidChange={newNamespace =>
                         (enumEntry.namespace.value = newNamespace?.prefix)}

--- a/frontend/src/routes/mainpage/packageEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/packageEditorDialog.svelte
@@ -59,6 +59,7 @@
 
     async function onOpen() {
         await fetchPackages();
+        namespaces = await getNamespaces(datasetName);
         if (pack) {
             isNewPackage = false;
             pkg = new ReactivePackage({
@@ -66,6 +67,7 @@
                 label: getPackageDisplayLabel(pack.label),
                 namespace: pack.prefix,
                 comment: pack.comment,
+                compareNamespaces: namespaces,
             });
         } else {
             isNewPackage = true;
@@ -83,9 +85,6 @@
             }
             return [];
         });
-        if (!readonly && datasetName) {
-            namespaces = await getNamespaces(datasetName);
-        }
     }
     async function fetchPackages() {
         if (!datasetName || !graphUri) {
@@ -182,10 +181,11 @@
                     " (" +
                     namespace.prefix +
                     ") "}
-                callOnValidChange={newNamespace =>
-                    (pkg.namespace.value = newNamespace
-                        ? newNamespace.prefix
-                        : null)}
+                callOnChange={newNamespace =>
+                    (pkg.namespace.value =
+                        newNamespace?.prefix !== undefined
+                            ? newNamespace.prefix
+                            : newNamespace)}
                 highlight={pkg.namespace.isModified}
                 warn={!pkg.namespace.isValid}
                 {readonly}

--- a/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/OntologyDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/OntologyDialog.svelte
@@ -73,6 +73,7 @@
                 ontology.uuid,
                 ontology.namespace,
                 ontology.entries,
+                namespaces,
             );
         }
     }
@@ -108,6 +109,7 @@
                     ontology.uuid,
                     ontology.namespace,
                     ontology.entries,
+                    namespaces,
                 );
             }
             ontologyObject.save();
@@ -219,8 +221,11 @@
                             )}
                         accessIdentifier={namespace =>
                             `${namespace.substitutedPrefix} (${namespace?.prefix})`}
-                        callOnValidChange={value =>
-                            (ontologyObject.namespace.value = value?.prefix)}
+                        callOnChange={value =>
+                            (ontologyObject.namespace.value =
+                                value?.prefix !== undefined
+                                    ? value.prefix
+                                    : value)}
                         {readonly}
                     />
                 </div>

--- a/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/OntologyDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/OntologyDialog.svelte
@@ -25,6 +25,7 @@
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import LoadingSpinner from "$lib/components/LoadingSpinner.svelte";
     import SearchableSelect from "$lib/components/SearchableSelect.svelte";
+    import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
     import DiscardCancelConfirmDialog from "$lib/dialog/DiscardCancelConfirmDialog.svelte";
@@ -66,14 +67,17 @@
         if (!namespaces) {
             namespaces = await getNamespaces(dataset);
         }
+
+        const resolvedNamespaces = namespaces ?? [];
+
         if (!ontology) {
-            ontologyObject = new ReactiveOntology();
+            ontologyObject = ReactiveOntology.empty(resolvedNamespaces);
         } else {
             ontologyObject = new ReactiveOntology(
                 ontology.uuid,
                 ontology.namespace,
                 ontology.entries,
-                namespaces,
+                resolvedNamespaces,
             );
         }
     }
@@ -109,7 +113,7 @@
                     ontology.uuid,
                     ontology.namespace,
                     ontology.entries,
-                    namespaces,
+                    namespaces ?? [],
                 );
             }
             ontologyObject.save();
@@ -207,7 +211,7 @@
     <div class="mx-2 flex h-full flex-col">
         {#key ontologyObject}
             {#if ontologyObject}
-                <div class="mb-2 w-150">
+                <div class="mb-2 flex w-150 flex-col">
                     <SearchableSelect
                         label="Namespace:"
                         placeholder="*namespace"
@@ -227,6 +231,9 @@
                                     ? value.prefix
                                     : value)}
                         {readonly}
+                    />
+                    <ViolationMessages
+                        violations={ontologyObject?.namespace.violations}
                     />
                 </div>
 


### PR DESCRIPTION
## Description

The SearchableSelect component, used in the ClassEditor for Package input among other places, had an internal state used to save the last valid input. This state was not updated by the InputWithControlButtons, resulting in mismatches in certain cases.
Now the state is synchronized across input field aswell as button actions.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
