### PR TITLE
fix: undo redo opens invalid class editor (RDFA-499)

### DIFF
--- a/frontend/src/lib/actions/versionControlActions.js
+++ b/frontend/src/lib/actions/versionControlActions.js
@@ -55,10 +55,10 @@ export async function fetchCanUndo(datasetName, graphURI) {
     return false;
 }
 
-export async function undo(datasetName, graphURI) {
-    eventStack.guardAction(async () => {
+export function undo(datasetName, graphURI) {
+    return eventStack.guardAction(async () => {
         const targets = resolveTargets(datasetName, graphURI);
-        if (!targets) return;
+        if (!targets) return false;
 
         const res = await fetch(
             `${PUBLIC_BACKEND_URL}/datasets/${targets.encodedDataset}/graphs/${targets.encodedGraph}/undo`,
@@ -71,9 +71,12 @@ export async function undo(datasetName, graphURI) {
         if (res.ok) {
             console.log("Undo successful.");
             forceReloadTrigger.trigger();
+            toastStore.info("Undone");
+            return true;
         } else {
             console.log("Undo failed.");
             toastStore.error("Undo failed", "Could not undo the last change.");
+            return false;
         }
     });
 }
@@ -99,10 +102,10 @@ export async function fetchCanRedo(datasetName, graphURI) {
     return false;
 }
 
-export async function redo(datasetName, graphURI) {
-    eventStack.guardAction(async () => {
+export function redo(datasetName, graphURI) {
+    return eventStack.guardAction(async () => {
         const targets = resolveTargets(datasetName, graphURI);
-        if (!targets) return;
+        if (!targets) return false;
 
         const res = await fetch(
             `${PUBLIC_BACKEND_URL}/datasets/${targets.encodedDataset}/graphs/${targets.encodedGraph}/redo`,
@@ -115,9 +118,12 @@ export async function redo(datasetName, graphURI) {
         if (res.ok) {
             console.log("Redo successful.");
             forceReloadTrigger.trigger();
+            toastStore.info("Redone");
+            return true;
         } else {
             console.log("Redo failed.");
             toastStore.error("Redo failed", "Could not redo the change.");
+            return false;
         }
     });
 }

--- a/frontend/src/lib/actions/versionControlActions.js
+++ b/frontend/src/lib/actions/versionControlActions.js
@@ -16,8 +16,9 @@
  */
 
 import { PUBLIC_BACKEND_URL } from "$lib/config/runtime";
+import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
 import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
-import { editorState } from "$lib/sharedState.svelte.js";
+import { editorState, forceReloadTrigger } from "$lib/sharedState.svelte.js";
 
 function resolveTargets(datasetName, graphURI) {
     const dataset = datasetName ?? editorState.selectedDataset.getValue();
@@ -55,25 +56,26 @@ export async function fetchCanUndo(datasetName, graphURI) {
 }
 
 export async function undo(datasetName, graphURI) {
-    const targets = resolveTargets(datasetName, graphURI);
-    if (!targets) return false;
+    eventStack.guardAction(async () => {
+        const targets = resolveTargets(datasetName, graphURI);
+        if (!targets) return;
 
-    const res = await fetch(
-        `${PUBLIC_BACKEND_URL}/datasets/${targets.encodedDataset}/graphs/${targets.encodedGraph}/undo`,
-        {
-            method: "POST",
-            credentials: "include",
-        },
-    );
+        const res = await fetch(
+            `${PUBLIC_BACKEND_URL}/datasets/${targets.encodedDataset}/graphs/${targets.encodedGraph}/undo`,
+            {
+                method: "POST",
+                credentials: "include",
+            },
+        );
 
-    if (res.ok) {
-        console.log("Undo successful.");
-        return true;
-    }
-
-    console.log("Undo failed.");
-    toastStore.error("Undo failed", "Could not undo the last change.");
-    return false;
+        if (res.ok) {
+            console.log("Undo successful.");
+            forceReloadTrigger.trigger();
+        } else {
+            console.log("Undo failed.");
+            toastStore.error("Undo failed", "Could not undo the last change.");
+        }
+    });
 }
 
 export async function fetchCanRedo(datasetName, graphURI) {
@@ -98,23 +100,24 @@ export async function fetchCanRedo(datasetName, graphURI) {
 }
 
 export async function redo(datasetName, graphURI) {
-    const targets = resolveTargets(datasetName, graphURI);
-    if (!targets) return false;
+    eventStack.guardAction(async () => {
+        const targets = resolveTargets(datasetName, graphURI);
+        if (!targets) return;
 
-    const res = await fetch(
-        `${PUBLIC_BACKEND_URL}/datasets/${targets.encodedDataset}/graphs/${targets.encodedGraph}/redo`,
-        {
-            method: "POST",
-            credentials: "include",
-        },
-    );
+        const res = await fetch(
+            `${PUBLIC_BACKEND_URL}/datasets/${targets.encodedDataset}/graphs/${targets.encodedGraph}/redo`,
+            {
+                method: "POST",
+                credentials: "include",
+            },
+        );
 
-    if (res.ok) {
-        console.log("Redo successful.");
-        return true;
-    }
-
-    console.log("Redo failed.");
-    toastStore.error("Redo failed", "Could not redo the change.");
-    return false;
+        if (res.ok) {
+            console.log("Redo successful.");
+            forceReloadTrigger.trigger();
+        } else {
+            console.log("Redo failed.");
+            toastStore.error("Redo failed", "Could not redo the change.");
+        }
+    });
 }

--- a/frontend/src/lib/components/InputWithButtonsControl.svelte
+++ b/frontend/src/lib/components/InputWithButtonsControl.svelte
@@ -42,6 +42,13 @@
     let ctrlPressed = $state(false);
 
     let showButtons = $derived(isHover && !ctrlPressed);
+
+    function handleKeyDown(e) {
+        ctrlPressed = e.ctrlKey;
+        if ((e.ctrlKey || e.metaKey) && (e.key === "z" || e.key === "y")) {
+            e.preventDefault();
+        }
+    }
 </script>
 
 <svelte:window
@@ -90,6 +97,7 @@
             bind:value
             oninput={() => callOnInput(value)}
             onchange={() => callOnChange(value)}
+            onkeydown={handleKeyDown}
             {disabled}
             {readonly}
             {list}

--- a/frontend/src/lib/dialog/DiscardCancelConfirmDialog.svelte
+++ b/frontend/src/lib/dialog/DiscardCancelConfirmDialog.svelte
@@ -30,6 +30,7 @@
         onDiscard = () => {},
         onSave = () => {},
         disableSave = false,
+        hideSave = false,
         ...restProps
     } = $props();
 
@@ -39,7 +40,7 @@
     }
 
     function handleKeyDown(event) {
-        if (event.key === "Enter" && !disableSave) {
+        if (event.key === "Enter" && !disableSave && !hideSave) {
             event.preventDefault();
             closeDialog(onSave);
         }
@@ -64,7 +65,7 @@
             <p class="text-sm leading-relaxed">
                 {#if disableSave}
                     Cannot save because the changes are invalid.
-                {:else}
+                {:else if !hideSave}
                     Do you want to save before continuing?
                 {/if}
             </p>
@@ -89,14 +90,16 @@
             />
         </div>
 
-        <div>
-            <FaIconButton
-                callOnClick={() => closeDialog(onSave)}
-                icon={faFloppyDisk}
-                disabled={disableSave}
-                text="Save"
-                title="Save changes"
-            />
-        </div>
+        {#if !hideSave}
+            <div>
+                <FaIconButton
+                    callOnClick={() => closeDialog(onSave)}
+                    icon={faFloppyDisk}
+                    disabled={disableSave}
+                    text="Save"
+                    title="Save changes"
+                />
+            </div>
+        {/if}
     </div>
 </AlertDialog>

--- a/frontend/src/lib/eventhandling/closeEventManager.svelte.js
+++ b/frontend/src/lib/eventhandling/closeEventManager.svelte.js
@@ -50,16 +50,18 @@ class EventStack {
         this.actionGuard = fn;
     }
 
-    unregisterActionGuard() {
-        this.actionGuard = null;
+    unregisterActionGuard(fn) {
+        if (this.actionGuard !== fn) {
+            this.actionGuard = null;
+        }
     }
 
     guardAction(action) {
         if (this.actionGuard) {
-            this.actionGuard(action);
-            return;
+            const result = this.actionGuard(action);
+            return result ?? Promise.resolve(false);
         }
-        action();
+        return action();
     }
 }
 eventStack = new EventStack();

--- a/frontend/src/lib/eventhandling/closeEventManager.svelte.js
+++ b/frontend/src/lib/eventhandling/closeEventManager.svelte.js
@@ -20,6 +20,7 @@ export let eventStack;
 class EventStack {
     constructor() {
         this.stack = [];
+        this.actionGuard = null;
     }
 
     stack;
@@ -43,6 +44,22 @@ class EventStack {
             return;
         }
         this.stack.at(-1)(...args);
+    }
+
+    registerActionGuard(fn) {
+        this.actionGuard = fn;
+    }
+
+    unregisterActionGuard() {
+        this.actionGuard = null;
+    }
+
+    guardAction(action) {
+        if (this.actionGuard) {
+            this.actionGuard(action);
+            return;
+        }
+        action();
     }
 }
 eventStack = new EventStack();

--- a/frontend/src/lib/eventhandling/closeEventManager.svelte.js
+++ b/frontend/src/lib/eventhandling/closeEventManager.svelte.js
@@ -51,7 +51,7 @@ class EventStack {
     }
 
     unregisterActionGuard(fn) {
-        if (this.actionGuard !== fn) {
+        if (this.actionGuard === fn) {
             this.actionGuard = null;
         }
     }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -234,14 +234,12 @@
             if (isRedo) {
                 if (canRedo && (await redo())) {
                     await reload();
-                    toastStore.info("Redone");
                 } else if (!canRedo) {
                     console.log("Redo blocked: nothing to redo.");
                 }
             } else {
                 if (canUndo && (await undo())) {
                     await reload();
-                    toastStore.info("Undone");
                 } else if (!canUndo) {
                     console.log("Undo blocked: nothing to undo.");
                 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -227,9 +227,7 @@
 
             event.preventDefault();
 
-            const isRedo =
-                key === "y" ||
-                (key === "z" && event.shiftKey);
+            const isRedo = key === "y" || (key === "z" && event.shiftKey);
 
             if (isRedo) {
                 if (canRedo && (await redo())) {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -212,17 +212,6 @@
             return;
         }
 
-        const target = event.target;
-        if (
-            target instanceof HTMLElement &&
-            (target.isContentEditable ||
-                target.tagName === "INPUT" ||
-                target.tagName === "TEXTAREA" ||
-                target.tagName === "SELECT")
-        ) {
-            return;
-        }
-
         const hasCtrl = event.ctrlKey || event.metaKey;
         const hasCtrlAltViaAltGr =
             event.getModifierState("AltGraph") && isLeftAltPressed;
@@ -231,9 +220,11 @@
             return;
         }
 
-        switch (event.key.toLowerCase()) {
-            case "z":
-                event.preventDefault();
+        // Undo/Redo always fires, even when an input is focused
+        let key = event.key.toLowerCase();
+        if (key === "z" || key === "y") {
+            event.preventDefault();
+            if (key === "z") {
                 if (event.shiftKey) {
                     if (canRedo && (await redo())) {
                         await reload();
@@ -245,19 +236,33 @@
                         toastStore.info("Undone");
                     }
                 }
-                break;
-            case "y":
-                event.preventDefault();
+            } else if (key === "y"){
                 if (canRedo && (await redo())) {
                     await reload();
                     toastStore.info("Redone");
                 }
-                break;
-            case "c":
+            }
+            return;
+        }
+
+        // All other shortcuts: skip when an input-like element is focused
+        const target = event.target;
+        if (
+            target instanceof HTMLElement &&
+            (target.isContentEditable ||
+                target.tagName === "INPUT" ||
+                target.tagName === "TEXTAREA" ||
+                target.tagName === "SELECT")
+        ) {
+            return;
+        }
+
+        switch (event.code) {
+            case "KeyC":
                 event.preventDefault();
                 if (canCopyClass) copyClass();
                 break;
-            case "v":
+            case "KeyV":
                 event.preventDefault();
                 if (canPasteClass) {
                     if (event.shiftKey && isLeftAltPressed) {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -204,10 +204,7 @@
             isLeftAltPressed = true;
         }
 
-        if (event.key === "Escape") {
-            if (event.defaultPrevented) {
-                return;
-            }
+        if (event.key === "Escape" && !event.defaultPrevented) {
             eventStack.executeNewestEvent();
             return;
         }
@@ -216,9 +213,7 @@
         const hasCtrlAltViaAltGr =
             event.getModifierState("AltGraph") && isLeftAltPressed;
 
-        if (!hasCtrl && !hasCtrlAltViaAltGr) {
-            return;
-        }
+        if (!hasCtrl && !hasCtrlAltViaAltGr) return;
 
         // Undo/Redo always fires, even when an input is focused
         let key = event.key.toLowerCase();
@@ -229,23 +224,26 @@
                 console.log(`${event.code} blocked because a dialog is open.`);
                 return;
             }
+
             event.preventDefault();
-            if (key === "z") {
-                if (event.shiftKey) {
-                    if (canRedo && (await redo())) {
-                        await reload();
-                        toastStore.info("Redone");
-                    }
-                } else {
-                    if (canUndo && (await undo())) {
-                        await reload();
-                        toastStore.info("Undone");
-                    }
-                }
-            } else if (key === "y"){
+
+            const isRedo =
+                key === "y" ||
+                (key === "z" && event.shiftKey);
+
+            if (isRedo) {
                 if (canRedo && (await redo())) {
                     await reload();
                     toastStore.info("Redone");
+                } else if (!canRedo) {
+                    console.log("Redo blocked: nothing to redo.");
+                }
+            } else {
+                if (canUndo && (await undo())) {
+                    await reload();
+                    toastStore.info("Undone");
+                } else if (!canUndo) {
+                    console.log("Undo blocked: nothing to undo.");
                 }
             }
             return;
@@ -269,17 +267,16 @@
                 if (canCopyClass) copyClass();
                 break;
             case "KeyV":
+                if (!canPasteClass) break;
                 event.preventDefault();
-                if (canPasteClass) {
-                    if (event.shiftKey && isLeftAltPressed) {
-                        await pasteClass(true, false, false);
-                    } else if (event.shiftKey) {
-                        await pasteClass(false, false, true);
-                    } else if (isLeftAltPressed) {
-                        await pasteClass(false, true, false);
-                    } else {
-                        await pasteClass(false, true, true);
-                    }
+                if (event.shiftKey && isLeftAltPressed) {
+                    await pasteClass(true, false, false);
+                } else if (event.shiftKey) {
+                    await pasteClass(false, false, true);
+                } else if (isLeftAltPressed) {
+                    await pasteClass(false, true, false);
+                } else {
+                    await pasteClass(false, true, true);
                 }
                 break;
         }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -223,6 +223,12 @@
         // Undo/Redo always fires, even when an input is focused
         let key = event.key.toLowerCase();
         if (key === "z" || key === "y") {
+            if (
+                document.querySelector('[role="dialog"], [role="alertdialog"]')
+            ) {
+                console.log(`${event.code} blocked because a dialog is open.`);
+                return;
+            }
             event.preventDefault();
             if (key === "z") {
                 if (event.shiftKey) {

--- a/frontend/src/routes/layout/menu-bar/Edit.svelte
+++ b/frontend/src/routes/layout/menu-bar/Edit.svelte
@@ -274,7 +274,6 @@
             copyAssociations,
         );
     }
-    $inspect("selectedPackageDetails: ", selectedPackageDetails);
 </script>
 
 <Menubar.Menu value="edit">

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -84,6 +84,8 @@
     let graphOfClassToOpenNext = $state(null);
     let classToOpenNext = $state(null);
 
+    let pendingAction = $state(null);
+
     let isEnum = $derived(
         reactiveClass?.stereotypes.contains(enumerationStereotype),
     );
@@ -96,9 +98,18 @@
         loadingContext = true;
         loadingClass = true;
         (async () => {
+            let res = await bec.getClassInfo(datasetName, graphUri, classUuid);
+            let resText = await res.text();
+            if (!resText) {
+                return closeClassEditor({
+                    datasetName: datasetName,
+                    graphUri: graphUri,
+                    classUuid: null,
+                });
+            }
             isDatasetReadOnly = await isReadOnly(datasetName);
             await loadContext();
-            await loadReactiveClass(cancellation);
+            await loadReactiveClass(cancellation, JSON.parse(resText));
         })();
 
         return () => {
@@ -112,11 +123,26 @@
         isDatasetReadOnly = await isReadOnly(datasetName);
     });
 
-    onMount(() => eventStack.addEvent(closeClassEditor));
+    onMount(() => {
+        eventStack.addEvent(closeClassEditor);
+        eventStack.registerActionGuard(withUnsavedChangesCheck);
+    });
 
-    onDestroy(() => eventStack.removeEvent(closeClassEditor));
+    onDestroy(() => {
+        eventStack.removeEvent(closeClassEditor);
+        eventStack.unregisterActionGuard(withUnsavedChangesCheck);
+    });
 
-    function closeClassEditor(
+    function withUnsavedChangesCheck(action) {
+        if (reactiveClass?.isModified) {
+            pendingAction = action;
+            showDiscardSaveConfirmDialog = true;
+            return;
+        }
+        action();
+    }
+
+    export function closeClassEditor(
         { datasetName = null, graphUri = null, classUuid = null } = {
             datasetName: null,
             graphUri: null,
@@ -153,13 +179,10 @@
         editorState.selectedContext.trigger();
     }
 
-    async function loadReactiveClass(cancelled) {
-        const classDto = await (
-            await bec.getClassInfo(datasetName, graphUri, classUuid)
-        ).json();
+    async function loadReactiveClass(cancelled, classDTO) {
         if (cancelled.cancelled) return;
         const newReactiveClass = mapClassDtoToReactiveClass(
-            classDto,
+            classDTO,
             context,
             uuid => context.targetClassInfos.find(cls => cls.uuid === uuid),
         );
@@ -229,7 +252,6 @@
         get backendConnection() {
             return bec;
         },
-        // get Objects by identifier functions
         get getClassByUuid() {
             return function (uuid) {
                 return context.classes.find(cls => cls.uuid === uuid);
@@ -287,6 +309,7 @@
                     <ClassEditorButtons
                         {reactiveClass}
                         bind:showDiscardSaveConfirmDialog
+                        bind:pendingAction
                         {datasetOfClassToOpenNext}
                         {graphOfClassToOpenNext}
                         {classToOpenNext}

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -107,9 +107,29 @@
                     classUuid: null,
                 });
             }
+            let classData;
+            try {
+                classData = JSON.parse(resText);
+            } catch (e) {
+                console.error(
+                    "Failed to parse class data for class UUID",
+                    classUuid,
+                    "in dataset",
+                    datasetName,
+                    "and graph",
+                    graphUri,
+                    ":",
+                    e,
+                );
+                return closeClassEditor({
+                    datasetName: datasetName,
+                    graphUri: graphUri,
+                    classUuid: null,
+                });
+            }
             isDatasetReadOnly = await isReadOnly(datasetName);
             await loadContext();
-            await loadReactiveClass(cancellation, JSON.parse(resText));
+            await loadReactiveClass(cancellation, classData);
         })();
 
         return () => {
@@ -139,7 +159,7 @@
             showDiscardSaveConfirmDialog = true;
             return;
         }
-        action();
+        return action();
     }
 
     export function closeClassEditor(

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -40,6 +40,7 @@
     let {
         reactiveClass,
         showDiscardSaveConfirmDialog = $bindable(),
+        pendingAction = $bindable(),
         datasetOfClassToOpenNext,
         graphOfClassToOpenNext,
         classToOpenNext,
@@ -111,6 +112,27 @@
         }
         forceReloadTrigger.trigger();
     }
+
+    function handleDiscard() {
+        reactiveClass.reset();
+        if (pendingAction) {
+            pendingAction();
+            pendingAction = null;
+        } else {
+            editorState.selectedClassDataset.updateValue(
+                datasetOfClassToOpenNext,
+            );
+            editorState.selectedClassGraph.updateValue(graphOfClassToOpenNext);
+            editorState.selectedClassUUID.updateValue(classToOpenNext);
+        }
+    }
+
+    function handleSave() {
+        saveChanges();
+        editorState.selectedClassDataset.updateValue(datasetOfClassToOpenNext);
+        editorState.selectedClassGraph.updateValue(graphOfClassToOpenNext);
+        editorState.selectedClassUUID.updateValue(classToOpenNext);
+    }
 </script>
 
 <div class="flex gap-1">
@@ -178,17 +200,8 @@
 
 <DiscardCancelConfirmDialog
     bind:showDialog={showDiscardSaveConfirmDialog}
-    onDiscard={() => {
-        reactiveClass.reset();
-        editorState.selectedClassDataset.updateValue(datasetOfClassToOpenNext);
-        editorState.selectedClassGraph.updateValue(graphOfClassToOpenNext);
-        editorState.selectedClassUUID.updateValue(classToOpenNext);
-    }}
-    onSave={() => {
-        saveChanges();
-        editorState.selectedClassDataset.updateValue(datasetOfClassToOpenNext);
-        editorState.selectedClassGraph.updateValue(graphOfClassToOpenNext);
-        editorState.selectedClassUUID.updateValue(classToOpenNext);
-    }}
-    disableSave={!reactiveClass?.isModified || !reactiveClass?.isValid}
+    onDiscard={handleDiscard}
+    onSave={handleSave}
+    disableSave={!reactiveClass?.isValid}
+    hideSave={!!pendingAction}
 />

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -113,6 +113,10 @@
         forceReloadTrigger.trigger();
     }
 
+    function handleCancel() {
+        pendingAction = null;
+    }
+
     function handleDiscard() {
         reactiveClass.reset();
         if (pendingAction) {
@@ -202,6 +206,7 @@
     bind:showDialog={showDiscardSaveConfirmDialog}
     onDiscard={handleDiscard}
     onSave={handleSave}
+    onCancel={handleCancel}
     disableSave={!reactiveClass?.isValid}
     hideSave={!!pendingAction}
 />

--- a/frontend/src/routes/mainpage/classEditor/fetch-class-editor-context.js
+++ b/frontend/src/routes/mainpage/classEditor/fetch-class-editor-context.js
@@ -42,7 +42,7 @@ export async function getPackages(datasetName, graphUri) {
         }),
     );
 
-    console.log("PACKAGES:", packages);
+    console.debug("PACKAGES:", packages);
     return packages;
 }
 
@@ -92,7 +92,7 @@ export async function getDataTypes(datasetName, graphUri) {
             sensitivity: "base",
         }),
     );
-    console.log("DATATYPES:", datatypes);
+    console.debug("DATATYPES:", datatypes);
     return datatypes;
 }
 
@@ -100,7 +100,7 @@ export async function getClasses(datasetName, graphUri) {
     const res = await bec.getClasses(datasetName, graphUri, true);
     let classesDto = await res.json();
     let classes = classesDto.map(cls => new Class(cls));
-    console.log("CLASSES:", classes);
+    console.debug("CLASSES:", classes);
     return classes;
 }
 
@@ -108,12 +108,12 @@ export async function getStereotypes(datasetName, graphUri) {
     const res = await bec.getStereotypes(datasetName, graphUri);
     let stereotypesJSON = await res.json();
 
-    console.log("STEREOTYPES:", stereotypesJSON);
+    console.debug("STEREOTYPES:", stereotypesJSON);
     return stereotypesJSON;
 }
 
 export async function getNamespaces(datasetName) {
-    const prefixes = await getNamespacesFromApi(datasetName);
-    console.log("PREFIXES:", prefixes);
-    return prefixes;
+    const namespaces = await getNamespacesFromApi(datasetName);
+    console.debug("NAMESPACES:", namespaces);
+    return namespaces;
 }

--- a/frontend/src/routes/mainpage/packageNavigation/PackageButton.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/PackageButton.svelte
@@ -128,7 +128,6 @@
             type: DiagramType.PACKAGE,
             id: packageNavEntry.id,
         });
-        console.log(editorState.selectedDiagram.getValue());
     }
 
     function pasteClass(copyAbstract, copyAttributes, copyAssociations) {

--- a/frontend/src/routes/mainpage/packageNavigation/build-nav-object.js
+++ b/frontend/src/routes/mainpage/packageNavigation/build-nav-object.js
@@ -67,11 +67,6 @@ function syncList(targetArray, freshEntries, parent = null) {
  * @returns {Promise<NavEntry[]>}
  */
 export async function getNavEntryList(existingDatasetNavList) {
-    console.log(
-        "started Building navObj with existingNavObj: ",
-        existingDatasetNavList,
-    );
-
     const freshEntries = (await getDatasetNames())
         .sort((a, b) => a.localeCompare(b))
         .map(label =>
@@ -95,8 +90,6 @@ export async function getNavEntryList(existingDatasetNavList) {
             );
         }
     }
-
-    console.log("finished Building navObj: ", result);
     return result;
 }
 


### PR DESCRIPTION
## Description

- before opening the classeditor the classeditor checks if the class its trying to open exists
- dialogs now block undo redo functionality, to ensure consistent behaviour

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
