### PR TITLE
fix(datasets): support dataset names with spaces and special characters (GH-151)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/SessionRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/SessionRESTController.java
@@ -1,0 +1,50 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/session")
+public class SessionRESTController {
+
+    private static final Logger logger = LoggerFactory.getLogger(SessionRESTController.class);
+
+    @Operation(
+            summary = "Reset session",
+            description = "Invalidates the current session, discarding all unsaved changes. A new session is created on the next request.",
+            tags = {"session"},
+            responses = {@ApiResponse(responseCode = "204")})
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void resetSession(HttpSession session) {
+        logger.info("Invalidating session {} on user request.", session.getId());
+        session.invalidate();
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/api/controller/SessionRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/SessionRESTController.java
@@ -38,7 +38,8 @@ public class SessionRESTController {
 
     @Operation(
             summary = "Reset session",
-            description = "Invalidates the current session, discarding all unsaved changes. A new session is created on the next request.",
+            description =
+                    "Invalidates the current session, discarding all unsaved changes. A new session is created on the next request.",
             tags = {"session"},
             responses = {@ApiResponse(responseCode = "204")})
     @DeleteMapping

--- a/backend/src/main/java/org/rdfarchitect/filters/DatasetFilter.java
+++ b/backend/src/main/java/org/rdfarchitect/filters/DatasetFilter.java
@@ -31,6 +31,8 @@ import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.exception.security.DatasetAccessDeniedException;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @RequiredArgsConstructor
 public class DatasetFilter implements Filter {
@@ -75,7 +77,8 @@ public class DatasetFilter implements Filter {
         if (uri != null && uri.startsWith("/api/datasets/")) {
             String remaining = uri.substring(14);
             int slashIndex = remaining.indexOf('/');
-            return slashIndex == -1 ? remaining : remaining.substring(0, slashIndex);
+            String encoded = slashIndex == -1 ? remaining : remaining.substring(0, slashIndex);
+            return URLDecoder.decode(encoded, StandardCharsets.UTF_8);
         }
         return null;
     }

--- a/frontend/src/lib/api/backend.js
+++ b/frontend/src/lib/api/backend.js
@@ -642,4 +642,12 @@ export class BackendConnection {
             credentials: "include",
         });
     }
+
+    async resetSession() {
+        const url = `${PUBLIC_BACKEND_URL}/session`;
+        return fetch(url, {
+            method: "DELETE",
+            credentials: "include",
+        });
+    }
 }

--- a/frontend/src/routes/ResetSessionDialog.svelte
+++ b/frontend/src/routes/ResetSessionDialog.svelte
@@ -1,0 +1,55 @@
+<!--
+  -    Copyright (c) 2024-2026 SOPTIM AG
+  -
+  -    Licensed under the Apache License, Version 2.0 (the "License");
+  -    you may not use this file except in compliance with the License.
+  -    You may obtain a copy of the License at
+  -
+  -        http://www.apache.org/licenses/LICENSE-2.0
+  -
+  -    Unless required by applicable law or agreed to in writing, software
+  -    distributed under the License is distributed on an "AS IS" BASIS,
+  -    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -    See the License for the specific language governing permissions and
+  -    limitations under the License.
+  -
+  -->
+
+<script>
+    import { BackendConnection } from "$lib/api/backend.js";
+    import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
+    import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
+
+    let { showDialog = $bindable() } = $props();
+
+    const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
+
+    async function resetSession() {
+        try {
+            await bec.resetSession();
+        } catch {
+            toastStore.error("Reset failed", "Could not reset the session.");
+            return;
+        }
+        window.location.reload();
+    }
+</script>
+
+<ActionDialog
+    bind:showDialog
+    title="Reset Session?"
+    primaryLabel="Reset Session"
+    primaryVariant="danger"
+    onPrimary={resetSession}
+>
+    <div class="space-y-2 px-3 py-3">
+        <p class="text-default-text text-sm leading-relaxed">
+            This will discard all unsaved changes and reload all data from the
+            database.
+        </p>
+        <p class="text-default-text text-sm leading-relaxed">
+            Use this to recover if the application is not responding correctly.
+        </p>
+    </div>
+</ActionDialog>

--- a/frontend/src/routes/layout/menu-bar/Help.svelte
+++ b/frontend/src/routes/layout/menu-bar/Help.svelte
@@ -17,20 +17,28 @@
 
 <script>
     import {
+        faArrowsRotate,
         faCircleInfo,
         faCircleQuestion,
         faCommentDots,
     } from "@fortawesome/free-solid-svg-icons";
 
+    import { BackendConnection } from "$lib/api/backend.js";
     import { Menubar } from "$lib/components/bitsui/menubar";
+    import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
+    import ActionDialog from "$lib/dialog/ActionDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
 
     import { goto } from "$app/navigation";
 
+    const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
     const externalResources = {
         help: "https://github.com/SOPTIM/RDFArchitect#readme",
         feedback: "https://github.com/SOPTIM/RDFArchitect/discussions",
     };
+
+    let showResetSessionDialog = $state(false);
 
     function openExternalResource(key) {
         const target = externalResources[key];
@@ -43,6 +51,16 @@
     function navigateHomepage() {
         editorState.reset();
         goto("/");
+    }
+
+    async function resetSession() {
+        try {
+            await bec.resetSession();
+        } catch {
+            toastStore.error("Reset failed", "Could not reset the session.");
+            return;
+        }
+        window.location.reload();
     }
 </script>
 
@@ -64,5 +82,31 @@
         <Menubar.Item.Button onSelect={navigateHomepage} faIcon={faCircleInfo}>
             About
         </Menubar.Item.Button>
+        <Menubar.Separator />
+        <Menubar.Item.Button
+            onSelect={() => (showResetSessionDialog = true)}
+            faIcon={faArrowsRotate}
+            variant="danger"
+        >
+            Reset Session
+        </Menubar.Item.Button>
     </Menubar.Content>
 </Menubar.Menu>
+
+<ActionDialog
+    bind:showDialog={showResetSessionDialog}
+    title="Reset Session?"
+    primaryLabel="Reset Session"
+    primaryVariant="danger"
+    onPrimary={resetSession}
+>
+    <div class="space-y-2 px-3 py-3">
+        <p class="text-default-text text-sm leading-relaxed">
+            This will discard all unsaved changes and reload all data from the
+            database.
+        </p>
+        <p class="text-default-text text-sm leading-relaxed">
+            Use this to recover if the application is not responding correctly.
+        </p>
+    </div>
+</ActionDialog>

--- a/frontend/src/routes/layout/menu-bar/Help.svelte
+++ b/frontend/src/routes/layout/menu-bar/Help.svelte
@@ -23,16 +23,13 @@
         faCommentDots,
     } from "@fortawesome/free-solid-svg-icons";
 
-    import { BackendConnection } from "$lib/api/backend.js";
     import { Menubar } from "$lib/components/bitsui/menubar";
-    import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
-    import ActionDialog from "$lib/dialog/ActionDialog.svelte";
-    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { editorState } from "$lib/sharedState.svelte.js";
+
+    import ResetSessionDialog from "../../ResetSessionDialog.svelte";
 
     import { goto } from "$app/navigation";
 
-    const bec = new BackendConnection(fetch, PUBLIC_BACKEND_URL);
     const externalResources = {
         help: "https://github.com/SOPTIM/RDFArchitect#readme",
         feedback: "https://github.com/SOPTIM/RDFArchitect/discussions",
@@ -51,16 +48,6 @@
     function navigateHomepage() {
         editorState.reset();
         goto("/");
-    }
-
-    async function resetSession() {
-        try {
-            await bec.resetSession();
-        } catch {
-            toastStore.error("Reset failed", "Could not reset the session.");
-            return;
-        }
-        window.location.reload();
     }
 </script>
 
@@ -93,20 +80,4 @@
     </Menubar.Content>
 </Menubar.Menu>
 
-<ActionDialog
-    bind:showDialog={showResetSessionDialog}
-    title="Reset Session?"
-    primaryLabel="Reset Session"
-    primaryVariant="danger"
-    onPrimary={resetSession}
->
-    <div class="space-y-2 px-3 py-3">
-        <p class="text-default-text text-sm leading-relaxed">
-            This will discard all unsaved changes and reload all data from the
-            database.
-        </p>
-        <p class="text-default-text text-sm leading-relaxed">
-            Use this to recover if the application is not responding correctly.
-        </p>
-    </div>
-</ActionDialog>
+<ResetSessionDialog bind:showDialog={showResetSessionDialog} />

--- a/frontend/src/routes/mainpage/packageNavigation/build-nav-object.js
+++ b/frontend/src/routes/mainpage/packageNavigation/build-nav-object.js
@@ -17,6 +17,7 @@
 
 import { BackendConnection } from "$lib/api/backend.js";
 import { PUBLIC_BACKEND_URL } from "$lib/config/runtime.js";
+import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
 import { URI } from "$lib/models/dto/index.ts";
 import { NavEntry } from "$lib/models/nav/NavEntry.svelte.js";
 import { DiagramType, editorState } from "$lib/sharedState.svelte.js";
@@ -81,7 +82,18 @@ export async function getNavEntryList(existingDatasetNavList) {
     syncList(result, freshEntries, null);
 
     for (const datasetNavEntry of result) {
-        await populateDataset(datasetNavEntry);
+        try {
+            await populateDataset(datasetNavEntry);
+        } catch (err) {
+            console.error(
+                "Error populating dataset " + datasetNavEntry.id,
+                err,
+            );
+            toastStore.error(
+                "Failed to load dataset",
+                `Could not load graphs for dataset "${datasetNavEntry.id}". Other datasets are still available.`,
+            );
+        }
     }
 
     console.log("finished Building navObj: ", result);
@@ -91,6 +103,10 @@ export async function getNavEntryList(existingDatasetNavList) {
 async function getDatasetNames() {
     try {
         const res = await bec.getDatasetNames();
+        if (!res.ok) {
+            console.error(`Error fetching dataset names: HTTP ${res.status}`);
+            return [];
+        }
         return await res.json();
     } catch (err) {
         console.error("Error fetching dataset names", err);
@@ -130,6 +146,12 @@ async function populateDataset(datasetNavEntry) {
 async function getGraphNames(datasetName) {
     try {
         const res = await bec.getGraphNames(datasetName);
+        if (!res.ok) {
+            console.error(
+                `Error fetching graph names for dataset "${datasetName}": HTTP ${res.status}`,
+            );
+            return [];
+        }
         return await res.json();
     } catch (err) {
         console.error(


### PR DESCRIPTION
## Summary

URL-decode the dataset name extracted from the raw request URI in DatasetFilter
so that names like "CGMES 2.4.15" (encoded as CGMES%202.4.15) are correctly
matched against the stored dataset list instead of triggering a 500 error.

Also improve frontend error resilience: each dataset is now loaded independently
so a failure in one does not blank the entire navigation panel, and a toast error
informs the user which dataset could not be loaded.

Add a "Reset Session" option to the Help menu that invalidates the server session
and reloads the page, giving users a self-service recovery path when the app gets
into a broken state.

## Related Issues

Closes #151

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

Tested dataset names with whitespaces and special chars.
Reset session tested.