### PR TITLE
fix(docs): point Help menu and README badge to rdfarchitect.soptim.de (GH-159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Frontend CI](https://github.com/SOPTIM/RDFArchitect/actions/workflows/frontend-ci.yml/badge.svg?branch=main)](https://github.com/SOPTIM/RDFArchitect/actions/workflows/frontend-ci.yml)
 [![Version](https://img.shields.io/github/v/tag/SOPTIM/RDFArchitect?sort=semver)](https://github.com/SOPTIM/RDFArchitect/releases)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-rdfarchitect.soptim.de-blue)](https://rdfarchitect.soptim.de)
 
 RDFArchitect is a web-based tool for visualizing, editing, and sharing RDFS schemas with CIM extensions - as used in CGMES and the ENTSO-e network code profiles — along with their SHACL constraints.
 

--- a/frontend/src/routes/layout/menu-bar/Help.svelte
+++ b/frontend/src/routes/layout/menu-bar/Help.svelte
@@ -28,7 +28,7 @@
     import { goto } from "$app/navigation";
 
     const externalResources = {
-        help: "https://github.com/SOPTIM/RDFArchitect#readme",
+        help: "https://rdfarchitect.soptim.de",
         feedback: "https://github.com/SOPTIM/RDFArchitect/discussions",
     };
 


### PR DESCRIPTION
## Summary

- `Help.svelte`: Help menu now opens `https://rdfarchitect.soptim.de`
- `README.md`: docs site is now a badge in the badge row.

## Related Issues

Closes #159

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
