### PR TITLE
fix(editor): dispatch keyboard shortcuts on event.key instead of event.code (GH-155)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -231,8 +231,8 @@
             return;
         }
 
-        switch (event.code) {
-            case "KeyZ":
+        switch (event.key.toLowerCase()) {
+            case "z":
                 event.preventDefault();
                 if (event.shiftKey) {
                     if (canRedo && (await redo())) {
@@ -246,18 +246,18 @@
                     }
                 }
                 break;
-            case "KeyY":
+            case "y":
                 event.preventDefault();
                 if (canRedo && (await redo())) {
                     await reload();
                     toastStore.info("Redone");
                 }
                 break;
-            case "KeyC":
+            case "c":
                 event.preventDefault();
                 if (canCopyClass) copyClass();
                 break;
-            case "KeyV":
+            case "v":
                 event.preventDefault();
                 if (canPasteClass) {
                     if (event.shiftKey && isLeftAltPressed) {


### PR DESCRIPTION
## Summary

The global keydown handler switched on event.code, which names keys by their physical US-QWERTY position rather than the character actually produced. On QWERTZ layouts the Y and Z keys are physically swapped relative to QWERTY, so event.code reported "KeyY" for the key labelled Z and vice versa. This made Ctrl+Z trigger redo and Ctrl+Y trigger undo for all users on German keyboards.

Switch the shortcut dispatch to event.key.toLowerCase() so it matches the produced character and is keyboard-layout independent. Copy/paste (C/V) were unaffected since those keys share the same position across layouts, but they are migrated too for consistency.

## Related Issues

Closes #155

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

Manually confirmed that keyboard shortcuts are working correctly now.
