### PR TITLE
fix: naming a class rdfs:class caused unexpected behaviour (RDFA-508)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/models/cim/queries/update/CIMUpdates.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/queries/update/CIMUpdates.java
@@ -658,6 +658,7 @@ public class CIMUpdates {
                 .build()
                 .addDelete(CIMQueryVars.URI, ANY_1, ANY_2)
                 .addWhere(CIMQueryVars.TYPE_URI, RDFA.uuid, classUUID.toString())
+                .addWhere(CIMQueryVars.TYPE_URI, CIMS.stereotype, CIMStereotypes.enumeration)
                 .addWhere(CIMQueryVars.URI, RDF.type, CIMQueryVars.TYPE_URI)
                 .addWhere(CIMQueryVars.URI, ANY_1, ANY_2);
     }
@@ -734,6 +735,7 @@ public class CIMUpdates {
                         .addDelete(CIMQueryVars.URI, "?pre", "?ref")
                         .addWhere("?ref", RDFA.uuid, uuid.toString())
                         .addWhere(CIMQueryVars.URI, "?pre", "?ref")
+                        .addFilter(new ExprFactory().ne("?pre", RDF.type))
                         .addInsert(CIMQueryVars.URI, "?pre", newURI.toNode());
         UpdateExecutionFactory.create(updateReferencesToThis.build(), dataset).execute();
     }

--- a/frontend/src/lib/models/reactive/models/reactive-class.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-class.svelte.js
@@ -35,12 +35,22 @@ import {
     isInvalidDatatypeUri,
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
 
-function initializeStereotypeViolationChecks(stereotype, stereotypesArray) {
-    stereotype.violationChecks.push(value =>
-        isInvalidStereotype(value, stereotypesArray),
-    );
-    stereotype.violationChecks.push(value =>
-        isManuallyEnteredConcreteStereotype(value, stereotype.isModified),
+function initializeStereotypeViolationChecks(
+    stereotype,
+    stereotypesArray,
+    reactiveNamespace,
+    reactiveLabel,
+) {
+    stereotype.violationChecks.push(
+        value =>
+            isInvalidStereotype(
+                value,
+                stereotypesArray,
+                reactiveNamespace,
+                reactiveLabel,
+            ),
+        value =>
+            isManuallyEnteredConcreteStereotype(value, stereotype.isModified),
     );
 }
 
@@ -115,10 +125,20 @@ export class ReactiveClass {
         let compareClasses = context.classes.filter(c => c.uuid !== uuid);
         this.uuid = new ReactiveValueWrapper(uuid, isInvalidUuid);
         this.namespace = new ReactiveValueWrapper(namespace, namespace =>
-            isInvalidNamespace(namespace, context.namespaces),
+            isInvalidNamespace(
+                namespace,
+                context.namespaces,
+                this.label,
+                this.stereotypes,
+            ),
         );
         this.label = new ReactiveValueWrapper(label, label =>
-            isInvalidClassLabel(label, this.namespace.value, compareClasses),
+            isInvalidClassLabel(
+                label,
+                this.namespace,
+                compareClasses,
+                this.stereotypes,
+            ),
         );
 
         this.package = new ReactiveValueWrapper(pack, isInvalidPackage);
@@ -130,7 +150,13 @@ export class ReactiveClass {
         this.stereotypes = new ReactiveObjectsArrayWrapper(
             stereotypes,
             ReactiveValueWrapper,
-            initializeStereotypeViolationChecks,
+            (stereotype, stereotypesArray) =>
+                initializeStereotypeViolationChecks(
+                    stereotype,
+                    stereotypesArray,
+                    this.namespace,
+                    this.label,
+                ),
         );
         this.attributes = new ReactiveObjectsArrayWrapper(
             attributes,

--- a/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
+++ b/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
@@ -14,10 +14,16 @@
  *    limitations under the License.
  *
  */
+import { untrack } from "svelte";
 import { validate as uuidValidate } from "uuid";
 import { IriValidationStrategy, validateIri } from "validate-iri";
 
-import { CONCRETE_STEREOTYPE } from "$lib/models/stereotype-constants.js";
+import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
+import {
+    CONCRETE_STEREOTYPE,
+    ENUMERATION_STEREOTYPE,
+    RDFS_NAMESPACE_URI,
+} from "$lib/models/stereotype-constants.js";
 import { getNCNameViolations } from "$lib/rdf-syntax-grammar/namespace/prefix/index.js";
 
 export function isInvalidUuid(uuid) {
@@ -36,8 +42,14 @@ export function isInvalidLabel(label) {
     return isNotEmptyValidation(label);
 }
 
-export function isInvalidClassLabel(label, namespace, compareClasses) {
+export function isInvalidClassLabel(
+    label,
+    reactiveNamespace,
+    compareClasses,
+    ReactiveStereotypes,
+) {
     const violations = [];
+    const namespace = reactiveNamespace?.getPlainObject();
     if (!label || label.trim() === "") {
         violations.push("must not be empty");
     }
@@ -49,6 +61,14 @@ export function isInvalidClassLabel(label, namespace, compareClasses) {
         ) {
             violations.push("must be unique");
         }
+    }
+
+    if (
+        label === "Class" &&
+        namespace === RDFS_NAMESPACE_URI &&
+        ReactiveStereotypes?.getPlainObject().includes(ENUMERATION_STEREOTYPE)
+    ) {
+        violations.push("enumeration cannot be named rdfs:Class");
     }
     return violations;
 }
@@ -131,7 +151,12 @@ export function isInvalidInverseAssociationLabel(association, getClassByUuid) {
     return violations;
 }
 
-export function isInvalidNamespace(namespace, compareNamespaces) {
+export function isInvalidNamespace(
+    namespace,
+    compareNamespaces,
+    ReactiveLabel,
+    ReactiveStereotypes,
+) {
     const violations = isNotEmptyValidation(namespace);
     if (violations.length > 0) return violations;
 
@@ -148,6 +173,15 @@ export function isInvalidNamespace(namespace, compareNamespaces) {
         violations.push('must end with "#" or "/"');
     }
 
+    if (
+        ReactiveLabel?.getPlainObject() === "Class" &&
+        namespace === RDFS_NAMESPACE_URI &&
+        ReactiveStereotypes?.getPlainObject().includes(ENUMERATION_STEREOTYPE)
+    ) {
+        violations.push(
+            'enumeration called "Class" cannot be in namespace rdfs',
+        );
+    }
     return violations;
 }
 
@@ -208,7 +242,12 @@ export function isInvalidTarget(target) {
     return violations;
 }
 
-export function isInvalidStereotype(stereotype, existingStereotypes) {
+export function isInvalidStereotype(
+    stereotype,
+    existingStereotypes,
+    reactiveNamespace,
+    reactiveLabel,
+) {
     const violations = [];
     if (!stereotype || stereotype.trim() === "") {
         violations.push("must not be empty");
@@ -218,6 +257,19 @@ export function isInvalidStereotype(stereotype, existingStereotypes) {
         existingStereotypes.filter(s => s.equals(stereotype)).length > 1
     ) {
         violations.push("must be unique");
+    }
+    if (
+        stereotype === ENUMERATION_STEREOTYPE &&
+        reactiveLabel?.value === "Class" &&
+        reactiveNamespace?.getPlainObject() === RDFS_NAMESPACE_URI
+    ) {
+        untrack(() =>
+            toastStore.warning(
+                "rdfs:Class cannot be an enum",
+                "This is a known limitation",
+            ),
+        );
+        violations.push("Cannot transform rdfs:Class into an enum");
     }
     return violations;
 }

--- a/frontend/src/lib/models/stereotype-constants.js
+++ b/frontend/src/lib/models/stereotype-constants.js
@@ -23,3 +23,7 @@
  */
 export const CONCRETE_STEREOTYPE =
     "http://iec.ch/TC57/NonStandard/UML#concrete";
+
+export const ENUMERATION_STEREOTYPE =
+    "http://iec.ch/TC57/NonStandard/UML#enumeration";
+export const RDFS_NAMESPACE_URI = "http://www.w3.org/2000/01/rdf-schema#";

--- a/frontend/src/routes/NewClassDialog.svelte
+++ b/frontend/src/routes/NewClassDialog.svelte
@@ -107,7 +107,7 @@
                 className = new ReactiveValueWrapper(currentValue, label =>
                     isInvalidClassLabel(
                         label,
-                        classURINamespace?.value,
+                        classURINamespace,
                         compareClasses,
                     ),
                 );
@@ -123,11 +123,7 @@
         classURINamespace = new ReactiveValueWrapper(null);
 
         className = new ReactiveValueWrapper("", label =>
-            isInvalidClassLabel(
-                label,
-                classURINamespace?.value,
-                compareClasses,
-            ),
+            isInvalidClassLabel(label, classURINamespace, compareClasses),
         );
 
         if (!datasetName) {


### PR DESCRIPTION
## Description

- fixed bug where replacing a class rdfs:Class would cause all class resource to be deleted

## Test Checklist
### General Behavior
- [ ] Components reload automatically when data changes
- [ ] Editing features are disabled in readonly datasets
- [ ] Dialogs pre-select current dataset/graph
- [ ] Required fields are validated in dialogs
- [ ] Discarding unsaved changes opens a discard cancel confirm dialog

### Global MenuBar
- [ ] Navigate to home page works
- File menu:
    - [ ] Import → Graph/SHACL works
    - [ ] Export → Graph/SHACL works
    - [ ] Share Snapshot works
    - [ ] Delete → Dataset/Graph works
- Edit menu:
    - [ ] New → Class works
    - [ ] New → Package works
    - [ ] Edit/View → Create/Edit/View Ontology works
    - [ ] Edit/View → Package works
    - [ ] Undo/Redo (Ctrl+Z / Ctrl+Y) works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete → Ontology/Package works
- View menu:
    - [ ] Changelog opens and shows current graph
    - [ ] Compare Graphs opens
    - [ ] Full SHACL works
- Help menu:
    - [ ] Help link works
    - [ ] Submit Feedback link works
    - [ ] About navigation works

### Welcome Page
- [ ] Navigation to Editor works
- [ ] Tips are displayed
- [ ] Security and data information displayed
- [ ] Copyright and version information displayed

### Editor - MenuBar
- [ ] Search function works with all filters (All Datasets, Current Dataset, Current Graph, Current Package)
- [ ] Search finds classes, attributes, associations, packages
- [ ] "Enable Editing" button appears for readonly datasets

### Editor - Navigation
- [ ] Hierarchical display (Datasets → Graphs → Packages) works
- [ ] Selection is highlighted
- [ ] Selecting a class does not change dataset/graph/package selection
- [ ] Class selection stays open/highlighted when switching dataset/graph/package
- [ ] Datasets and graphs are collapsible
- [ ] Single click selects; double click or chevron toggles expand/collapse
- [ ] State persists on reload (non-browser)
- [ ] Context menus act on the dataset/graph/package they were opened on
- [ ] Hover labels show prefixes when configured
- Dataset context menu:
    - [ ] Import graph works (disabled in readonly datasets)
    - [ ] Share Snapshot works
    - [ ] Enable/Disable editing works
    - [ ] Manage/View namespaces works
    - [ ] Delete dataset works
- Graph context menu:
    - [ ] New package works (disabled in readonly datasets)
    - [ ] Undo/Redo works (only enabled when available)
    - [ ] Create Ontology
    - [ ] Edit Ontology (View Ontology in readonly)
    - [ ] Delete Ontology
    - [ ] Changelog navigation works
    - [ ] Compare dialog works
    - [ ] SHACL import/export/full view works (import disabled in readonly datasets)
    - [ ] Export graph works
    - [ ] Delete graph works (disabled in readonly datasets)
- Package context menu:
    - [ ] Create new class works (disabled in readonly datasets)
    - [ ] View/Edit package works
    - [ ] Copy URL works
    - [ ] Delete package works (disabled for external/default packages and readonly datasets)
- Class context menu:
    - [ ] Open class (editor) works
    - [ ] SHACL works
    - [ ] Delete class works (disabled in readonly datasets)

### Editor - Package View
- [ ] Class diagram displays correctly
- [ ] Moving nodes works and layout changes persist after reload
- [ ] Loading animation shows while loading
- [ ] Info cards show when no package or no classes available
- [ ] Drag and zoom diagram works
- [ ] "Reset View" button works
- [ ] "Filter View" works
- [ ] "Reset Layout" button resets diagram to auto-generated layout
- [ ] Click on class opens class editor

### Editor - Class Editor
- [ ] Display and edit class properties: Label, Namespace, Package, Derived from, Abstract, Stereotypes, Attributes, Associations, Comment
- [ ] Delete class works
- [ ] Save changes works
- [ ] Discard changes works
- [ ] Attribute Editor works
- [ ] Association Editor works
- [ ] attribute/association SHACL View works
- [ ] Class SHACL View works 

### Prefixes Page
- [ ] View, add, remove and edit namespaces works

### Changelog Page
- [ ] Select graph and display write operations works
- [ ] Operations shown in reverse chronological order
- [ ] Detailed view of changed triples works
- [ ] Restoring graph to a version works

### Compare Page
- [ ] Compare two graphs works
