### PR TITLE
feat(toast): add toast notifications for user feedback across app (RDFA-243)

### DIFF
--- a/frontend/src/lib/GraphExport.svelte
+++ b/frontend/src/lib/GraphExport.svelte
@@ -25,6 +25,7 @@
     import { DropdownMenu } from "$lib/components/bitsui/dropdown/index";
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { ReactiveOntology } from "$lib/models/reactive/models/ontology/reactive-ontology.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
     import { saveFile, supportedRDFMediaTypes } from "$lib/utils/fileUtils.ts";
@@ -159,13 +160,28 @@
         }
         try {
             const response = await fetchGraphFile(getAPIRoute);
+            if (!response.ok) {
+                toastStore.error(
+                    "Export failed",
+                    `Could not export "${graphURI}".`,
+                );
+                return;
+            }
             const blob = await response.blob();
             const suggestedFilename = response.headers.get(
                 "content-disposition",
             );
             saveFile(blob, suggestedFilename, selectedMediaType);
+            toastStore.success(
+                "Export ready",
+                `"${graphURI}" downloaded as ${selectedMediaType.name}.`,
+            );
         } catch (e) {
             console.error("Failed to download graph:", e);
+            toastStore.error(
+                "Export failed",
+                "An unexpected error occurred while exporting.",
+            );
         } finally {
             showDialog = false;
         }

--- a/frontend/src/lib/GraphExport.svelte
+++ b/frontend/src/lib/GraphExport.svelte
@@ -151,11 +151,18 @@
                     ontology.entries.append(entry);
                 }
             }
-            await bec.putOntology(
+            const ontologyRes = await bec.putOntology(
                 selectedDatasetName,
                 graphURI,
                 ontology.getPlainObject(),
             );
+            if (ontologyRes && ontologyRes.ok === false) {
+                toastStore.error(
+                    "Profile header update failed",
+                    "Could not persist the generated profile header entries; export aborted.",
+                );
+                return;
+            }
             forceReloadTrigger.trigger();
         }
         try {

--- a/frontend/src/lib/actions/editingActions.js
+++ b/frontend/src/lib/actions/editingActions.js
@@ -1,0 +1,77 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+/**
+ * Shared actions for toggling the read-only state of a dataset.
+ *
+ * Each function performs the API call, surfaces a success or error toast,
+ * and returns `true` when the write succeeded. Reactive state updates that
+ * are local to a call site (refreshing local `readonly` flags, triggering
+ * editor state, etc.) remain the caller's responsibility.
+ */
+
+import { BackendConnection } from "$lib/api/backend.js";
+import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
+
+const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
+
+/**
+ * Make the dataset editable. Toasts on success and failure.
+ *
+ * @param {string} datasetName
+ * @returns {Promise<boolean>} `true` when the dataset is now editable.
+ */
+export async function enableEditing(datasetName) {
+    if (!datasetName) return false;
+    const res = await bec.enableEditing(datasetName);
+    if (res && res.ok === false) {
+        toastStore.error(
+            "Could not enable editing",
+            `Dataset "${datasetName}" remains read-only.`,
+        );
+        return false;
+    }
+    toastStore.success(
+        "Editing enabled",
+        `Dataset "${datasetName}" is now editable.`,
+    );
+    return true;
+}
+
+/**
+ * Mark the dataset read-only. Toasts on success and failure.
+ *
+ * @param {string} datasetName
+ * @returns {Promise<boolean>} `true` when the dataset is now read-only.
+ */
+export async function disableEditing(datasetName) {
+    if (!datasetName) return false;
+    const res = await bec.disableEditing(datasetName);
+    if (res && res.ok === false) {
+        toastStore.error(
+            "Could not disable editing",
+            `Dataset "${datasetName}" remains editable.`,
+        );
+        return false;
+    }
+    toastStore.success(
+        "Editing disabled",
+        `Dataset "${datasetName}" is now read-only.`,
+    );
+    return true;
+}

--- a/frontend/src/lib/actions/versionControlActions.js
+++ b/frontend/src/lib/actions/versionControlActions.js
@@ -16,6 +16,7 @@
  */
 
 import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 import { editorState } from "$lib/sharedState.svelte.js";
 
 function resolveTargets(datasetName, graphURI) {
@@ -71,6 +72,7 @@ export async function undo(datasetName, graphURI) {
     }
 
     console.log("Undo failed.");
+    toastStore.error("Undo failed", "Could not undo the last change.");
     return false;
 }
 
@@ -113,5 +115,6 @@ export async function redo(datasetName, graphURI) {
     }
 
     console.log("Redo failed.");
+    toastStore.error("Redo failed", "Could not redo the change.");
     return false;
 }

--- a/frontend/src/lib/api/backendConnectionMonitor.svelte.js
+++ b/frontend/src/lib/api/backendConnectionMonitor.svelte.js
@@ -1,0 +1,137 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+/**
+ * Backend connection monitor.
+ *
+ * Installs a wrapper around `window.fetch` that detects network-level
+ * failures (TypeError from `fetch`) on requests to the backend and surfaces
+ * them as a single sticky toast. HTTP error responses (4xx / 5xx) are NOT
+ * intercepted — those are application-level errors and remain the
+ * responsibility of the individual call site.
+ *
+ * On the first request that succeeds after an offline period the sticky toast
+ * is dismissed and a short "connection restored" toast is shown.
+ */
+
+import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
+
+/** Reactive connection state — components can read `.isOffline` if needed. */
+export const backendConnection = $state({ isOffline: false });
+
+let offlineToastId = null;
+let installed = false;
+
+/**
+ * Resolve the URL of a `fetch()` first argument to a string we can pattern-match.
+ * `fetch` accepts string | URL | Request, so we have to handle all three.
+ */
+function resolveUrl(input) {
+    if (typeof input === "string") return input;
+    if (input instanceof URL) return input.href;
+    if (typeof Request !== "undefined" && input instanceof Request) {
+        return input.url;
+    }
+    return "";
+}
+
+function isBackendUrl(url) {
+    if (!PUBLIC_BACKEND_URL) return false;
+    return url.startsWith(PUBLIC_BACKEND_URL);
+}
+
+function isNetworkError(error) {
+    if (!error) return false;
+    if (error.name === "AbortError") return false;
+    return error instanceof TypeError;
+}
+
+function markOffline() {
+    backendConnection.isOffline = true;
+    if (offlineToastId !== null) return;
+    offlineToastId = toastStore.error(
+        "Backend unreachable",
+        "Could not reach the backend. Check that the server is running and try again.",
+        { duration: 0 },
+    );
+}
+
+function markOnline() {
+    if (!backendConnection.isOffline) return;
+    backendConnection.isOffline = false;
+    if (offlineToastId !== null) {
+        toastStore.dismiss(offlineToastId);
+        offlineToastId = null;
+    }
+    toastStore.success(
+        "Backend connection restored",
+        "The connection to the backend has been restored.",
+    );
+}
+
+/**
+ * Install the global fetch interceptor. Safe to call multiple times.
+ * Returns an `uninstall` function.
+ */
+export function installBackendFetchInterceptor() {
+    if (typeof window === "undefined") return () => {};
+    if (installed) return () => {};
+    installed = true;
+
+    const originalFetch = window.fetch.bind(window);
+
+    window.fetch = async function interceptedFetch(input, init) {
+        const url = resolveUrl(input);
+        const watched = isBackendUrl(url);
+
+        try {
+            const response = await originalFetch(input, init);
+            if (watched) {
+                markOnline();
+            }
+            return response;
+        } catch (error) {
+            if (watched && isNetworkError(error)) {
+                markOffline();
+            }
+            throw error;
+        }
+    };
+
+    return function uninstall() {
+        if (!installed) return;
+        window.fetch = originalFetch;
+        installed = false;
+    };
+}
+
+/**
+ * Active probe — call this on app start so a cold-start with the backend
+ * already down surfaces the toast before the user clicks anything.
+ */
+export async function probeBackendConnection() {
+    if (!PUBLIC_BACKEND_URL || typeof window === "undefined") return;
+    try {
+        await fetch(`${PUBLIC_BACKEND_URL}/datasets`, {
+            method: "GET",
+            credentials: "include",
+        });
+    } catch {
+        // Ignore errors here; the interceptor will mark offline if it's a network error.
+    }
+}

--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -1,0 +1,118 @@
+<!--
+  -    Copyright (c) 2024-2026 SOPTIM AG
+  -
+  -    Licensed under the Apache License, Version 2.0 (the "License");
+  -    you may not use this file except in compliance with the License.
+  -    You may obtain a copy of the License at
+  -
+  -        http://www.apache.org/licenses/LICENSE-2.0
+  -
+  -    Unless required by applicable law or agreed to in writing, software
+  -    distributed under the License is distributed on an "AS IS" BASIS,
+  -    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -    See the License for the specific language governing permissions and
+  -    limitations under the License.
+  -->
+
+<script>
+    import {
+        faCircleCheck,
+        faCircleExclamation,
+        faCircleInfo,
+        faTriangleExclamation,
+        faXmark,
+    } from "@fortawesome/free-solid-svg-icons";
+    import { Fa } from "svelte-fa";
+
+    /**
+     * A single toast notification card. Rendered by ToastContainer; not
+     * intended for direct use at call sites — use {@link
+     * $lib/eventhandling/toastStore.svelte.js} instead.
+     */
+
+    const { toast, onDismiss = () => {} } = $props();
+
+    const VARIANTS = {
+        success: {
+            icon: faCircleCheck,
+            iconClass: "text-green-text",
+            surfaceClass: "toast-surface-success",
+        },
+        error: {
+            icon: faCircleExclamation,
+            iconClass: "text-red-text",
+            surfaceClass: "toast-surface-error",
+        },
+        info: {
+            icon: faCircleInfo,
+            iconClass: "text-blue",
+            surfaceClass: "toast-surface-info",
+        },
+        warning: {
+            icon: faTriangleExclamation,
+            iconClass: "text-orange",
+            surfaceClass: "toast-surface-warning",
+        },
+    };
+
+    const config = $derived(VARIANTS[toast.variant] ?? VARIANTS.info);
+
+    const role = $derived(
+        toast.variant === "error" || toast.variant === "warning"
+            ? "alert"
+            : "status",
+    );
+</script>
+
+<div
+    class="toast-card {config.surfaceClass} pointer-events-auto flex
+        w-80 max-w-[90vw] items-start gap-3 rounded-lg border p-3 shadow-md"
+    {role}
+    aria-live={role === "alert" ? "assertive" : "polite"}
+>
+    <Fa icon={config.icon} class="{config.iconClass} mt-0.5 shrink-0" />
+    <div class="min-w-0 flex-1 text-sm leading-snug">
+        <p class="font-medium break-words">{toast.title}</p>
+        {#if toast.message}
+            <p class="text-default-text/80 mt-0.5 break-words">
+                {toast.message}
+            </p>
+        {/if}
+    </div>
+    <button
+        type="button"
+        class="text-text-subtle hover:text-default-text -m-1 cursor-pointer
+            rounded p-1 transition-colors"
+        aria-label="Dismiss notification"
+        onclick={() => onDismiss(toast.id)}
+    >
+        <Fa icon={faXmark} />
+    </button>
+</div>
+
+<style>
+    .toast-card {
+        background: var(--color-white);
+        color: var(--color-default-text);
+    }
+
+    .toast-surface-success {
+        background: var(--color-green-background);
+        border-color: var(--color-green-border);
+    }
+
+    .toast-surface-error {
+        background: var(--color-red-background);
+        border-color: var(--color-red-border);
+    }
+
+    .toast-surface-info {
+        background: var(--color-lightblue);
+        border-color: var(--color-blue);
+    }
+
+    .toast-surface-warning {
+        background: var(--color-white);
+        border-color: var(--color-orange);
+    }
+</style>

--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -22,7 +22,10 @@
         faTriangleExclamation,
         faXmark,
     } from "@fortawesome/free-solid-svg-icons";
+    import { fly } from "svelte/transition";
     import { Fa } from "svelte-fa";
+
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     /**
      * A single toast notification card. Rendered by ToastContainer; not
@@ -62,13 +65,30 @@
             ? "alert"
             : "status",
     );
+
+    const showProgress = $derived(toast.duration > 0);
+
+    function pause() {
+        toastStore.pause(toast.id);
+    }
+
+    function resume() {
+        toastStore.resume(toast.id);
+    }
 </script>
 
 <div
-    class="toast-card {config.surfaceClass} pointer-events-auto flex
-        w-80 max-w-[90vw] items-start gap-3 rounded-lg border p-3 shadow-md"
+    class="toast-card {config.surfaceClass} pointer-events-auto relative flex
+        w-80 max-w-[90vw] items-start gap-3 overflow-hidden rounded-lg border
+        p-3 shadow-md"
     {role}
     aria-live={role === "alert" ? "assertive" : "polite"}
+    in:fly={{ x: 24, duration: 200 }}
+    out:fly={{ x: 24, duration: 150 }}
+    onmouseenter={pause}
+    onmouseleave={resume}
+    onfocusin={pause}
+    onfocusout={resume}
 >
     <Fa icon={config.icon} class="{config.iconClass} mt-0.5 shrink-0" />
     <div class="min-w-0 flex-1 text-sm leading-snug">
@@ -88,31 +108,76 @@
     >
         <Fa icon={faXmark} />
     </button>
+    {#if showProgress}
+        <div
+            class="toast-progress"
+            style:animation-duration="{toast.duration}ms"
+            aria-hidden="true"
+        ></div>
+    {/if}
 </div>
 
 <style>
     .toast-card {
         background: var(--color-white);
         color: var(--color-default-text);
+        --toast-progress-color: var(--color-default-text);
     }
 
     .toast-surface-success {
         background: var(--color-green-background);
         border-color: var(--color-green-border);
+        --toast-progress-color: var(--color-green-border);
     }
 
     .toast-surface-error {
         background: var(--color-red-background);
         border-color: var(--color-red-border);
+        --toast-progress-color: var(--color-red-border);
     }
 
     .toast-surface-info {
         background: var(--color-lightblue);
         border-color: var(--color-blue);
+        --toast-progress-color: var(--color-blue);
     }
 
     .toast-surface-warning {
         background: var(--color-white);
         border-color: var(--color-orange);
+        --toast-progress-color: var(--color-orange);
+    }
+
+    .toast-progress {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        height: 3px;
+        width: 100%;
+        background: var(--toast-progress-color);
+        transform-origin: left center;
+        animation-name: toast-progress-shrink;
+        animation-timing-function: linear;
+        animation-fill-mode: forwards;
+    }
+
+    .toast-card:hover .toast-progress {
+        animation-play-state: paused;
+    }
+
+    @keyframes toast-progress-shrink {
+        from {
+            transform: scaleX(1);
+        }
+        to {
+            transform: scaleX(0);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .toast-progress {
+            animation: none;
+            opacity: 0.4;
+        }
     }
 </style>

--- a/frontend/src/lib/components/ToastContainer.svelte
+++ b/frontend/src/lib/components/ToastContainer.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <div
-    class="pointer-events-none fixed top-14 right-4 z-50 flex flex-col gap-2"
+    class="pointer-events-none fixed right-4 bottom-4 z-50 flex flex-col-reverse gap-2"
     aria-label="Notifications"
 >
     {#each toasts as toast (toast.id)}

--- a/frontend/src/lib/components/ToastContainer.svelte
+++ b/frontend/src/lib/components/ToastContainer.svelte
@@ -1,0 +1,41 @@
+<!--
+  -    Copyright (c) 2024-2026 SOPTIM AG
+  -
+  -    Licensed under the Apache License, Version 2.0 (the "License");
+  -    you may not use this file except in compliance with the License.
+  -    You may obtain a copy of the License at
+  -
+  -        http://www.apache.org/licenses/LICENSE-2.0
+  -
+  -    Unless required by applicable law or agreed to in writing, software
+  -    distributed under the License is distributed on an "AS IS" BASIS,
+  -    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -    See the License for the specific language governing permissions and
+  -    limitations under the License.
+  -->
+
+<script>
+    import Toast from "$lib/components/Toast.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
+
+    /**
+     * Global toast outlet. Mount exactly once near the root of the app
+     * (see `src/routes/+layout.svelte`). Toasts are emitted through
+     * {@link $lib/eventhandling/toastStore.svelte.js}.
+     */
+
+    const toasts = $derived(toastStore.getToasts());
+
+    function dismiss(id) {
+        toastStore.dismiss(id);
+    }
+</script>
+
+<div
+    class="pointer-events-none fixed top-14 right-4 z-50 flex flex-col gap-2"
+    aria-label="Notifications"
+>
+    {#each toasts as toast (toast.id)}
+        <Toast {toast} onDismiss={dismiss} />
+    {/each}
+</div>

--- a/frontend/src/lib/eventhandling/toastStore.svelte.js
+++ b/frontend/src/lib/eventhandling/toastStore.svelte.js
@@ -1,0 +1,116 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+/**
+ * Lightweight toast notification store.
+ *
+ * Toasts are short-lived, non-blocking event notifications surfaced in a fixed
+ * region of the viewport. Use them for confirmations and recoverable failures
+ * where opening a dialog would be excessive.
+ *
+ * The store is a singleton consumed by ToastContainer.svelte (mounted once in
+ * `+layout.svelte`) and by call sites via {@link toastStore}.
+ *
+ * @typedef {"success" | "error" | "info" | "warning"} ToastVariant
+ *
+ * @typedef {{
+ *   id: number,
+ *   variant: ToastVariant,
+ *   title: string,
+ *   message?: string,
+ *   duration: number,
+ * }} Toast
+ */
+
+/** Default auto-dismiss duration in ms, per variant. `0` disables auto-dismiss. */
+const DEFAULT_DURATIONS = {
+    success: 3500,
+    info: 3500,
+    warning: 5000,
+    error: 6000,
+};
+const timeouts = new Map();
+
+/**
+ * Singleton facade. Methods read and mutate the reactive `toasts` state, so
+ * `getToasts()` is intentionally a function — components subscribe by reading
+ * it inside a `$derived`/effect.
+ */
+export const toastStore = {
+    getToasts: () => toasts,
+    show,
+    success: (title, message, options = {}) =>
+        show({ ...options, variant: "success", title, message }),
+    error: (title, message, options = {}) =>
+        show({ ...options, variant: "error", title, message }),
+    info: (title, message, options = {}) =>
+        show({ ...options, variant: "info", title, message }),
+    warning: (title, message, options = {}) =>
+        show({ ...options, variant: "warning", title, message }),
+    dismiss,
+    clear,
+};
+
+let toasts = $state([]);
+let nextId = 1;
+
+/**
+ * Show a toast and return its id (so callers can dismiss it manually).
+ *
+ * @param {{
+ *   variant?: ToastVariant,
+ *   title: string,
+ *   message?: string,
+ *   duration?: number,
+ * }} options
+ */
+function show({ variant = "info", title, message, duration } = {}) {
+    const id = nextId++;
+    const resolvedDuration = duration ?? DEFAULT_DURATIONS[variant] ?? 3500;
+    const toast = {
+        id,
+        variant,
+        title,
+        message,
+        duration: resolvedDuration,
+    };
+    toasts = [...toasts, toast];
+
+    if (resolvedDuration > 0 && typeof window !== "undefined") {
+        const handle = window.setTimeout(() => dismiss(id), resolvedDuration);
+        timeouts.set(id, handle);
+    }
+
+    return id;
+}
+
+function dismiss(id) {
+    const handle = timeouts.get(id);
+    if (handle !== undefined) {
+        clearTimeout(handle);
+        timeouts.delete(id);
+    }
+    toasts = toasts.filter(t => t.id !== id);
+}
+
+function clear() {
+    for (const handle of timeouts.values()) {
+        clearTimeout(handle);
+    }
+    timeouts.clear();
+    toasts = [];
+}

--- a/frontend/src/lib/eventhandling/toastStore.svelte.js
+++ b/frontend/src/lib/eventhandling/toastStore.svelte.js
@@ -43,7 +43,15 @@ const DEFAULT_DURATIONS = {
     warning: 5000,
     error: 6000,
 };
-const timeouts = new Map();
+
+/**
+ * Per-toast countdown state. The handle is the active `setTimeout` id (null
+ * while paused); `remaining` tracks how much of the duration is left so that
+ * pause/resume can be alternated repeatedly.
+ *
+ * @type {Map<number, { handle: number | null, startedAt: number, remaining: number }>}
+ */
+const timers = new Map();
 
 /**
  * Singleton facade. Methods read and mutate the reactive `toasts` state, so
@@ -62,6 +70,8 @@ export const toastStore = {
     warning: (title, message, options = {}) =>
         show({ ...options, variant: "warning", title, message }),
     dismiss,
+    pause,
+    resume,
     clear,
 };
 
@@ -92,25 +102,64 @@ function show({ variant = "info", title, message, duration } = {}) {
 
     if (resolvedDuration > 0 && typeof window !== "undefined") {
         const handle = window.setTimeout(() => dismiss(id), resolvedDuration);
-        timeouts.set(id, handle);
+        timers.set(id, {
+            handle,
+            startedAt: Date.now(),
+            remaining: resolvedDuration,
+        });
     }
 
     return id;
 }
 
+/**
+ * Halt the auto-dismiss countdown for a toast (e.g. while the user hovers it).
+ *
+ * @param {number} id
+ */
+function pause(id) {
+    const timer = timers.get(id);
+    if (!timer || timer.handle === null) return;
+    clearTimeout(timer.handle);
+    const elapsed = Date.now() - timer.startedAt;
+    timer.remaining = Math.max(0, timer.remaining - elapsed);
+    timer.handle = null;
+}
+
+/**
+ * Resume a previously paused auto-dismiss countdown.
+ *
+ * @param {number} id
+ */
+function resume(id) {
+    const timer = timers.get(id);
+    if (!timer || timer.handle !== null) return;
+    if (typeof window === "undefined") return;
+    if (timer.remaining <= 0) {
+        dismiss(id);
+        return;
+    }
+    timer.startedAt = Date.now();
+    timer.handle = window.setTimeout(() => dismiss(id), timer.remaining);
+}
+
 function dismiss(id) {
-    const handle = timeouts.get(id);
-    if (handle !== undefined) {
-        clearTimeout(handle);
-        timeouts.delete(id);
+    const timer = timers.get(id);
+    if (timer) {
+        if (timer.handle !== null) {
+            clearTimeout(timer.handle);
+        }
+        timers.delete(id);
     }
     toasts = toasts.filter(t => t.id !== id);
 }
 
 function clear() {
-    for (const handle of timeouts.values()) {
-        clearTimeout(handle);
+    for (const timer of timers.values()) {
+        if (timer.handle !== null) {
+            clearTimeout(timer.handle);
+        }
     }
-    timeouts.clear();
+    timers.clear();
     toasts = [];
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -29,8 +29,10 @@
     import { Menubar } from "$lib/components/bitsui/menubar";
     import BrandLogo from "$lib/components/BrandLogo.svelte";
     import ButtonControl from "$lib/components/ButtonControl.svelte";
+    import ToastContainer from "$lib/components/ToastContainer.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     import {
         editorState,
@@ -78,11 +80,22 @@
         if (!selectedDataset || !isDatasetReadOnly) {
             return;
         }
-        await bec.enableEditing(selectedDataset);
+        const res = await bec.enableEditing(selectedDataset);
+        if (res && res.ok === false) {
+            toastStore.error(
+                "Could not enable editing",
+                `Dataset "${selectedDataset}" remains read-only.`,
+            );
+            return;
+        }
         forceReloadTrigger.trigger();
         editorState.selectedClassUUID.trigger();
         editorState.selectedDiagram.trigger();
         isDatasetReadOnly = false;
+        toastStore.success(
+            "Editing enabled",
+            `You can now modify "${selectedDataset}".`,
+        );
     }
 
     async function loadSnapshot() {
@@ -91,6 +104,15 @@
             const res = await bec.loadSnapshot(base64Param);
             if (res.ok) {
                 await goto("/mainpage");
+                toastStore.success(
+                    "Snapshot loaded",
+                    "The shared snapshot has been loaded.",
+                );
+            } else {
+                toastStore.error(
+                    "Could not load snapshot",
+                    "The snapshot link is invalid or has expired.",
+                );
             }
         }
     }
@@ -146,14 +168,23 @@
             case "z":
                 event.preventDefault();
                 if (event.shiftKey) {
-                    if (canRedo && (await redo())) await reload();
+                    if (canRedo && (await redo())) {
+                        await reload();
+                        toastStore.info("Redone");
+                    }
                 } else {
-                    if (canUndo && (await undo())) await reload();
+                    if (canUndo && (await undo())) {
+                        await reload();
+                        toastStore.info("Undone");
+                    }
                 }
                 break;
             case "y":
                 event.preventDefault();
-                if (canRedo && (await redo())) await reload();
+                if (canRedo && (await redo())) {
+                    await reload();
+                    toastStore.info("Redone");
+                }
                 break;
         }
     }
@@ -220,3 +251,4 @@
         {@render children?.()}
     </div>
 </div>
+<ToastContainer />

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -26,6 +26,10 @@
         fetchCanRedo,
     } from "$lib/actions/versionControlActions.js";
     import { BackendConnection } from "$lib/api/backend.js";
+    import {
+        installBackendFetchInterceptor,
+        probeBackendConnection,
+    } from "$lib/api/backendConnectionMonitor.svelte.js";
     import { Menubar } from "$lib/components/bitsui/menubar";
     import BrandLogo from "$lib/components/BrandLogo.svelte";
     import ButtonControl from "$lib/components/ButtonControl.svelte";
@@ -73,6 +77,8 @@
     });
 
     onMount(() => {
+        installBackendFetchInterceptor();
+        probeBackendConnection();
         loadSnapshot();
     });
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -92,10 +92,6 @@
         editorState.selectedClassUUID.trigger();
         editorState.selectedDiagram.trigger();
         isDatasetReadOnly = false;
-        toastStore.success(
-            "Editing enabled",
-            `You can now modify "${selectedDataset}".`,
-        );
     }
 
     async function loadSnapshot() {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
     import "../app.css";
     import { onMount } from "svelte";
 
+    import { enableEditing } from "$lib/actions/editingActions.js";
     import {
         undo,
         fetchCanUndo,
@@ -86,12 +87,7 @@
         if (!selectedDataset || !isDatasetReadOnly) {
             return;
         }
-        const res = await bec.enableEditing(selectedDataset);
-        if (res && res.ok === false) {
-            toastStore.error(
-                "Could not enable editing",
-                `Dataset "${selectedDataset}" remains read-only.`,
-            );
+        if (!(await enableEditing(selectedDataset))) {
             return;
         }
         forceReloadTrigger.trigger();

--- a/frontend/src/routes/DatasetDeleteDialog.svelte
+++ b/frontend/src/routes/DatasetDeleteDialog.svelte
@@ -21,6 +21,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         forceReloadTrigger,
         editorState,
@@ -50,11 +51,24 @@
     async function deleteDataset() {
         try {
             if (datasetName) {
-                await bec.deleteDataset(datasetName);
+                const res = await bec.deleteDataset(datasetName);
+                if (res && res.ok === false) {
+                    toastStore.error(
+                        "Delete failed",
+                        `Could not delete dataset "${datasetName}".`,
+                    );
+                    return;
+                }
             }
 
             if (editorState.selectedDataset.getValue() === datasetName) {
                 editorState.reset();
+            }
+            if (datasetName) {
+                toastStore.success(
+                    "Dataset deleted",
+                    `"${datasetName}" was removed.`,
+                );
             }
         } finally {
             forceReloadTrigger.trigger();

--- a/frontend/src/routes/GraphDeleteDialog.svelte
+++ b/frontend/src/routes/GraphDeleteDialog.svelte
@@ -20,6 +20,7 @@
 
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     import {
         editorState,
@@ -58,6 +59,7 @@
         ).then(res => {
             if (res.ok) {
                 console.log("successfully deleted data");
+                const deletedGraph = graphURI;
                 editorState.selectedDataset.updateValue(null);
                 editorState.selectedGraph.updateValue(null);
                 editorState.selectedDiagram.updateValue({
@@ -67,14 +69,26 @@
                 editorState.selectedClassDataset.updateValue(null);
                 editorState.selectedClassGraph.updateValue(null);
                 editorState.selectedClassUUID.updateValue(null);
+                toastStore.success(
+                    "Schema deleted",
+                    `"${deletedGraph}" was removed.`,
+                );
             } else {
                 console.log("failed to insert data");
+                toastStore.error(
+                    "Delete failed",
+                    `Could not delete schema "${graphURI}".`,
+                );
             }
         });
         promise
             .catch(e => {
                 console.log("failed to delete graph:");
                 console.log(e);
+                toastStore.error(
+                    "Delete failed",
+                    "An unexpected error occurred while deleting the schema.",
+                );
             })
             .finally(() => {
                 forceReloadTrigger.trigger();

--- a/frontend/src/routes/ImportDialog.svelte
+++ b/frontend/src/routes/ImportDialog.svelte
@@ -24,6 +24,7 @@
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { supportedRDFMediaTypes } from "$lib/utils/fileUtils";
 
     import {
@@ -207,20 +208,30 @@
     async function parseResponse(response, datasetName) {
         if (!response.ok) {
             console.log("failed to insert data");
+            toastStore.error(
+                "Import failed",
+                `Could not import into "${datasetName}".`,
+            );
             return;
         }
 
         const body = await response.json();
         console.log(body.message);
 
-        const failedImports = body.failedImports;
+        const failedImports = body.failedImports ?? [];
         if (failedImports.length > 0) {
             console.warn("failed imports:", failedImports);
         }
 
         //only update the selected dataset and graph if at least one import was successful, otherwise keep the old selection
-        const importedGraphUris = body.importedGraphUris;
+        const importedGraphUris = body.importedGraphUris ?? [];
         if (importedGraphUris.length === 0) {
+            toastStore.error(
+                "Import failed",
+                failedImports.length > 0
+                    ? `${failedImports.length} file(s) could not be imported.`
+                    : "No graphs were imported.",
+            );
             return;
         }
         console.log("imported graphs:", importedGraphUris);
@@ -231,6 +242,17 @@
         editorState.selectedClassDataset.updateValue(null);
         editorState.selectedClassGraph.updateValue(null);
         editorState.selectedClassUUID.updateValue(null);
+
+        const importedCount = importedGraphUris.length;
+        const summary = `${importedCount} graph${importedCount === 1 ? "" : "s"} imported into "${datasetName}".`;
+        if (failedImports.length > 0) {
+            toastStore.warning(
+                "Import partially succeeded",
+                `${summary} ${failedImports.length} file(s) were skipped.`,
+            );
+        } else {
+            toastStore.success("Import complete", summary);
+        }
     }
 
     async function importGraphs() {
@@ -246,6 +268,10 @@
         } catch (e) {
             console.log("failed to insert data:");
             console.log(e);
+            toastStore.error(
+                "Import failed",
+                "An unexpected error occurred while importing.",
+            );
         } finally {
             forceReloadTrigger.trigger();
         }

--- a/frontend/src/routes/NamespacesDialog.svelte
+++ b/frontend/src/routes/NamespacesDialog.svelte
@@ -27,6 +27,7 @@
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ModifyDataDialog from "$lib/dialog/ModifyDataDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { mapNamespaceDtoToReactiveNamespace } from "$lib/models/reactive/mapper/map-dto-to-reactive-object.js";
     import { mapReactiveNamespaceToNamespaceDto } from "$lib/models/reactive/mapper/map-reactive-object-to-dto.js";
     import { ReactiveNamespace } from "$lib/models/reactive/models/reactive-namespace.svelte.js";
@@ -82,8 +83,28 @@
         const namespaceDTOs = plainReactiveNamespaces.map(namespace => {
             return mapReactiveNamespaceToNamespaceDto(namespace);
         });
-        await bec.replaceNamespaces(datasetName, namespaceDTOs);
-        forceReloadTrigger.trigger();
+        try {
+            const res = await bec.replaceNamespaces(datasetName, namespaceDTOs);
+            if (res && res.ok === false) {
+                toastStore.error(
+                    "Save failed",
+                    `Could not save namespaces for "${datasetName}".`,
+                );
+                return;
+            }
+            toastStore.success(
+                "Namespaces saved",
+                `Updated for "${datasetName}".`,
+            );
+        } catch (err) {
+            console.error("Failed to save namespaces:", err);
+            toastStore.error(
+                "Save failed",
+                "An unexpected error occurred while saving namespaces.",
+            );
+        } finally {
+            forceReloadTrigger.trigger();
+        }
     }
 
     async function addNamespace() {

--- a/frontend/src/routes/NewClassDialog.svelte
+++ b/frontend/src/routes/NewClassDialog.svelte
@@ -27,6 +27,7 @@
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { ReactiveValueWrapper } from "$lib/models/reactive/reactive-wrappers/reactive-value-wrapper.svelte.js";
     import { isInvalidClassLabel } from "$lib/models/reactive/validity-rules/validityFunctions.js";
     import { getPackageDisplayLabel } from "$lib/utils/package-label.js";
@@ -245,11 +246,23 @@
                 editorState.selectedClassDataset.updateValue(datasetNameLocal);
                 editorState.selectedClassGraph.updateValue(graphURILocal);
                 editorState.selectedClassUUID.updateValue(uuid);
+                toastStore.success(
+                    "Class created",
+                    `"${classNameLocal.value}" was added.`,
+                );
             } else {
                 console.log("failed to insert data");
+                toastStore.error(
+                    "Create failed",
+                    `Could not create class "${classNameLocal.value}".`,
+                );
             }
         } catch (e) {
             console.log("failed to add class:", e);
+            toastStore.error(
+                "Create failed",
+                "An unexpected error occurred while creating the class.",
+            );
         } finally {
             forceReloadTrigger.trigger();
             editorState.selectedDataset.trigger();

--- a/frontend/src/routes/NewGraphDialog.svelte
+++ b/frontend/src/routes/NewGraphDialog.svelte
@@ -22,6 +22,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     import {
         DiagramType,
@@ -133,8 +134,16 @@
                     id: "default",
                 });
                 editorState.selectedClassUUID.updateValue(null);
+                toastStore.success(
+                    "Schema created",
+                    `"${graphURILocal}" was added to "${datasetNameLocal}".`,
+                );
             } else {
                 console.log("failed to create graph");
+                toastStore.error(
+                    "Create failed",
+                    `Could not create schema "${graphURILocal}".`,
+                );
             }
         });
 
@@ -142,6 +151,10 @@
             .catch(e => {
                 console.log("failed to create graph:");
                 console.log(e);
+                toastStore.error(
+                    "Create failed",
+                    "An unexpected error occurred while creating the schema.",
+                );
             })
             .finally(() => {
                 forceReloadTrigger.trigger();

--- a/frontend/src/routes/NewPackageDialog.svelte
+++ b/frontend/src/routes/NewPackageDialog.svelte
@@ -25,6 +25,7 @@
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { Package } from "$lib/models/dto";
     import { DiagramType } from "$lib/sharedState.svelte.js";
 
@@ -209,11 +210,19 @@
                     type: DiagramType.PACKAGE,
                     id: uuid,
                 });
+                toastStore.success(
+                    "Package created",
+                    `"${packageLabel}" was added.`,
+                );
             });
         promise
             .catch(e => {
                 console.log("failed to add package:");
                 console.log(e);
+                toastStore.error(
+                    "Create failed",
+                    `Could not create package "${packageLabel}".`,
+                );
             })
             .finally(() => {
                 forceReloadTrigger.trigger();

--- a/frontend/src/routes/Searchbar.svelte
+++ b/frontend/src/routes/Searchbar.svelte
@@ -25,6 +25,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         DiagramType,
         editorState,
@@ -151,6 +152,10 @@
             console.error(
                 "Error fetching search results:",
                 response.statusText,
+            );
+            toastStore.error(
+                "Search failed",
+                "Could not fetch search results. Please try again.",
             );
         }
     }

--- a/frontend/src/routes/SnapshotDialog.svelte
+++ b/frontend/src/routes/SnapshotDialog.svelte
@@ -24,6 +24,7 @@
     import SelectEditControl from "$lib/components/SelectEditControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     import ButtonControl from "../lib/components/ButtonControl.svelte";
     import { editorState } from "../lib/sharedState.svelte.js";
@@ -60,10 +61,18 @@
                 "Successfully created snapshot for dataset",
                 datasetName,
             );
+            toastStore.success(
+                "Snapshot ready",
+                `Share link created for "${datasetName}".`,
+            );
         } else {
             console.error(
                 "Error creating snapshot for dataset:",
                 res.statusText,
+            );
+            toastStore.error(
+                "Snapshot failed",
+                `Could not create a snapshot for "${datasetName}".`,
             );
         }
     }
@@ -83,8 +92,13 @@
             setTimeout(() => {
                 copySuccess = false;
             }, 2000);
+            toastStore.success("Snapshot link copied to clipboard");
         } catch (err) {
             console.error("Failed to copy: ", err);
+            toastStore.error(
+                "Copy failed",
+                "Could not write the snapshot link to the clipboard.",
+            );
         }
     }
 </script>

--- a/frontend/src/routes/SnapshotDialog.svelte
+++ b/frontend/src/routes/SnapshotDialog.svelte
@@ -39,8 +39,6 @@
     let datasets = $state([]);
     let base64Token = $state();
 
-    let copySuccess = $state(false);
-
     const datasetSelectionLocked = $derived(!!lockedDatasetName);
 
     function onOpen() {
@@ -88,10 +86,6 @@
             await navigator.clipboard.writeText(
                 `${window.location.origin}/?snapshot=${base64Token}`,
             );
-            copySuccess = true;
-            setTimeout(() => {
-                copySuccess = false;
-            }, 2000);
             toastStore.success("Snapshot link copied to clipboard");
         } catch (err) {
             console.error("Failed to copy: ", err);
@@ -144,13 +138,6 @@
                             <Fa icon={faClipboardList} />
                         </ButtonControl>
                     </div>
-                {/if}
-            </div>
-            <div class="h-6">
-                {#if copySuccess}
-                    <p class="text-green-text text-sm">
-                        Link copied to clipboard!
-                    </p>
                 {/if}
             </div>
         </div>

--- a/frontend/src/routes/changelog/ChangesRow.svelte
+++ b/frontend/src/routes/changelog/ChangesRow.svelte
@@ -21,6 +21,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         editorState,
         forceReloadTrigger,
@@ -52,8 +53,16 @@
         if (res.ok) {
             console.log("Version restored successfully");
             forceReloadTrigger.trigger();
+            toastStore.success(
+                "Version restored",
+                "The selected version has been restored.",
+            );
         } else {
             console.error("Failed to restore version:", res.statusText);
+            toastStore.error(
+                "Restore failed",
+                "Could not restore the selected version.",
+            );
         }
     }
 

--- a/frontend/src/routes/delete-relations-dialog/DeleteDependenciesDialog.svelte
+++ b/frontend/src/routes/delete-relations-dialog/DeleteDependenciesDialog.svelte
@@ -21,6 +21,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
 
@@ -145,15 +146,26 @@
         if (!deleteDependencies) return;
         const payload = buildPayload(deleteDependencies);
         console.log("Submit delete with selections:", payload);
+        const label = deleteDependencies.resourceIdentifier.label;
         let res = await bec.deleteResources(datasetName, graphUri, payload);
         if (!res.ok) {
             console.error("Failed to delete resources:", await res.text());
+            toastStore.error(
+                "Delete failed",
+                label
+                    ? `Could not delete ${type} "${label}".`
+                    : "Could not delete the selected resources.",
+            );
         } else {
             console.log("Successfully submitted delete request");
             forceReloadTrigger.trigger();
             editorState.selectedClassDataset.updateValue(null);
             editorState.selectedClassGraph.updateValue(null);
             editorState.selectedClassUUID.updateValue(null);
+            toastStore.success(
+                `${type ? type.charAt(0).toUpperCase() + type.slice(1) : "Resource"} deleted`,
+                label ? `"${label}" was removed.` : "Resource was removed.",
+            );
         }
     }
 

--- a/frontend/src/routes/layout/menu-bar/Edit.svelte
+++ b/frontend/src/routes/layout/menu-bar/Edit.svelte
@@ -38,6 +38,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import { Menubar } from "$lib/components/bitsui/menubar";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         editorState,
         forceReloadTrigger,
@@ -229,11 +230,33 @@
     }
 
     async function enableEditing(datasetName) {
-        await bec.enableEditing(datasetName);
+        const res = await bec.enableEditing(datasetName);
+        if (res && res.ok === false) {
+            toastStore.error(
+                "Could not enable editing",
+                `Dataset "${datasetName}" remains read-only.`,
+            );
+            return;
+        }
+        toastStore.success(
+            "Editing enabled",
+            `Dataset "${datasetName}" is now editable.`,
+        );
     }
 
     async function disableEditing(datasetName) {
-        await bec.disableEditing(datasetName);
+        const res = await bec.disableEditing(datasetName);
+        if (res && res.ok === false) {
+            toastStore.error(
+                "Could not disable editing",
+                `Dataset "${datasetName}" remains editable.`,
+            );
+            return;
+        }
+        toastStore.success(
+            "Editing disabled",
+            `Dataset "${datasetName}" is now read-only.`,
+        );
     }
     $inspect("selectedPackageDetails: ", selectedPackageDetails);
 </script>

--- a/frontend/src/routes/layout/menu-bar/Edit.svelte
+++ b/frontend/src/routes/layout/menu-bar/Edit.svelte
@@ -32,13 +32,16 @@
     } from "@fortawesome/free-solid-svg-icons";
 
     import {
+        enableEditing,
+        disableEditing,
+    } from "$lib/actions/editingActions.js";
+    import {
         undo as doUndo,
         redo as doRedo,
     } from "$lib/actions/versionControlActions.js";
     import { BackendConnection } from "$lib/api/backend.js";
     import { Menubar } from "$lib/components/bitsui/menubar";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
-    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         editorState,
         forceReloadTrigger,
@@ -124,7 +127,9 @@
         if (!selectedDataset || !isDatasetReadOnly) {
             return;
         }
-        await enableEditing(selectedDataset);
+        if (!(await enableEditing(selectedDataset))) {
+            return;
+        }
         await reload();
         forceReloadTrigger.trigger();
     }
@@ -133,7 +138,9 @@
         if (!selectedDataset || isDatasetReadOnly) {
             return;
         }
-        await disableEditing(selectedDataset);
+        if (!(await disableEditing(selectedDataset))) {
+            return;
+        }
         await reload();
         editorState.selectedDiagram.trigger();
     }
@@ -229,35 +236,6 @@
         if (await doRedo()) reload();
     }
 
-    async function enableEditing(datasetName) {
-        const res = await bec.enableEditing(datasetName);
-        if (res && res.ok === false) {
-            toastStore.error(
-                "Could not enable editing",
-                `Dataset "${datasetName}" remains read-only.`,
-            );
-            return;
-        }
-        toastStore.success(
-            "Editing enabled",
-            `Dataset "${datasetName}" is now editable.`,
-        );
-    }
-
-    async function disableEditing(datasetName) {
-        const res = await bec.disableEditing(datasetName);
-        if (res && res.ok === false) {
-            toastStore.error(
-                "Could not disable editing",
-                `Dataset "${datasetName}" remains editable.`,
-            );
-            return;
-        }
-        toastStore.success(
-            "Editing disabled",
-            `Dataset "${datasetName}" is now read-only.`,
-        );
-    }
     $inspect("selectedPackageDetails: ", selectedPackageDetails);
 </script>
 

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -27,6 +27,7 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import DiscardCancelConfirmDialog from "$lib/dialog/DiscardCancelConfirmDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { mapReactiveClassToClassDto } from "$lib/models/reactive/mapper/map-reactive-object-to-dto.js";
     import {
         editorState,
@@ -80,6 +81,7 @@
     }
 
     async function saveChangesToBackend(classDto) {
+        const classLabel = classDto.label ?? classDto.uuid;
         const res = await bec.replaceClass(
             datasetName,
             graphUri,
@@ -96,10 +98,15 @@
             editorState.selectedClassUUID.trigger();
             editorState.selectedDiagram.trigger();
             forceReloadTrigger.trigger();
+            toastStore.success("Class saved", `"${classLabel}" was saved.`);
         } else {
             console.error(
                 "Could not save unsaved changes to class:",
                 responseText,
+            );
+            toastStore.error(
+                "Save failed",
+                `Could not save class "${classLabel}".`,
             );
         }
         forceReloadTrigger.trigger();

--- a/frontend/src/routes/mainpage/packageEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/packageEditorDialog.svelte
@@ -22,6 +22,7 @@
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ModifyDataDialog from "$lib/dialog/ModifyDataDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { mapReactivePackageToPackageDto } from "$lib/models/reactive/mapper/map-reactive-object-to-dto.js";
     import { ReactivePackage } from "$lib/models/reactive/models/reactive-package.svelte.js";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/utils/reactive-objects-control-button-utils.js";
@@ -121,9 +122,17 @@
             console.log("Successfully saved package");
             pkg.save();
             forceReloadTrigger.trigger();
+            toastStore.success(
+                isNewPackage ? "Package created" : "Package saved",
+                `"${getPackageDisplayLabel(apiPackage.label)}" was saved.`,
+            );
         } else {
             const errorText = await res.text();
             console.error("Could not save package:", errorText);
+            toastStore.error(
+                "Save failed",
+                `Could not save package "${getPackageDisplayLabel(apiPackage.label)}".`,
+            );
         }
 
         return res;

--- a/frontend/src/routes/mainpage/packageNavigation/DatasetSection.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/DatasetSection.svelte
@@ -29,12 +29,13 @@
     } from "@fortawesome/free-solid-svg-icons";
     import { getContext } from "svelte";
 
+    import {
+        enableEditing,
+        disableEditing,
+    } from "$lib/actions/editingActions.js";
     import { getNamespaces, isReadOnly } from "$lib/api/apiDatasetUtils.js";
-    import { BackendConnection } from "$lib/api/backend.js";
     import { ContextMenu } from "$lib/components/bitsui/contextmenu";
     import NavigationEntry from "$lib/components/navigation/NavigationEntry.svelte";
-    import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
-    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
 
@@ -49,8 +50,6 @@
     import CustomDatasetDiagramDialog from "./custom-diagram-dialogs/CustomDatasetDiagramDialog.svelte";
 
     let { datasetNavEntry } = $props();
-
-    const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
 
     let showImportDialog = $state(false);
     let showNewGraphDialog = $state(false);
@@ -101,45 +100,26 @@
         editorState.selectedDataset.updateValue(datasetNavEntry.label);
     }
 
-    async function enableEditing() {
+    async function requestEnableEditing() {
         if (!datasetNavEntry?.id || !readonly) {
             return;
         }
-
-        const res = await bec.enableEditing(datasetNavEntry.id);
-        if (res && res.ok === false) {
-            toastStore.error(
-                "Could not enable editing",
-                `Dataset "${datasetNavEntry.label}" remains read-only.`,
-            );
+        if (!(await enableEditing(datasetNavEntry.id))) {
             return;
         }
         readonly = false;
         forceReloadTrigger.trigger();
-        toastStore.success(
-            "Editing enabled",
-            `Dataset "${datasetNavEntry.label}" is now editable.`,
-        );
     }
 
-    async function disableEditing() {
+    async function requestDisableEditing() {
         if (!datasetNavEntry?.id || readonly) {
             return;
         }
-        const res = await bec.disableEditing(datasetNavEntry.id);
-        if (res && res.ok === false) {
-            toastStore.error(
-                "Could not disable editing",
-                `Dataset "${datasetNavEntry.label}" remains editable.`,
-            );
+        if (!(await disableEditing(datasetNavEntry.id))) {
             return;
         }
         readonly = true;
         forceReloadTrigger.trigger();
-        toastStore.success(
-            "Editing disabled",
-            `Dataset "${datasetNavEntry.label}" is now read-only.`,
-        );
     }
 </script>
 
@@ -214,14 +194,14 @@
             </ContextMenu.Item.Button>
             {#if readonly}
                 <ContextMenu.Item.Button
-                    onSelect={() => enableEditing()}
+                    onSelect={() => requestEnableEditing()}
                     faIcon={faPenToSquare}
                 >
                     Enable Editing
                 </ContextMenu.Item.Button>
             {:else}
                 <ContextMenu.Item.Button
-                    onSelect={() => disableEditing()}
+                    onSelect={() => requestDisableEditing()}
                     faIcon={faLock}
                 >
                     Disable Editing

--- a/frontend/src/routes/mainpage/packageNavigation/DatasetSection.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/DatasetSection.svelte
@@ -34,6 +34,7 @@
     import { ContextMenu } from "$lib/components/bitsui/contextmenu";
     import NavigationEntry from "$lib/components/navigation/NavigationEntry.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
 
@@ -105,20 +106,40 @@
             return;
         }
 
-        await bec.enableEditing(datasetNavEntry.id).then(() => {
-            readonly = false;
-            forceReloadTrigger.trigger();
-        });
+        const res = await bec.enableEditing(datasetNavEntry.id);
+        if (res && res.ok === false) {
+            toastStore.error(
+                "Could not enable editing",
+                `Dataset "${datasetNavEntry.label}" remains read-only.`,
+            );
+            return;
+        }
+        readonly = false;
+        forceReloadTrigger.trigger();
+        toastStore.success(
+            "Editing enabled",
+            `Dataset "${datasetNavEntry.label}" is now editable.`,
+        );
     }
 
     async function disableEditing() {
         if (!datasetNavEntry?.id || readonly) {
             return;
         }
-        await bec.disableEditing(datasetNavEntry.id).then(() => {
-            readonly = true;
-            forceReloadTrigger.trigger();
-        });
+        const res = await bec.disableEditing(datasetNavEntry.id);
+        if (res && res.ok === false) {
+            toastStore.error(
+                "Could not disable editing",
+                `Dataset "${datasetNavEntry.label}" remains editable.`,
+            );
+            return;
+        }
+        readonly = true;
+        forceReloadTrigger.trigger();
+        toastStore.success(
+            "Editing disabled",
+            `Dataset "${datasetNavEntry.label}" is now read-only.`,
+        );
     }
 </script>
 

--- a/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ExtendClassDialog.svelte
@@ -20,6 +20,7 @@
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         DiagramType,
         editorState,
@@ -52,6 +53,13 @@
                 classUUID,
                 body,
             );
+            if (!response.ok) {
+                toastStore.error(
+                    "Could not extend class",
+                    "The class could not be extended. Please try again.",
+                );
+                return;
+            }
             const newClass = await response.json();
             editorState.selectedDataset.updateValue(selectedDatasetName);
             editorState.selectedGraph.updateValue(selectedGraphURI);
@@ -60,8 +68,16 @@
                 id: newClass.belongsToCategory,
             });
             forceReloadTrigger.trigger();
+            toastStore.success(
+                "Class extended",
+                `The class has been extended in "${selectedDatasetName}".`,
+            );
         } catch (e) {
             console.log(e);
+            toastStore.error(
+                "Could not extend class",
+                "An unexpected error occurred. Please try again.",
+            );
         }
     }
 </script>

--- a/frontend/src/routes/mainpage/packageNavigation/PackageDeleteDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/PackageDeleteDialog.svelte
@@ -20,6 +20,7 @@
 
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         forceReloadTrigger,
         editorState,
@@ -29,6 +30,9 @@
     let { showDialog = $bindable(), datasetName, graphUri, pack } = $props();
 
     async function deletePackage() {
+        const packageLabel = pack?.label
+            ? getPackageDisplayLabel(pack.label)
+            : null;
         try {
             const url = `${PUBLIC_BACKEND_URL}/datasets/${encodeURIComponent(datasetName)}/graphs/${encodeURIComponent(graphUri)}/packages/${encodeURIComponent(pack.uuid)}`;
             const res = await fetch(url, {
@@ -37,6 +41,13 @@
             });
             if (!res.ok) {
                 console.error("Failed to delete package");
+                toastStore.error(
+                    "Delete failed",
+                    packageLabel
+                        ? `Could not delete package "${packageLabel}".`
+                        : "Could not delete package.",
+                );
+                return;
             }
             if (editorState.selectedDiagram.getProperty("id") === pack.uuid) {
                 editorState.selectedDiagram.updateValue({
@@ -47,6 +58,12 @@
                 editorState.selectedClassGraph.updateValue(null);
                 editorState.selectedClassUUID.updateValue(null);
             }
+            toastStore.success(
+                "Package deleted",
+                packageLabel
+                    ? `"${packageLabel}" was removed.`
+                    : "Package was removed.",
+            );
         } finally {
             forceReloadTrigger.trigger();
         }

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/AddToDatasetDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/AddToDatasetDiagramDialog.svelte
@@ -20,6 +20,7 @@
     import SelectEditControl from "$lib/components/SelectEditControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
     let {
@@ -60,16 +61,31 @@
     }
 
     async function addToDiagram() {
-        const classesToAdd = classes.map(cls => ({
-            graphUri: lockedGraphUri,
-            uuid: cls.id,
-        }));
-        await bec.addToCustomDatasetDiagram(
-            lockedDatasetName,
-            selectedDiagram.diagramId,
-            classesToAdd,
-        );
-        forceReloadTrigger.trigger();
+        const diagramName = selectedDiagram?.name;
+        const count = classes.length;
+        try {
+            const res = await bec.addToCustomDatasetDiagram(
+                lockedDatasetName,
+                selectedDiagram.diagramId,
+                classes.map(cls => ({
+                    graphUri: lockedGraphUri,
+                    uuid: cls.id,
+                })),
+            );
+            if (res && res.ok === false) {
+                toastStore.error(
+                    "Add failed",
+                    `Could not add ${count === 1 ? "class" : "classes"} to "${diagramName}".`,
+                );
+                return;
+            }
+            toastStore.success(
+                "Added to diagram",
+                `${count} ${count === 1 ? "class" : "classes"} added to "${diagramName}".`,
+            );
+        } finally {
+            forceReloadTrigger.trigger();
+        }
     }
 </script>
 

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/AddToGraphDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/AddToGraphDiagramDialog.svelte
@@ -20,6 +20,7 @@
     import SelectEditControl from "$lib/components/SelectEditControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
     let {
@@ -63,17 +64,32 @@
     }
 
     async function addToDiagram() {
-        const classesToAdd = classes.map(cls => ({
-            uuid: cls.id,
-            graphUri: lockedGraphUri,
-        }));
-        await bec.addToCustomGraphDiagram(
-            lockedDatasetName,
-            lockedGraphUri,
-            selectedDiagram.diagramId,
-            classesToAdd,
-        );
-        forceReloadTrigger.trigger();
+        const diagramName = selectedDiagram?.name;
+        const count = classes.length;
+        try {
+            const res = await bec.addToCustomGraphDiagram(
+                lockedDatasetName,
+                lockedGraphUri,
+                selectedDiagram.diagramId,
+                classes.map(cls => ({
+                    uuid: cls.id,
+                    graphUri: lockedGraphUri,
+                })),
+            );
+            if (res && res.ok === false) {
+                toastStore.error(
+                    "Add failed",
+                    `Could not add ${count === 1 ? "class" : "classes"} to "${diagramName}".`,
+                );
+                return;
+            }
+            toastStore.success(
+                "Added to diagram",
+                `${count} ${count === 1 ? "class" : "classes"} added to "${diagramName}".`,
+            );
+        } finally {
+            forceReloadTrigger.trigger();
+        }
     }
 </script>
 

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomDatasetDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomDatasetDiagramDialog.svelte
@@ -22,6 +22,7 @@
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { isValidDiagramName } from "$lib/models/reactive/validity-rules/validityFunctions.js";
     import {
         DiagramType,
@@ -200,8 +201,16 @@
                     type: DiagramType.CUSTOM_DATASET_DIAGRAM,
                     id: localDiagramId,
                 });
+                toastStore.success(
+                    "Diagram saved",
+                    `"${localDiagramName}" was saved.`,
+                );
             } else {
                 console.error("Failed to save diagram");
+                toastStore.error(
+                    "Save failed",
+                    `Could not save diagram "${localDiagramName}".`,
+                );
             }
         } finally {
             forceReloadTrigger.trigger();

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomDiagramDeleteDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomDiagramDeleteDialog.svelte
@@ -21,6 +21,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         forceReloadTrigger,
         editorState,
@@ -47,6 +48,13 @@
                     "Failed to delete custom diagram",
                     await res.text(),
                 );
+                toastStore.error(
+                    "Delete failed",
+                    diagram?.label
+                        ? `Could not delete custom diagram "${diagram.label}".`
+                        : "Could not delete custom diagram.",
+                );
+                return;
             }
             if (
                 editorState.selectedDiagram.getProperty("id") ===
@@ -60,6 +68,12 @@
                 editorState.selectedClassGraph.updateValue(null);
                 editorState.selectedClassUUID.updateValue(null);
             }
+            toastStore.success(
+                "Custom diagram deleted",
+                diagram?.label
+                    ? `"${diagram.label}" was removed.`
+                    : "Diagram was removed.",
+            );
         } finally {
             forceReloadTrigger.trigger();
         }

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomGraphDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomGraphDiagramDialog.svelte
@@ -22,6 +22,7 @@
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { isValidDiagramName } from "$lib/models/reactive/validity-rules/validityFunctions.js";
     import {
         DiagramType,
@@ -133,8 +134,16 @@
                     type: DiagramType.CUSTOM_GRAPH_DIAGRAM,
                     id: localDiagramId,
                 });
+                toastStore.success(
+                    "Diagram saved",
+                    `"${localDiagramName}" was saved.`,
+                );
             } else {
                 console.error("Failed to save diagram");
+                toastStore.error(
+                    "Save failed",
+                    `Could not save diagram "${localDiagramName}".`,
+                );
             }
         } finally {
             forceReloadTrigger.trigger();

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/RemoveFromDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/RemoveFromDiagramDialog.svelte
@@ -21,6 +21,7 @@
     import { BackendConnection } from "$lib/api/backend.js";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
     let {
@@ -35,21 +36,37 @@
     const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
 
     async function removeFromDiagram() {
-        if (graphUri) {
-            await bec.removeFromCustomGraphDiagram(
-                lockedDatasetName,
-                graphUri,
-                diagramId,
-                classId,
+        try {
+            const res = graphUri
+                ? await bec.removeFromCustomGraphDiagram(
+                      lockedDatasetName,
+                      graphUri,
+                      diagramId,
+                      classId,
+                  )
+                : await bec.removeFromCustomDatasetDiagram(
+                      lockedDatasetName,
+                      diagramId,
+                      classId,
+                  );
+            if (res && res.ok === false) {
+                toastStore.error(
+                    "Remove failed",
+                    classLabel
+                        ? `Could not remove class "${classLabel}" from the diagram.`
+                        : "Could not remove class from the diagram.",
+                );
+                return;
+            }
+            toastStore.success(
+                "Class removed",
+                classLabel
+                    ? `"${classLabel}" was removed from the diagram.`
+                    : "Class was removed from the diagram.",
             );
-        } else {
-            await bec.removeFromCustomDatasetDiagram(
-                lockedDatasetName,
-                diagramId,
-                classId,
-            );
+        } finally {
+            forceReloadTrigger.trigger();
         }
-        forceReloadTrigger.trigger();
     }
 </script>
 

--- a/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/OntologyDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/OntologyDialog.svelte
@@ -28,6 +28,7 @@
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
     import DiscardCancelConfirmDialog from "$lib/dialog/DiscardCancelConfirmDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { ReactiveOntology } from "$lib/models/reactive/models/ontology/reactive-ontology.svelte.js";
     import { forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
@@ -144,11 +145,20 @@
 
     async function saveOntology(datasetName, graphUri, ontologyObject) {
         const serializable = ontologyObject.getPlainObject();
-        if (ontologyObject.uuid.value) {
-            await bec.putOntology(datasetName, graphUri, serializable);
-        } else {
-            await bec.postOntology(datasetName, graphUri, serializable);
+        const res = ontologyObject.uuid.value
+            ? await bec.putOntology(datasetName, graphUri, serializable)
+            : await bec.postOntology(datasetName, graphUri, serializable);
+        if (res && res.ok === false) {
+            toastStore.error(
+                "Save failed",
+                "Could not save the profile header.",
+            );
+            return;
         }
+        toastStore.success(
+            "Profile header saved",
+            "The profile header was saved.",
+        );
     }
 
     function scrollEntriesToBottom() {

--- a/frontend/src/routes/migrate/steps/ConfirmClassRenames.svelte
+++ b/frontend/src/routes/migrate/steps/ConfirmClassRenames.svelte
@@ -21,6 +21,7 @@
     import EmptyStateCard from "$lib/components/EmptyStateCard.svelte";
     import InfoBox from "$lib/components/InfoBox.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     import RenameTable from "./RenameTable.svelte";
 
@@ -79,12 +80,29 @@
 
     export async function onNext() {
         let body = deletedAndRenamed.filter(r => r.newResource != null);
-        await fetch(PUBLIC_BACKEND_URL + "/migrations/class-renamings", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify(body),
-        });
+        try {
+            const res = await fetch(
+                PUBLIC_BACKEND_URL + "/migrations/class-renamings",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    credentials: "include",
+                    body: JSON.stringify(body),
+                },
+            );
+            if (!res.ok) {
+                toastStore.error(
+                    "Save failed",
+                    "Could not save class renames for the migration.",
+                );
+            }
+        } catch (e) {
+            console.log("Failed to save class renames:", e);
+            toastStore.error(
+                "Save failed",
+                "Could not save class renames for the migration.",
+            );
+        }
     }
 </script>
 

--- a/frontend/src/routes/migrate/steps/ConfirmDefaults.svelte
+++ b/frontend/src/routes/migrate/steps/ConfirmDefaults.svelte
@@ -19,6 +19,7 @@
     import { onMount } from "svelte";
 
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     let {
         substeps = [],
@@ -48,12 +49,29 @@
     });
 
     export async function onNext() {
-        await fetch(PUBLIC_BACKEND_URL + "/migrations/default-values", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify(classes),
-        });
+        try {
+            const res = await fetch(
+                PUBLIC_BACKEND_URL + "/migrations/default-values",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    credentials: "include",
+                    body: JSON.stringify(classes),
+                },
+            );
+            if (!res.ok) {
+                toastStore.error(
+                    "Save failed",
+                    "Could not save default values for the migration.",
+                );
+            }
+        } catch (e) {
+            console.log("Failed to save default values:", e);
+            toastStore.error(
+                "Save failed",
+                "Could not save default values for the migration.",
+            );
+        }
     }
 </script>
 

--- a/frontend/src/routes/migrate/steps/ConfirmPropertyRenames.svelte
+++ b/frontend/src/routes/migrate/steps/ConfirmPropertyRenames.svelte
@@ -19,6 +19,7 @@
     import { onMount } from "svelte";
 
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 
     let { substeps = [], currentSubstepIndex = 0 } = $props();
 
@@ -43,12 +44,29 @@
 
     export async function onNext() {
         let body = buildPropertyRenameList();
-        await fetch(PUBLIC_BACKEND_URL + "/migrations/property-renames", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify(body),
-        });
+        try {
+            const res = await fetch(
+                PUBLIC_BACKEND_URL + "/migrations/property-renames",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    credentials: "include",
+                    body: JSON.stringify(body),
+                },
+            );
+            if (!res.ok) {
+                toastStore.error(
+                    "Save failed",
+                    "Could not save property renames for the migration.",
+                );
+            }
+        } catch (e) {
+            console.log("Failed to save property renames:", e);
+            toastStore.error(
+                "Save failed",
+                "Could not save property renames for the migration.",
+            );
+        }
     }
 
     function buildPropertyRenameList() {

--- a/frontend/src/routes/migrate/steps/SelectSchemas.svelte
+++ b/frontend/src/routes/migrate/steps/SelectSchemas.svelte
@@ -24,6 +24,7 @@
     import InfoBox from "$lib/components/InfoBox.svelte";
     import SelectEditControl from "$lib/components/SelectEditControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { migrationState } from "$lib/sharedState.svelte.js";
 
     let { disableNext = $bindable() } = $props();
@@ -132,10 +133,19 @@
                     fileA,
                     fileB,
                 });
+            } else {
+                toastStore.error(
+                    "Migration setup failed",
+                    "Could not establish the migration context.",
+                );
             }
         } catch (e) {
             console.log("failed to establish migration context:");
             console.log(e);
+            toastStore.error(
+                "Migration setup failed",
+                "Could not establish the migration context.",
+            );
         }
     }
 </script>

--- a/frontend/src/routes/shacl/SHACLFullViewDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLFullViewDialog.svelte
@@ -19,6 +19,7 @@
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
     import TtlCodeEditor from "$lib/ttl/TtlCodeEditor.svelte";
 
@@ -122,15 +123,24 @@
             );
             if (res.ok) {
                 customSHACLBackup = customSHACL;
+                toastStore.success("Constraints saved");
             } else {
                 console.warn(
                     "Failed to save custom SHACL:",
                     res.status,
                     res.statusText,
                 );
+                toastStore.error(
+                    "Save failed",
+                    "Could not save custom constraints.",
+                );
             }
         } catch (error) {
             console.warn("Failed to save custom SHACL:", error);
+            toastStore.error(
+                "Save failed",
+                "An unexpected error occurred while saving custom constraints.",
+            );
         }
     }
 </script>

--- a/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLPropertySpecificDialog.svelte
@@ -19,6 +19,7 @@
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { ReactiveAssociation } from "$lib/models/reactive/models/reactive-association.svelte.js";
     import { ReactiveAttribute } from "$lib/models/reactive/models/reactive-attribute.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
@@ -188,9 +189,19 @@
                     res.status,
                     res.statusText,
                 );
+                toastStore.error(
+                    "Save failed",
+                    "Could not save property constraints.",
+                );
+            } else {
+                toastStore.success("Constraints saved");
             }
         } catch (error) {
             console.warn("Failed to save custom SHACL:", error);
+            toastStore.error(
+                "Save failed",
+                "An unexpected error occurred while saving property constraints.",
+            );
         } finally {
             await fetchShacl(
                 editorState.selectedClassUUID.getValue(),

--- a/frontend/src/routes/shacl/SHACLUploadDialog.svelte
+++ b/frontend/src/routes/shacl/SHACLUploadDialog.svelte
@@ -20,6 +20,7 @@
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
     import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         editorState,
         forceReloadTrigger,
@@ -69,13 +70,25 @@
             .then(res => {
                 if (res.ok) {
                     console.log("successfully inserted data");
+                    toastStore.success(
+                        "Constraints imported",
+                        `"${file.name}" was applied to "${graphURI}".`,
+                    );
                 } else {
                     console.log("failed to insert SHACL file");
+                    toastStore.error(
+                        "Import failed",
+                        `Could not import "${file.name}".`,
+                    );
                 }
             })
             .catch(e => {
                 console.log("failed to insert SHACL file:");
                 console.log(e);
+                toastStore.error(
+                    "Import failed",
+                    "An unexpected error occurred while uploading the SHACL file.",
+                );
             })
             .finally(() => {
                 forceReloadTrigger.trigger();

--- a/frontend/src/routes/shacl/shaclclassspecific/SHACLShapeTtlRenderer.svelte
+++ b/frontend/src/routes/shacl/shaclclassspecific/SHACLShapeTtlRenderer.svelte
@@ -20,6 +20,7 @@
 
     import ButtonControl from "$lib/components/ButtonControl.svelte";
     import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
     import TtlCodeEditor from "$lib/ttl/TtlCodeEditor.svelte";
 
@@ -93,9 +94,23 @@
             .then(res => {
                 if (res.ok) {
                     console.log("successfully updated custom shacl of class.");
+                    toastStore.success(
+                        "SHACL shapes saved",
+                        "Custom SHACL shapes were saved.",
+                    );
                 } else {
                     console.log("failed to update custom shacl of class.");
+                    toastStore.error(
+                        "Save failed",
+                        "Could not save custom SHACL shapes.",
+                    );
                 }
+            })
+            .catch(() => {
+                toastStore.error(
+                    "Save failed",
+                    "Could not save custom SHACL shapes.",
+                );
             })
             .finally(() => {
                 editorState.selectedClassUUID.trigger();


### PR DESCRIPTION
## Description

Introduce a global toast notification system to enhance user feedback for actions like imports, exports, edits, and errors. Includes `Toast`, `ToastContainer`, and a lightweight `toastStore` for managing notifications.

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
