### PR TITLE
feature/automatic extension (RDFA-113)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/ClassExtensionRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/ClassExtensionRESTController.java
@@ -21,7 +21,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import lombok.RequiredArgsConstructor;
+
 import org.rdfarchitect.api.dto.ClassDTO;
 import org.rdfarchitect.api.dto.attributes.AttributeDTO;
 import org.rdfarchitect.database.GraphIdentifier;
@@ -54,26 +56,26 @@ public class ClassExtensionRESTController {
     @PostMapping
     public ClassDTO extendClass(
             @Parameter(description = "The name/url of the inquirer.")
-            @RequestHeader(
-                    value = HttpHeaders.ORIGIN,
-                    required = false,
-                    defaultValue = "unknown")
-            String originURL,
-            @Parameter(description = "The literal name of the dataset.")
-            @PathVariable String datasetName,
+                    @RequestHeader(
+                            value = HttpHeaders.ORIGIN,
+                            required = false,
+                            defaultValue = "unknown")
+                    String originURL,
+            @Parameter(description = "The literal name of the dataset.") @PathVariable
+                    String datasetName,
             @Parameter(
-                    description =
-                            "The url encoded uri of the graph, or \"default\" to access the default graph.")
-            @PathVariable
-            String graphURI,
+                            description =
+                                    "The url encoded uri of the graph, or \"default\" to access the default graph.")
+                    @PathVariable
+                    String graphURI,
             @Parameter(description = "The uuid of the class.") @PathVariable String classUUID,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    required = true,
-                    description = "The new attribute",
-                    content =
-                    @Content(schema = @Schema(implementation = AttributeDTO.class)))
-            @RequestBody
-            GraphIdentifier newGraphIdentifier) {
+                            required = true,
+                            description = "The new attribute",
+                            content =
+                                    @Content(schema = @Schema(implementation = AttributeDTO.class)))
+                    @RequestBody
+                    GraphIdentifier newGraphIdentifier) {
         logger.info(
                 "Received POST request: \"/api/datasets/{{}}/graphs/{{}}/classes/{{}}/extend\" from \"{}\".",
                 datasetName,
@@ -84,7 +86,8 @@ public class ClassExtensionRESTController {
         var extendedGraphURI = expandURIUseCase.expandUri(datasetName, graphURI);
         var graphIdentifier = new GraphIdentifier(datasetName, extendedGraphURI);
 
-        var newClass = classExtensionUseCase.extendClass(graphIdentifier, classUUID, newGraphIdentifier);
+        var newClass =
+                classExtensionUseCase.extendClass(graphIdentifier, classUUID, newGraphIdentifier);
 
         logger.info(
                 "Sending response to POST request: \"/api/datasets/{{}}/graphs/{{}}/classes/{{}}/extend\" to \"{}\".",

--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/ClassExtensionRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/classes/ClassExtensionRESTController.java
@@ -1,0 +1,97 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.controller.datasets.graphs.classes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.rdfarchitect.api.dto.ClassDTO;
+import org.rdfarchitect.api.dto.attributes.AttributeDTO;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.services.ClassExtensionUseCase;
+import org.rdfarchitect.services.ExpandURIUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/classes/{classUUID}/extend")
+@RequiredArgsConstructor
+public class ClassExtensionRESTController {
+    private static final Logger logger =
+            LoggerFactory.getLogger(ClassExtensionRESTController.class);
+
+    private final ExpandURIUseCase expandURIUseCase;
+    private final ClassExtensionUseCase classExtensionUseCase;
+
+    @Operation(
+            summary = "Extend class",
+            description = "extends a class in another graph",
+            tags = {"class"})
+    @PostMapping
+    public ClassDTO extendClass(
+            @Parameter(description = "The name/url of the inquirer.")
+            @RequestHeader(
+                    value = HttpHeaders.ORIGIN,
+                    required = false,
+                    defaultValue = "unknown")
+            String originURL,
+            @Parameter(description = "The literal name of the dataset.")
+            @PathVariable String datasetName,
+            @Parameter(
+                    description =
+                            "The url encoded uri of the graph, or \"default\" to access the default graph.")
+            @PathVariable
+            String graphURI,
+            @Parameter(description = "The uuid of the class.") @PathVariable String classUUID,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "The new attribute",
+                    content =
+                    @Content(schema = @Schema(implementation = AttributeDTO.class)))
+            @RequestBody
+            GraphIdentifier newGraphIdentifier) {
+        logger.info(
+                "Received POST request: \"/api/datasets/{{}}/graphs/{{}}/classes/{{}}/extend\" from \"{}\".",
+                datasetName,
+                graphURI,
+                classUUID,
+                originURL);
+
+        var extendedGraphURI = expandURIUseCase.expandUri(datasetName, graphURI);
+        var graphIdentifier = new GraphIdentifier(datasetName, extendedGraphURI);
+
+        var newClass = classExtensionUseCase.extendClass(graphIdentifier, classUUID, newGraphIdentifier);
+
+        logger.info(
+                "Sending response to POST request: \"/api/datasets/{{}}/graphs/{{}}/classes/{{}}/extend\" to \"{}\".",
+                datasetName,
+                graphURI,
+                classUUID,
+                originURL);
+        return newClass;
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/services/ClassExtensionService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/ClassExtensionService.java
@@ -1,0 +1,107 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.rdfarchitect.api.dto.ClassDTO;
+import org.rdfarchitect.api.dto.ClassMapper;
+import org.rdfarchitect.database.DatabasePort;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.models.cim.data.CIMObjectFetcher;
+import org.rdfarchitect.models.cim.data.dto.relations.CIMSBelongsToCategory;
+import org.rdfarchitect.models.cim.data.dto.relations.RDFSLabel;
+import org.rdfarchitect.models.cim.data.dto.relations.uri.URI;
+import org.rdfarchitect.models.cim.queries.update.CIMUpdates;
+import org.rdfarchitect.models.cim.rdf.resources.CIMS;
+import org.rdfarchitect.models.cim.rdf.resources.CIMStereotypes;
+import org.rdfarchitect.models.cim.rdf.resources.RDFA;
+import org.rdfarchitect.models.cim.relations.CIMClassRelationFinder;
+import org.rdfarchitect.rdf.graph.wrapper.GraphRewindableWithUUIDs;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ClassExtensionService implements ClassExtensionUseCase {
+
+    private DatabasePort databasePort;
+    private ClassMapper classMapper;
+
+    @Override
+    public ClassDTO extendClass(GraphIdentifier graphIdentifier, String classUUID, GraphIdentifier newGraphIdentifier) {
+        var graph = databasePort.getGraphWithContext(graphIdentifier);
+        var model = ModelFactory.createModelForGraph(graph.getRdfGraph());
+        var cimObjectFetcher = new CIMObjectFetcher(databasePort.getGraphWithContext(graphIdentifier).getRdfGraph(), graphIdentifier.graphUri(), databasePort.getPrefixMapping(graphIdentifier.datasetName()));
+
+        var corePackage = model.listSubjectsWithProperty(RDF.type, CIMS.classCategory)
+                .filterKeep(s -> s.toString().toLowerCase().contains("core"))
+                .next();
+
+        CIMSBelongsToCategory pack = null;
+        if (corePackage != null) {
+            pack = new CIMSBelongsToCategory();
+            pack.setUri(new URI(corePackage.getURI()));
+            pack.setLabel(new RDFSLabel(corePackage.getProperty(RDFS.label).getString()));
+            pack.setUuid(UUID.fromString(corePackage.getProperty(RDFA.uuid).getString()));
+        }
+
+        var classResource = model.listSubjectsWithProperty(RDFA.uuid, classUUID).next();
+        var cimClass = cimObjectFetcher.fetchCIMClass(
+                classResource
+                        .getProperty(RDFA.uuid)
+                        .getObject()
+                        .asLiteral()
+                        .getString());
+        var filteredStereotypes = cimClass.getStereotypes().stream()
+                .filter(s -> !s.getStereotype().equals(CIMStereotypes.concreteString))
+                .toList();
+        cimClass.setUuid(UUID.randomUUID());
+        cimClass.setStereotypes(filteredStereotypes);
+        cimClass.setBelongsToCategory(pack);
+
+        var relationFinder = new CIMClassRelationFinder(model);
+        var superClasses = relationFinder.findSuperClasses(UUID.fromString(classUUID));
+        for (var superClass : superClasses) {
+            filteredStereotypes = superClass.getStereotypes().stream()
+                    .filter(s -> !s.getStereotype().equals(CIMStereotypes.concreteString))
+                    .toList();
+            superClass.setUuid(UUID.randomUUID());
+            superClass.setStereotypes(filteredStereotypes);
+            superClass.setBelongsToCategory(pack);
+        }
+
+        GraphRewindableWithUUIDs newGraph = null;
+        try {
+            newGraph = databasePort.getGraphWithContext(newGraphIdentifier).getRdfGraph();
+            newGraph.begin(TxnType.WRITE);
+            for (var cls : superClasses) {
+                CIMUpdates.insertClass(newGraph, databasePort.getPrefixMapping(newGraphIdentifier.datasetName()), cls);
+            }
+        } finally {
+            if (newGraph != null) {
+                newGraph.end();
+            }
+        }
+
+        return classMapper.toDTO(cimClass);
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/services/ClassExtensionService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/ClassExtensionService.java
@@ -17,9 +17,11 @@
 
 package org.rdfarchitect.services;
 
-import java.util.UUID;
 import lombok.AllArgsConstructor;
+
+import org.apache.jena.graph.Graph;
 import org.apache.jena.query.TxnType;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
@@ -27,7 +29,9 @@ import org.rdfarchitect.api.dto.ClassDTO;
 import org.rdfarchitect.api.dto.ClassMapper;
 import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.models.changelog.ChangeLogEntry;
 import org.rdfarchitect.models.cim.data.CIMObjectFetcher;
+import org.rdfarchitect.models.cim.data.dto.CIMClass;
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSBelongsToCategory;
 import org.rdfarchitect.models.cim.data.dto.relations.RDFSLabel;
 import org.rdfarchitect.models.cim.data.dto.relations.uri.URI;
@@ -36,8 +40,11 @@ import org.rdfarchitect.models.cim.rdf.resources.CIMS;
 import org.rdfarchitect.models.cim.rdf.resources.CIMStereotypes;
 import org.rdfarchitect.models.cim.rdf.resources.RDFA;
 import org.rdfarchitect.models.cim.relations.CIMClassRelationFinder;
-import org.rdfarchitect.rdf.graph.wrapper.GraphRewindableWithUUIDs;
+import org.rdfarchitect.rdf.graph.wrapper.GraphRewindable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @AllArgsConstructor
@@ -45,63 +52,131 @@ public class ClassExtensionService implements ClassExtensionUseCase {
 
     private DatabasePort databasePort;
     private ClassMapper classMapper;
+    private ChangeLogUseCase changeLogUseCase;
 
     @Override
-    public ClassDTO extendClass(GraphIdentifier graphIdentifier, String classUUID, GraphIdentifier newGraphIdentifier) {
+    public ClassDTO extendClass(
+            GraphIdentifier graphIdentifier, String classUUID, GraphIdentifier newGraphIdentifier) {
         var graph = databasePort.getGraphWithContext(graphIdentifier);
-        var model = ModelFactory.createModelForGraph(graph.getRdfGraph());
-        var cimObjectFetcher = new CIMObjectFetcher(databasePort.getGraphWithContext(graphIdentifier).getRdfGraph(), graphIdentifier.graphUri(), databasePort.getPrefixMapping(graphIdentifier.datasetName()));
+        CIMClass classCopy;
+        List<CIMClass> superClasses;
 
-        var corePackage = model.listSubjectsWithProperty(RDF.type, CIMS.classCategory)
-                .filterKeep(s -> s.toString().toLowerCase().contains("core"))
-                .next();
+        GraphRewindable rdfGraph = null;
+        try {
+            rdfGraph = graph.getRdfGraph();
+            rdfGraph.begin(TxnType.READ);
 
-        CIMSBelongsToCategory pack = null;
-        if (corePackage != null) {
-            pack = new CIMSBelongsToCategory();
-            pack.setUri(new URI(corePackage.getURI()));
-            pack.setLabel(new RDFSLabel(corePackage.getProperty(RDFS.label).getString()));
-            pack.setUuid(UUID.fromString(corePackage.getProperty(RDFA.uuid).getString()));
+            classCopy = fetchStubbedClassCopy(graphIdentifier, classUUID);
+            superClasses = fetchStubbedSuperClasses(rdfGraph, UUID.fromString(classUUID));
+
+        } finally {
+            if (rdfGraph != null) {
+                rdfGraph.end();
+            }
         }
 
-        var classResource = model.listSubjectsWithProperty(RDFA.uuid, classUUID).next();
-        var cimClass = cimObjectFetcher.fetchCIMClass(
-                classResource
-                        .getProperty(RDFA.uuid)
-                        .getObject()
-                        .asLiteral()
-                        .getString());
-        var filteredStereotypes = cimClass.getStereotypes().stream()
-                .filter(s -> !s.getStereotype().equals(CIMStereotypes.concreteString))
-                .toList();
-        cimClass.setUuid(UUID.randomUUID());
-        cimClass.setStereotypes(filteredStereotypes);
-        cimClass.setBelongsToCategory(pack);
+        var newGraph = databasePort.getGraphWithContext(newGraphIdentifier).getRdfGraph();
+        insertNewClasses(newGraph, newGraphIdentifier, classCopy, superClasses);
+        changeLogUseCase.recordChange(
+                newGraphIdentifier,
+                new ChangeLogEntry(
+                        "Added "
+                                + classCopy.getLabel().getValue()
+                                + " and its superclasses to graph "
+                                + newGraphIdentifier.graphUri(),
+                        newGraph.getLastDelta()));
 
+        return classMapper.toDTO(classCopy);
+    }
+
+    private CIMClass fetchStubbedClassCopy(GraphIdentifier graphIdentifier, String classUUID) {
+        var cimObjectFetcher =
+                new CIMObjectFetcher(
+                        databasePort.getGraphWithContext(graphIdentifier).getRdfGraph(),
+                        graphIdentifier.graphUri(),
+                        databasePort.getPrefixMapping(graphIdentifier.datasetName()));
+
+        var classCopy = cimObjectFetcher.fetchCIMClass(classUUID);
+        if (classCopy == null) {
+            throw new IllegalArgumentException(
+                    "Class with UUID "
+                            + classUUID
+                            + " not found in graph "
+                            + graphIdentifier.graphUri());
+        }
+
+        // set new UUID and remove concrete stereotype
+        var filteredStereotypes =
+                classCopy.getStereotypes().stream()
+                        .filter(s -> !s.getStereotype().equals(CIMStereotypes.concreteString))
+                        .toList();
+        classCopy.setUuid(UUID.randomUUID());
+        classCopy.setStereotypes(filteredStereotypes);
+
+        return classCopy;
+    }
+
+    private List<CIMClass> fetchStubbedSuperClasses(Graph graph, UUID classUUID) {
+        var model = ModelFactory.createModelForGraph(graph);
         var relationFinder = new CIMClassRelationFinder(model);
-        var superClasses = relationFinder.findSuperClasses(UUID.fromString(classUUID));
+
+        var superClasses = relationFinder.findSuperClasses(classUUID);
         for (var superClass : superClasses) {
-            filteredStereotypes = superClass.getStereotypes().stream()
-                    .filter(s -> !s.getStereotype().equals(CIMStereotypes.concreteString))
-                    .toList();
+            // set new UUID and remove concrete stereotype
+            var filteredStereotypes =
+                    superClass.getStereotypes().stream()
+                            .filter(s -> !s.getStereotype().equals(CIMStereotypes.concreteString))
+                            .toList();
             superClass.setUuid(UUID.randomUUID());
             superClass.setStereotypes(filteredStereotypes);
-            superClass.setBelongsToCategory(pack);
         }
 
-        GraphRewindableWithUUIDs newGraph = null;
+        return superClasses.stream().toList();
+    }
+
+    private void insertNewClasses(
+            GraphRewindable newGraph,
+            GraphIdentifier newGraphIdentifier,
+            CIMClass classCopy,
+            List<CIMClass> superClasses) {
         try {
-            newGraph = databasePort.getGraphWithContext(newGraphIdentifier).getRdfGraph();
+            var model = ModelFactory.createModelForGraph(newGraph);
             newGraph.begin(TxnType.WRITE);
+            var prefixMapping = databasePort.getPrefixMapping(newGraphIdentifier.datasetName());
+
+            var newPackage = fetchNewPackage(model);
+
             for (var cls : superClasses) {
-                CIMUpdates.insertClass(newGraph, databasePort.getPrefixMapping(newGraphIdentifier.datasetName()), cls);
+                if (!model.containsResource(model.createResource(cls.getUri().toString()))) {
+                    cls.setBelongsToCategory(newPackage);
+                    CIMUpdates.insertClass(newGraph, prefixMapping, cls);
+                }
             }
+            classCopy.setBelongsToCategory(newPackage);
+            CIMUpdates.insertClass(newGraph, prefixMapping, classCopy);
+
+            newGraph.commit();
         } finally {
             if (newGraph != null) {
                 newGraph.end();
             }
         }
+    }
 
-        return classMapper.toDTO(cimClass);
+    private CIMSBelongsToCategory fetchNewPackage(Model model) {
+        var it =
+                model.listSubjectsWithProperty(RDF.type, CIMS.classCategory)
+                        .filterKeep(s -> s.toString().contains("Core"));
+
+        if (!it.hasNext()) {
+            return null;
+        }
+
+        var corePackage = it.next();
+        CIMSBelongsToCategory pack = new CIMSBelongsToCategory();
+        pack.setUri(new URI(corePackage.getURI()));
+        pack.setLabel(new RDFSLabel(corePackage.getProperty(RDFS.label).getString(), "en"));
+        pack.setUuid(UUID.fromString(corePackage.getProperty(RDFA.uuid).getString()));
+        return pack;
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/services/ClassExtensionService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/ClassExtensionService.java
@@ -147,7 +147,7 @@ public class ClassExtensionService implements ClassExtensionUseCase {
             var newPackage = fetchNewPackage(model);
 
             for (var cls : superClasses) {
-                if (!model.containsResource(model.createResource(cls.getUri().toString()))) {
+                if (!model.contains(model.createResource(cls.getUri().toString()), null)) {
                     cls.setBelongsToCategory(newPackage);
                     CIMUpdates.insertClass(newGraph, prefixMapping, cls);
                 }

--- a/backend/src/main/java/org/rdfarchitect/services/ClassExtensionUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/ClassExtensionUseCase.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services;
+
+import org.rdfarchitect.api.dto.ClassDTO;
+import org.rdfarchitect.database.GraphIdentifier;
+
+public interface ClassExtensionUseCase {
+    /**
+     * enables extension of a class by creating an abstract stub of the class and all its superclasses in the new graph
+     *
+     * @param graphIdentifier the dataset name and graph URI of the class to extend
+     * @param classUUID       the uuid of the class to be extended
+     * @param newGraph        the identifier of the new graph, where the class is to be extended
+     * @return the uuid of the newly created class stub in the new graph
+     */
+    ClassDTO extendClass(GraphIdentifier graphIdentifier, String classUUID, GraphIdentifier newGraph);
+}

--- a/backend/src/main/java/org/rdfarchitect/services/ClassExtensionUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/ClassExtensionUseCase.java
@@ -22,12 +22,14 @@ import org.rdfarchitect.database.GraphIdentifier;
 
 public interface ClassExtensionUseCase {
     /**
-     * enables extension of a class by creating an abstract stub of the class and all its superclasses in the new graph
+     * enables extension of a class by creating an abstract stub of the class and all its
+     * superclasses in the new graph
      *
      * @param graphIdentifier the dataset name and graph URI of the class to extend
-     * @param classUUID       the uuid of the class to be extended
-     * @param newGraph        the identifier of the new graph, where the class is to be extended
+     * @param classUUID the uuid of the class to be extended
+     * @param newGraph the identifier of the new graph, where the class is to be extended
      * @return the uuid of the newly created class stub in the new graph
      */
-    ClassDTO extendClass(GraphIdentifier graphIdentifier, String classUUID, GraphIdentifier newGraph);
+    ClassDTO extendClass(
+            GraphIdentifier graphIdentifier, String classUUID, GraphIdentifier newGraph);
 }

--- a/backend/src/test/java/org/rdfarchitect/services/extension/ClassExtensionServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/extension/ClassExtensionServiceTest.java
@@ -1,0 +1,354 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import static utils.TestUtils.readMultipartFileFromFile;
+
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rdfarchitect.api.dto.ClassMapper;
+import org.rdfarchitect.context.SessionContext;
+import org.rdfarchitect.database.DatabasePort;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.database.inmemory.InMemoryDatabaseAdapter;
+import org.rdfarchitect.database.inmemory.InMemoryDatabaseImpl;
+import org.rdfarchitect.rdf.graph.source.builder.implementations.GraphFileSourceBuilderImpl;
+import org.rdfarchitect.services.ChangeLogService;
+import org.rdfarchitect.services.ClassExtensionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
+
+@SpringBootTest
+class ClassExtensionServiceTest {
+
+    private ClassExtensionService classExtensionService;
+    private DatabasePort databasePort;
+    @Autowired private ClassMapper classMapper;
+
+    private static final String PATH = "src/test/java/org/rdfarchitect/services/extension/";
+
+    @BeforeEach
+    void setUp() {
+        SessionContext.setSessionId(UUID.randomUUID().toString());
+        databasePort = new InMemoryDatabaseAdapter(new InMemoryDatabaseImpl());
+        var mockChangeLogService = mock(ChangeLogService.class);
+        classExtensionService =
+                new ClassExtensionService(databasePort, classMapper, mockChangeLogService);
+    }
+
+    @Test
+    void extendClass_classWithSuperClass_copiesClasses() {
+        // arrange
+        var sourceGraphId = new GraphIdentifier("source-ds", "http://example.org/source");
+        var targetGraphId = new GraphIdentifier("target-ds", "http://example.org/target");
+        var classUuid = "2c9916ee-a33e-4a2a-a0b8-ad1ba1322ffd"; // UUID of ex:Child in source ttl
+
+        var sourceFile = readMultipartFileFromFile(PATH, "class-extension-source.ttl");
+        var sourceGraphSource =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(sourceFile)
+                        .setGraphName(sourceGraphId.graphUri())
+                        .build();
+        databasePort.createGraph(sourceGraphId, sourceGraphSource.graph());
+
+        var targetFile = readMultipartFileFromFile(PATH, "class-extension-target-with-core.ttl");
+        var targetGraphSource =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(targetFile)
+                        .setGraphName(targetGraphId.graphUri())
+                        .build();
+        databasePort.createGraph(targetGraphId, targetGraphSource.graph());
+
+        // act
+        var result = classExtensionService.extendClass(sourceGraphId, classUuid, targetGraphId);
+
+        // assert DTO returned
+        assertThat(result).isNotNull();
+
+        var targetGraph = databasePort.getGraphWithContext(targetGraphId).getRdfGraph();
+        var sourceGraph = databasePort.getGraphWithContext(sourceGraphId).getRdfGraph();
+        var targetModel = ModelFactory.createModelForGraph(targetGraph);
+        var sourceModel = ModelFactory.createModelForGraph(sourceGraph);
+
+        var ex = "http://example.org#";
+        var cims = "http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#";
+        var rdfa = "http://example.org#uuid";
+
+        try {
+            sourceGraph.begin(TxnType.READ);
+            targetGraph.begin(TxnType.READ);
+
+            // class exists in target
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    RDF.type.asNode(),
+                                    RDFS.Class.asNode()))
+                    .isTrue();
+
+            // superclass relation exists => superclass copied/usable
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    RDFS.subClassOf.asNode(),
+                                    NodeFactory.createURI(ex + "Base")))
+                    .isTrue();
+
+            // superclass exists in target graph
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Base"),
+                                    RDF.type.asNode(),
+                                    RDFS.Class.asNode()))
+                    .isTrue();
+
+            // UUID changed for copied class
+            var sourceUuid =
+                    sourceModel
+                            .getProperty(
+                                    sourceModel.getResource(ex + "Child"),
+                                    sourceModel.createProperty(rdfa))
+                            .getString();
+
+            var targetUuid =
+                    targetModel
+                            .getProperty(
+                                    targetModel.getResource(ex + "Child"),
+                                    targetModel.createProperty(rdfa))
+                            .getString();
+
+            assertThat(targetUuid).isNotBlank();
+            assertThat(targetUuid).isNotEqualTo(sourceUuid);
+
+            // UUID changed for copied superclass
+            var sourceBaseUuid =
+                    sourceModel
+                            .getProperty(
+                                    sourceModel.getResource(ex + "Base"),
+                                    sourceModel.createProperty(rdfa))
+                            .getString();
+
+            var targetBaseUuid =
+                    targetModel
+                            .getProperty(
+                                    targetModel.getResource(ex + "Base"),
+                                    targetModel.createProperty(rdfa))
+                            .getString();
+
+            assertThat(targetBaseUuid).isNotBlank();
+            assertThat(targetBaseUuid).isNotEqualTo(sourceBaseUuid);
+
+            // concrete stereotype removed from copied class
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    NodeFactory.createURI(cims + "stereotype"),
+                                    NodeFactory.createURI(
+                                            "http://iec.ch/TC57/NonStandard/UML#concrete")))
+                    .isFalse();
+
+            // copied class belongs to Core package in target
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    NodeFactory.createURI(cims + "belongsToCategory"),
+                                    NodeFactory.createURI(ex + "CorePackage")))
+                    .isTrue();
+
+            // copied superclass belongs to Core package as well
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Base"),
+                                    NodeFactory.createURI(cims + "belongsToCategory"),
+                                    NodeFactory.createURI(ex + "CorePackage")))
+                    .isTrue();
+
+        } finally {
+            targetGraph.end();
+            sourceGraph.end();
+        }
+    }
+
+    @Test
+    void extendClass_whenSuperclassAlreadyPresent_skipsSuperclassInsert_butAddsClass() {
+        // arrange
+        var sourceGraphId = new GraphIdentifier("source-ds-2", "http://example.org/source2");
+        var targetGraphId = new GraphIdentifier("target-ds-2", "http://example.org/target2");
+        var classUuid = "2c9916ee-a33e-4a2a-a0b8-ad1ba1322ffd"; // ex:Child
+
+        var sourceFile = readMultipartFileFromFile(PATH, "class-extension-source.ttl");
+        var sourceGraphSource =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(sourceFile)
+                        .setGraphName(sourceGraphId.graphUri())
+                        .build();
+        databasePort.createGraph(sourceGraphId, sourceGraphSource.graph());
+
+        // target already contains Base class with existing UUID; should not be replaced
+        var targetFile =
+                readMultipartFileFromFile(PATH, "class-extension-target-with-existing-class.ttl");
+        var targetGraphSource =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(targetFile)
+                        .setGraphName(targetGraphId.graphUri())
+                        .build();
+        databasePort.createGraph(targetGraphId, targetGraphSource.graph());
+
+        var ex = "http://example.org#";
+        var rdfa = "http://example.org#uuid";
+
+        var targetGraph = databasePort.getGraphWithContext(targetGraphId).getRdfGraph();
+        var targetModel = ModelFactory.createModelForGraph(targetGraph);
+
+        String existingBaseUuidBefore;
+        try {
+            targetGraph.begin(TxnType.READ);
+            existingBaseUuidBefore =
+                    targetModel
+                            .getProperty(
+                                    targetModel.getResource(ex + "Base"),
+                                    targetModel.createProperty(rdfa))
+                            .getString();
+        } finally {
+            targetGraph.end();
+        }
+
+        // act
+        var result = classExtensionService.extendClass(sourceGraphId, classUuid, targetGraphId);
+
+        // assert
+        assertThat(result).isNotNull();
+
+        try {
+            targetGraph.begin(TxnType.READ);
+
+            // class got added
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    RDF.type.asNode(),
+                                    RDFS.Class.asNode()))
+                    .isTrue();
+
+            // relation to existing superclass remains
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    RDFS.subClassOf.asNode(),
+                                    NodeFactory.createURI(ex + "Base")))
+                    .isTrue();
+
+            // superclass was skipped for reinsertion: UUID unchanged
+            var existingBaseUuidAfter =
+                    targetModel
+                            .getProperty(
+                                    targetModel.getResource(ex + "Base"),
+                                    targetModel.createProperty(rdfa))
+                            .getString();
+
+            assertThat(existingBaseUuidAfter).isEqualTo(existingBaseUuidBefore);
+
+            // and still exactly one UUID triple for Base
+            var baseUuidStatements =
+                    targetModel
+                            .listStatements(
+                                    targetModel.getResource(ex + "Base"),
+                                    targetModel.createProperty(rdfa),
+                                    (RDFNode) null)
+                            .toList();
+            assertThat(baseUuidStatements).hasSize(1);
+
+        } finally {
+            targetGraph.end();
+        }
+    }
+
+    @Test
+    void extendClass_whenNoCorePackagePresent_addsClassWithoutBelongsToCategory() {
+        // arrange
+        var sourceGraphId = new GraphIdentifier("source-ds-3", "http://example.org/source3");
+        var targetGraphId = new GraphIdentifier("target-ds-3", "http://example.org/target3");
+        var classUuid = "2c9916ee-a33e-4a2a-a0b8-ad1ba1322ffd"; // ex:Child
+
+        var sourceFile = readMultipartFileFromFile(PATH, "class-extension-source.ttl");
+        var sourceGraphSource =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(sourceFile)
+                        .setGraphName(sourceGraphId.graphUri())
+                        .build();
+        databasePort.createGraph(sourceGraphId, sourceGraphSource.graph());
+
+        // target has no package containing "Core"
+        var targetFile = readMultipartFileFromFile(PATH, "class-extension-target-no-core.ttl");
+        var targetGraphSource =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(targetFile)
+                        .setGraphName(targetGraphId.graphUri())
+                        .build();
+        databasePort.createGraph(targetGraphId, targetGraphSource.graph());
+
+        // act
+        var result = classExtensionService.extendClass(sourceGraphId, classUuid, targetGraphId);
+
+        // assert
+        assertThat(result).isNotNull();
+
+        var targetGraph = databasePort.getGraphWithContext(targetGraphId).getRdfGraph();
+        var targetModel = ModelFactory.createModelForGraph(targetGraph);
+
+        var ex = "http://example.org#";
+        var cimsBelongsToCategory =
+                "http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#belongsToCategory";
+
+        try {
+            targetGraph.begin(TxnType.READ);
+
+            // class still gets inserted
+            assertThat(
+                            targetGraph.contains(
+                                    NodeFactory.createURI(ex + "Child"),
+                                    RDF.type.asNode(),
+                                    RDFS.Class.asNode()))
+                    .isTrue();
+
+            // with no core package, service should not attach belongsToCategory
+            var categoryStatements =
+                    targetModel
+                            .listStatements(
+                                    targetModel.getResource(ex + "Child"),
+                                    targetModel.createProperty(cimsBelongsToCategory),
+                                    (RDFNode) null)
+                            .toList();
+            assertThat(categoryStatements).isEmpty();
+
+        } finally {
+            targetGraph.end();
+        }
+    }
+}

--- a/backend/src/test/java/org/rdfarchitect/services/extension/ClassExtensionServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/extension/ClassExtensionServiceTest.java
@@ -31,6 +31,7 @@ import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rdfarchitect.api.dto.ClassMapper;
+import org.rdfarchitect.config.SchemaConfig;
 import org.rdfarchitect.context.SessionContext;
 import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.database.GraphIdentifier;
@@ -56,7 +57,8 @@ class ClassExtensionServiceTest {
     @BeforeEach
     void setUp() {
         SessionContext.setSessionId(UUID.randomUUID().toString());
-        databasePort = new InMemoryDatabaseAdapter(new InMemoryDatabaseImpl());
+        var schemaConfig = new SchemaConfig();
+        databasePort = new InMemoryDatabaseAdapter(new InMemoryDatabaseImpl(), schemaConfig);
         var mockChangeLogService = mock(ChangeLogService.class);
         classExtensionService =
                 new ClassExtensionService(databasePort, classMapper, mockChangeLogService);

--- a/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-source.ttl
+++ b/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-source.ttl
@@ -1,0 +1,17 @@
+PREFIX ex:   <http://example.org#>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cims: <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#>
+
+ex:Base
+    rdf:type rdfs:Class ;
+    rdfs:label "Base"@en ;
+    cims:stereotype <http://iec.ch/TC57/NonStandard/UML#concrete> ;
+    ex:uuid "22222222-2222-2222-2222-222222222222" .
+
+ex:Child
+    rdf:type rdfs:Class ;
+    rdfs:label "Child"@en ;
+    rdfs:subClassOf ex:Base ;
+    cims:stereotype <http://iec.ch/TC57/NonStandard/UML#concrete> ;
+    ex:uuid "2c9916ee-a33e-4a2a-a0b8-ad1ba1322ffd" .

--- a/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-target-no-core.ttl
+++ b/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-target-no-core.ttl
@@ -1,0 +1,9 @@
+PREFIX ex:   <http://example.org#>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cims: <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#>
+
+ex:Wires
+    rdf:type cims:ClassCategory ;
+    rdfs:label "Wires"@en ;
+    ex:uuid "e118a879-da21-4910-a9ca-c7a41b68b1c1" .

--- a/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-target-with-core.ttl
+++ b/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-target-with-core.ttl
@@ -1,0 +1,9 @@
+PREFIX ex:   <http://example.org#>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cims: <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#>
+
+ex:CorePackage
+    rdf:type cims:ClassCategory ;
+    rdfs:label "Core"@en ;
+    ex:uuid "c5349024-0f39-4681-a54a-2c42e646520e" .

--- a/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-target-with-existing-class.ttl
+++ b/backend/src/test/java/org/rdfarchitect/services/extension/class-extension-target-with-existing-class.ttl
@@ -1,0 +1,15 @@
+PREFIX ex:   <http://example.org#>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cims: <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#>
+
+ex:CorePackage
+    rdf:type cims:ClassCategory ;
+    rdfs:label "Core"@en ;
+    ex:uuid "99999999-9999-9999-9999-999999999999" .
+
+ex:Base
+    rdf:type rdfs:Class ;
+    rdfs:label "Base"@en ;
+    ex:uuid "33333333-3333-3333-3333-333333333333" ;
+    cims:belongsToCategory ex:CorePackage .

--- a/frontend/src/lib/api/backend.js
+++ b/frontend/src/lib/api/backend.js
@@ -486,6 +486,17 @@ export class BackendConnection {
         });
     }
 
+    async extendClass(datasetName, graphURI, classUUID, body) {
+        let url = `${PUBLIC_BACKEND_URL}/datasets/${encodeURIComponent(datasetName)}/graphs/${encodeURIComponent(graphURI)}/classes/${encodeURIComponent(classUUID)}/extend`;
+        return await fetch(url, {
+            method: "POST",
+            mode: "cors",
+            headers: new Headers({ "Content-Type": "application/json" }),
+            body: JSON.stringify(body),
+            credentials: "include",
+        });
+    }
+
     async getCustomDiagramsForGraph(datasetName, graphURI) {
         let url = `${PUBLIC_BACKEND_URL}/datasets/${encodeURIComponent(datasetName)}/graphs/${encodeURIComponent(graphURI)}/diagrams`;
         return await fetch(url, {

--- a/frontend/src/lib/rendering/svelteflow/components/SvelteFlowClassContextMenu.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/SvelteFlowClassContextMenu.svelte
@@ -21,6 +21,7 @@
         faAnglesDown,
         faAnglesUp,
         faAngleUp,
+        faFileExport,
         faLayerGroup,
         faMinus,
         faTrash,
@@ -37,6 +38,7 @@
     } from "./contextMenuUtils.js";
     import DeleteDependenciesDialog from "../../../../routes/delete-relations-dialog/DeleteDependenciesDialog.svelte";
     import RemoveFromDiagramDialog from "../../../../routes/mainpage/packageNavigation/custom-diagram-dialogs/RemoveFromDiagramDialog.svelte";
+    import ExtendClassDialog from "../../../../routes/mainpage/packageNavigation/ExtendClassDialog.svelte";
 
     let {
         request = null,
@@ -54,8 +56,9 @@
 
     let triggerRef = $state(null);
     let open = $state(false);
-    let deleteClassTarget = $state(null);
+    let dialogClass = $state(null);
     let showDeleteDependenciesDialog = $state(false);
+    let showExtendClassDialog = $state(false);
     let showRemoveFromDiagramDialog = $state(false);
 
     let triggerStyle = $derived(getContextMenuTriggerStyle(request));
@@ -83,7 +86,7 @@
         if (!contextMenuClass) {
             return;
         }
-        deleteClassTarget = contextMenuClass;
+        dialogClass = contextMenuClass;
         showDeleteDependenciesDialog = true;
         onClose();
     }
@@ -93,6 +96,15 @@
             return;
         }
         showRemoveFromDiagramDialog = true;
+        onClose();
+    }
+
+    function openExtendClassDialog() {
+        if (!contextMenuClass) {
+            return;
+        }
+        dialogClass = contextMenuClass;
+        showExtendClassDialog = true;
         onClose();
     }
 
@@ -139,6 +151,12 @@
         {disabled}
     />
     <ContextMenu.Content>
+        <ContextMenu.Item.Button
+            onSelect={openExtendClassDialog}
+            faIcon={faFileExport}
+        >
+            Extend Class
+        </ContextMenu.Item.Button>
         <ContextMenu.SubMenu.Root>
             <ContextMenu.SubMenu.Trigger faIcon={faLayerGroup}>
                 Move
@@ -219,7 +237,13 @@
     bind:showDialog={showDeleteDependenciesDialog}
     {datasetName}
     {graphUri}
-    resourceUuid={deleteClassTarget?.uuid}
+    resourceUuid={dialogClass?.uuid}
+/>
+<ExtendClassDialog
+    {datasetName}
+    {graphUri}
+    classUUID={dialogClass?.uuid}
+    bind:showDialog={showExtendClassDialog}
 />
 <RemoveFromDiagramDialog
     bind:showDialog={showRemoveFromDiagramDialog}

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -427,7 +427,7 @@
         bec.updateClassPositions(
             editorState.selectedDataset.getValue(),
             editorState.selectedGraph.getValue(),
-            editorState.selectedPackageUUID.getValue(),
+            editorState.selectedDiagram.getProperty("id"),
             classPositionDTOList,
         );
     }

--- a/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
@@ -32,13 +32,13 @@
     import { DiagramType, editorState } from "$lib/sharedState.svelte.js";
     import { shortenIri } from "$lib/utils/iri.js";
 
+    import ExtendClassDialog from "./ExtendClassDialog.svelte";
     import AddToDatasetDiagramDialog from "./custom-diagram-dialogs/AddToDatasetDiagramDialog.svelte";
     import AddToGraphDiagramDialog from "./custom-diagram-dialogs/AddToGraphDiagramDialog.svelte";
     import RemoveFromDiagramDialog from "./custom-diagram-dialogs/RemoveFromDiagramDialog.svelte";
     import { isSelectedClass } from "./packageNavigationUtils.svelte.js";
     import DeleteDependenciesDialog from "../../delete-relations-dialog/DeleteDependenciesDialog.svelte";
     import SHACLClassSpecificPopUp from "../../shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte";
-    import ExtendClassDialog from "./ExtendClassDialog.svelte";
 
     let {
         datasetNavEntry,
@@ -225,6 +225,6 @@
 <ExtendClassDialog
     datasetName={datasetNavEntry.id}
     graphUri={graphNavEntry.id}
-    classUuid={classNavEntry.id}
+    classUUID={classNavEntry.id}
     bind:showDialog={showExtendClassDialog}
 />

--- a/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
@@ -32,10 +32,10 @@
     import { DiagramType, editorState } from "$lib/sharedState.svelte.js";
     import { shortenIri } from "$lib/utils/iri.js";
 
-    import ExtendClassDialog from "./ExtendClassDialog.svelte";
     import AddToDatasetDiagramDialog from "./custom-diagram-dialogs/AddToDatasetDiagramDialog.svelte";
     import AddToGraphDiagramDialog from "./custom-diagram-dialogs/AddToGraphDiagramDialog.svelte";
     import RemoveFromDiagramDialog from "./custom-diagram-dialogs/RemoveFromDiagramDialog.svelte";
+    import ExtendClassDialog from "./ExtendClassDialog.svelte";
     import { isSelectedClass } from "./packageNavigationUtils.svelte.js";
     import DeleteDependenciesDialog from "../../delete-relations-dialog/DeleteDependenciesDialog.svelte";
     import SHACLClassSpecificPopUp from "../../shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte";

--- a/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
@@ -20,6 +20,7 @@
     import {
         faArrowUpRightFromSquare,
         faDiagramProject,
+        faFileExport,
         faMinus,
         faObjectGroup,
         faTrash,
@@ -37,6 +38,7 @@
     import { isSelectedClass } from "./packageNavigationUtils.svelte.js";
     import DeleteDependenciesDialog from "../../delete-relations-dialog/DeleteDependenciesDialog.svelte";
     import SHACLClassSpecificPopUp from "../../shacl/shaclclassspecific/SHACLClassSpecificPopUp.svelte";
+    import ExtendClassDialog from "./ExtendClassDialog.svelte";
 
     let {
         datasetNavEntry,
@@ -51,6 +53,7 @@
 
     let showDeleteDependenciesDialog = $state(false);
     let showSHACLDialog = $state(false);
+    let showExtendClassDialog = $state(false);
     let showAddToGraphDiagramDialog = $state(false);
     let showAddToDatasetDiagramDialog = $state(false);
     let showRemoveFromDiagramDialog = $state(false);
@@ -132,6 +135,15 @@
         >
             Constraints
         </ContextMenu.Item.Button>
+        <ContextMenu.Separator />
+        <ContextMenu.Item.Button
+            onSelect={() => {
+                showExtendClassDialog = true;
+            }}
+            faIcon={faFileExport}
+        >
+            Extend Class
+        </ContextMenu.Item.Button>
         {#if !diagramId}
             <ContextMenu.Item.Button
                 onSelect={() => {
@@ -208,4 +220,11 @@
     {diagramId}
     classId={classNavEntry.id}
     classLabel={classNavEntry.label}
+/>
+
+<ExtendClassDialog
+    datasetName={datasetNavEntry.id}
+    graphUri={graphNavEntry.id}
+    classUuid={classNavEntry.id}
+    bind:showDialog={showExtendClassDialog}
 />

--- a/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
@@ -1,0 +1,72 @@
+<!--
+  -    Copyright (c) 2024-2026 SOPTIM AG
+  -
+  -    Licensed under the Apache License, Version 2.0 (the "License");
+  -    you may not use this file except in compliance with the License.
+  -    You may obtain a copy of the License at
+  -
+  -        http://www.apache.org/licenses/LICENSE-2.0
+  -
+  -    Unless required by applicable law or agreed to in writing, software
+  -    distributed under the License is distributed on an "AS IS" BASIS,
+  -    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -    See the License for the specific language governing permissions and
+  -    limitations under the License.
+  -
+  -->
+
+<script>
+    import { BackendConnection } from "$lib/api/backend.js";
+    import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
+    import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { editorState } from "$lib/sharedState.svelte.js";
+
+    let {
+        showDialog = $bindable(),
+        datasetName,
+        graphUri,
+        classUUID,
+    } = $props();
+
+    let bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
+
+    let selectedDatasetName = $state(null);
+    let selectedGraphURI = $state(null);
+
+    let disableSubmit = $derived(
+        !selectedDatasetName ||
+        !selectedGraphURI
+    );
+
+    async function extendClass() {
+        let body = {
+            datasetName: selectedDatasetName,
+            graphUri: selectedGraphURI,
+        }
+        try {
+            const newClass = await bec.extendClass(datasetName, graphUri, classUUID, body);
+            editorState.selectedDataset.updateValue(selectedDatasetName);
+            editorState.selectedGraph.updateValue(selectedGraphURI);
+            editorState.selectedPackageUUID.updateValue(newClass.package.uuid);
+        } catch (e) {
+            console.log(e);
+        }
+    }
+
+</script>
+
+<ActionDialog
+    bind:showDialog
+    primaryLabel="Extend Class"
+    onPrimary={extendClass}
+    disablePrimary={disableSubmit}
+    title="Extend Class"
+>
+    <DatasetAndGraphSelection
+        bind:dataset={selectedDatasetName}
+        bind:graph={selectedGraphURI}
+        allowSelectionOfReadonlyDatasets={false}
+        displayAsCard={false}
+    />
+</ActionDialog>

--- a/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
@@ -20,7 +20,11 @@
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
-    import { DiagramType, editorState, forceReloadTrigger } from "$lib/sharedState.svelte.js";
+    import {
+        DiagramType,
+        editorState,
+        forceReloadTrigger,
+    } from "$lib/sharedState.svelte.js";
 
     let {
         showDialog = $bindable(),

--- a/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
@@ -34,26 +34,30 @@
     let selectedDatasetName = $state(null);
     let selectedGraphURI = $state(null);
 
-    let disableSubmit = $derived(
-        !selectedDatasetName ||
-        !selectedGraphURI
-    );
+    let disableSubmit = $derived(!selectedDatasetName || !selectedGraphURI);
 
     async function extendClass() {
         let body = {
             datasetName: selectedDatasetName,
             graphUri: selectedGraphURI,
-        }
+        };
         try {
-            const newClass = await bec.extendClass(datasetName, graphUri, classUUID, body);
+            const response = await bec.extendClass(
+                datasetName,
+                graphUri,
+                classUUID,
+                body,
+            );
+            const newClass = await response.json();
             editorState.selectedDataset.updateValue(selectedDatasetName);
             editorState.selectedGraph.updateValue(selectedGraphURI);
-            editorState.selectedPackageUUID.updateValue(newClass.package.uuid);
+            editorState.selectedPackageUUID.updateValue(
+                newClass.belongsToCategory ?? "default",
+            );
         } catch (e) {
             console.log(e);
         }
     }
-
 </script>
 
 <ActionDialog
@@ -63,10 +67,15 @@
     disablePrimary={disableSubmit}
     title="Extend Class"
 >
-    <DatasetAndGraphSelection
-        bind:dataset={selectedDatasetName}
-        bind:graph={selectedGraphURI}
-        allowSelectionOfReadonlyDatasets={false}
-        displayAsCard={false}
-    />
+    <div class="space-y-4 px-3 py-3">
+        <p class="text-default-text w-2/3 text-sm leading-relaxed">
+            Please select the graph that you want to extend this class in
+        </p>
+        <DatasetAndGraphSelection
+            bind:dataset={selectedDatasetName}
+            bind:graph={selectedGraphURI}
+            allowSelectionOfReadonlyDatasets={false}
+            displayAsCard={false}
+        />
+    </div>
 </ActionDialog>

--- a/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
@@ -20,7 +20,7 @@
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
-    import { editorState } from "$lib/sharedState.svelte.js";
+    import { DiagramType, editorState, forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
     let {
         showDialog = $bindable(),
@@ -51,9 +51,11 @@
             const newClass = await response.json();
             editorState.selectedDataset.updateValue(selectedDatasetName);
             editorState.selectedGraph.updateValue(selectedGraphURI);
-            editorState.selectedPackageUUID.updateValue(
-                newClass.belongsToCategory ?? "default",
-            );
+            editorState.selectedDiagram.updateValue({
+                type: DiagramType.PACKAGE,
+                id: newClass.belongsToCategory,
+            });
+            forceReloadTrigger.trigger();
         } catch (e) {
             console.log(e);
         }


### PR DESCRIPTION
## Description

Added the option of automatically extending a class in another profile, which copies stubs of that class and all its superclasses to the new profile.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
