### PR TITLE
feat(compare): add Before/After labels and swap button to compare dialog (GH-152)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/migration/MigrationContextRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/migration/MigrationContextRESTController.java
@@ -109,6 +109,12 @@ public class MigrationContextRESTController {
             var extendedGraphURIB = expandURIUseCase.expandUri(datasetB, graphB);
             setMigrationContextUseCase.setMigrationContext(
                     fileA, new GraphIdentifier(datasetB, extendedGraphURIB));
+        }
+        // stored to file
+        else if (datasetA != null && graphA != null && fileA != null) {
+            var extendedGraphURIA = expandURIUseCase.expandUri(datasetA, graphA);
+            setMigrationContextUseCase.setMigrationContext(
+                    new GraphIdentifier(datasetA, extendedGraphURIA), fileA);
         } else {
             logger.warn(
                     "Invalid request to POST \"/api/migrations/context\" from \"{}\". Missing required parameters.",

--- a/backend/src/main/java/org/rdfarchitect/services/schemamigration/SchemaMigrationService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/schemamigration/SchemaMigrationService.java
@@ -112,6 +112,24 @@ public class SchemaMigrationService
     }
 
     @Override
+    public void setMigrationContext(GraphIdentifier originalSchema, MultipartFile updatedSchema) {
+        Graph originalGraph;
+        try (var originalCtx =
+                databasePort.getGraphWithContext(originalSchema).begin(ReadWrite.READ)) {
+            originalGraph = GraphUtils.deepCopy(originalCtx.getRdfGraph());
+        }
+
+        var updatedGraph =
+                new GraphFileSourceBuilderImpl()
+                        .setFile(updatedSchema)
+                        .setGraphName(GRAPH_URI)
+                        .build()
+                        .graph();
+
+        initContext(originalGraph, updatedGraph);
+    }
+
+    @Override
     public void setMigrationContext(MultipartFile originalSchema, MultipartFile updatedSchema) {
         var originalGraph =
                 new GraphFileSourceBuilderImpl()

--- a/backend/src/main/java/org/rdfarchitect/services/schemamigration/SetMigrationContextUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/schemamigration/SetMigrationContextUseCase.java
@@ -42,6 +42,14 @@ public interface SetMigrationContextUseCase {
     void setMigrationContext(GraphIdentifier originalSchema, GraphIdentifier updatedSchema);
 
     /**
+     * Sets the migration context for a stored original schema and an uploaded updated schema.
+     *
+     * @param originalSchema the graph identifier of the original schema loaded in memory
+     * @param updatedSchema the uploaded updated schema
+     */
+    void setMigrationContext(GraphIdentifier originalSchema, MultipartFile updatedSchema);
+
+    /**
      * Sets the migration context for the two uploaded schema files.
      *
      * @param originalSchema the graph identifier of the edited schema loaded in memory

--- a/frontend/src/routes/compare/CompareDialog.svelte
+++ b/frontend/src/routes/compare/CompareDialog.svelte
@@ -44,10 +44,10 @@
         STORED_TO_STORED: 0,
         FILE_TO_STORED: 1,
         FILE_TO_FILE: 2,
+        STORED_TO_FILE: 3,
     });
 
     let compareMode = $state(CompareMode.STORED_TO_STORED);
-    let swapped = $state(false);
 
     let datasetA = $state(null);
     let graphA = $state(null);
@@ -70,6 +70,11 @@
             disabled: false,
         },
         {
+            value: CompareMode.STORED_TO_FILE,
+            label: "Stored schema → Uploaded schema",
+            disabled: false,
+        },
+        {
             value: CompareMode.FILE_TO_FILE,
             label: "Uploaded schema → Uploaded schema",
             disabled: !!lockedDatasetName || !!lockedGraphUri,
@@ -83,6 +88,10 @@
 
         if (compareMode === CompareMode.FILE_TO_STORED) {
             return !datasetB || !graphB || !fileA;
+        }
+
+        if (compareMode === CompareMode.STORED_TO_FILE) {
+            return !datasetA || !graphA || !fileA;
         }
 
         if (compareMode === CompareMode.STORED_TO_STORED) {
@@ -105,7 +114,6 @@
 
     function onClose() {
         compareMode = CompareMode.STORED_TO_STORED;
-        swapped = false;
 
         datasetA = null;
         graphA = null;
@@ -119,7 +127,6 @@
 
     function onCompareModeChange(mode) {
         compareMode = mode;
-        swapped = false;
 
         datasetB = null;
         graphB = null;
@@ -135,7 +142,17 @@
         } else if (compareMode === CompareMode.FILE_TO_FILE) {
             [fileA, fileB] = [fileB, fileA];
         } else if (compareMode === CompareMode.FILE_TO_STORED) {
-            swapped = !swapped;
+            datasetA = datasetB;
+            graphA = graphB;
+            datasetB = null;
+            graphB = null;
+            compareMode = CompareMode.STORED_TO_FILE;
+        } else if (compareMode === CompareMode.STORED_TO_FILE) {
+            datasetB = datasetA;
+            graphB = graphA;
+            datasetA = null;
+            graphA = null;
+            compareMode = CompareMode.FILE_TO_STORED;
         }
     }
 
@@ -168,12 +185,17 @@
 
     async function runCompare() {
         let response;
+        let invert = false;
         switch (compareMode) {
             case CompareMode.FILE_TO_FILE:
                 response = await bec.compareSchemasFromFiles(fileA, fileB);
                 break;
             case CompareMode.FILE_TO_STORED:
                 response = await bec.compareSchemas(datasetB, graphB, fileA);
+                break;
+            case CompareMode.STORED_TO_FILE:
+                response = await bec.compareSchemas(datasetA, graphA, fileA);
+                invert = true;
                 break;
             case CompareMode.STORED_TO_STORED:
                 response = await bec.compareDatasetSchemas(
@@ -188,7 +210,7 @@
         }
 
         let changeList = await response.json();
-        if (swapped) {
+        if (invert) {
             changeList = invertChangeList(changeList);
         }
         changeList.sort((a, b) => a.label.localeCompare(b.label));
@@ -279,7 +301,7 @@
             {#if compareMode === CompareMode.FILE_TO_STORED}
                 <div class="flex flex-col gap-1.5">
                     <span class="text-text-subtle px-1 text-xs font-medium">
-                        {swapped ? "After" : "Before"}
+                        Before
                     </span>
                     <div
                         class="border-border bg-background-subtle rounded border p-3"
@@ -303,7 +325,7 @@
 
                 <div class="flex flex-col gap-1.5">
                     <span class="text-text-subtle px-1 text-xs font-medium">
-                        {swapped ? "Before" : "After"}
+                        After
                     </span>
                     <DatasetAndGraphSelection
                         bind:dataset={datasetB}
@@ -311,6 +333,44 @@
                         {lockedDatasetName}
                         {lockedGraphUri}
                     />
+                </div>
+            {/if}
+
+            {#if compareMode === CompareMode.STORED_TO_FILE}
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        Before
+                    </span>
+                    <DatasetAndGraphSelection
+                        bind:dataset={datasetA}
+                        bind:graph={graphA}
+                        {lockedDatasetName}
+                        {lockedGraphUri}
+                    />
+                </div>
+
+                <div class="flex items-center gap-3">
+                    <div class="bg-border h-px w-full"></div>
+                    <button
+                        onclick={swapSelections}
+                        class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                        title="Swap Before and After"
+                    >
+                        <Fa icon={faRightLeft} />
+                        Swap
+                    </button>
+                    <div class="bg-border h-px w-full"></div>
+                </div>
+
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        After
+                    </span>
+                    <div
+                        class="border-border bg-background-subtle rounded border p-3"
+                    >
+                        <FileSelectButton bind:file={fileA} />
+                    </div>
                 </div>
             {/if}
 

--- a/frontend/src/routes/compare/CompareDialog.svelte
+++ b/frontend/src/routes/compare/CompareDialog.svelte
@@ -15,8 +15,9 @@
   -
   -->
 <script>
-    import { Fa } from "svelte-fa";
     import { faRightLeft } from "@fortawesome/free-solid-svg-icons";
+    import { Fa } from "svelte-fa";
+
     import { BackendConnection } from "$lib/api/backend.js";
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import FileSelectButton from "$lib/components/FileSelectButton.svelte";
@@ -143,7 +144,10 @@
     }
 
     function invertResourceChange(resource) {
-        return { ...resource, changes: resource.changes?.map(invertPropertyChange) ?? null };
+        return {
+            ...resource,
+            changes: resource.changes?.map(invertPropertyChange) ?? null,
+        };
     }
 
     function invertClassChange(cls) {
@@ -237,7 +241,9 @@
 
             {#if compareMode === CompareMode.STORED_TO_STORED}
                 <div class="flex flex-col gap-1.5">
-                    <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        Before
+                    </span>
                     <DatasetAndGraphSelection
                         bind:dataset={datasetA}
                         bind:graph={graphA}
@@ -260,7 +266,9 @@
                 </div>
 
                 <div class="flex flex-col gap-1.5">
-                    <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        After
+                    </span>
                     <DatasetAndGraphSelection
                         bind:dataset={datasetB}
                         bind:graph={graphB}
@@ -273,7 +281,9 @@
                     <span class="text-text-subtle px-1 text-xs font-medium">
                         {swapped ? "After" : "Before"}
                     </span>
-                    <div class="border-border bg-background-subtle rounded border p-3">
+                    <div
+                        class="border-border bg-background-subtle rounded border p-3"
+                    >
                         <FileSelectButton bind:file={fileA} />
                     </div>
                 </div>
@@ -306,8 +316,12 @@
 
             {#if compareMode === CompareMode.FILE_TO_FILE}
                 <div class="flex flex-col gap-1.5">
-                    <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
-                    <div class="border-border bg-background-subtle rounded border p-3">
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        Before
+                    </span>
+                    <div
+                        class="border-border bg-background-subtle rounded border p-3"
+                    >
                         <FileSelectButton bind:file={fileA} />
                     </div>
                 </div>
@@ -326,8 +340,12 @@
                 </div>
 
                 <div class="flex flex-col gap-1.5">
-                    <span class="text-text-subtle px-1 text-xs font-medium">After</span>
-                    <div class="border-border bg-background-subtle rounded border p-3">
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        After
+                    </span>
+                    <div
+                        class="border-border bg-background-subtle rounded border p-3"
+                    >
                         <FileSelectButton
                             bind:file={fileB}
                             label="Select second file"

--- a/frontend/src/routes/compare/CompareDialog.svelte
+++ b/frontend/src/routes/compare/CompareDialog.svelte
@@ -15,6 +15,8 @@
   -
   -->
 <script>
+    import { Fa } from "svelte-fa";
+    import { faRightLeft } from "@fortawesome/free-solid-svg-icons";
     import { BackendConnection } from "$lib/api/backend.js";
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import FileSelectButton from "$lib/components/FileSelectButton.svelte";
@@ -44,6 +46,7 @@
     });
 
     let compareMode = $state(CompareMode.STORED_TO_STORED);
+    let swapped = $state(false);
 
     let datasetA = $state(null);
     let graphA = $state(null);
@@ -101,6 +104,7 @@
 
     function onClose() {
         compareMode = CompareMode.STORED_TO_STORED;
+        swapped = false;
 
         datasetA = null;
         graphA = null;
@@ -114,12 +118,48 @@
 
     function onCompareModeChange(mode) {
         compareMode = mode;
+        swapped = false;
 
         datasetB = null;
         graphB = null;
 
         fileA = null;
         fileB = null;
+    }
+
+    function swapSelections() {
+        if (compareMode === CompareMode.STORED_TO_STORED) {
+            [datasetA, datasetB] = [datasetB, datasetA];
+            [graphA, graphB] = [graphB, graphA];
+        } else if (compareMode === CompareMode.FILE_TO_FILE) {
+            [fileA, fileB] = [fileB, fileA];
+        } else if (compareMode === CompareMode.FILE_TO_STORED) {
+            swapped = !swapped;
+        }
+    }
+
+    function invertPropertyChange(change) {
+        return { ...change, from: change.to, to: change.from };
+    }
+
+    function invertResourceChange(resource) {
+        return { ...resource, changes: resource.changes?.map(invertPropertyChange) ?? null };
+    }
+
+    function invertClassChange(cls) {
+        return {
+            ...invertResourceChange(cls),
+            attributes: cls.attributes?.map(invertResourceChange) ?? null,
+            associations: cls.associations?.map(invertResourceChange) ?? null,
+            enumEntries: cls.enumEntries?.map(invertResourceChange) ?? null,
+        };
+    }
+
+    function invertChangeList(changeList) {
+        return changeList.map(pkg => ({
+            ...invertResourceChange(pkg),
+            classes: pkg.classes.map(invertClassChange),
+        }));
     }
 
     async function runCompare() {
@@ -143,7 +183,10 @@
                 throw new Error(`Unknown compareMode: ${compareMode}`);
         }
 
-        const changeList = await response.json();
+        let changeList = await response.json();
+        if (swapped) {
+            changeList = invertChangeList(changeList);
+        }
         changeList.sort((a, b) => a.label.localeCompare(b.label));
         compareState.changeList.updateValue(changeList);
         migrationState.set({
@@ -193,78 +236,103 @@
             </div>
 
             {#if compareMode === CompareMode.STORED_TO_STORED}
-                <DatasetAndGraphSelection
-                    bind:dataset={datasetA}
-                    bind:graph={graphA}
-                    {lockedDatasetName}
-                    {lockedGraphUri}
-                />
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                    <DatasetAndGraphSelection
+                        bind:dataset={datasetA}
+                        bind:graph={graphA}
+                        {lockedDatasetName}
+                        {lockedGraphUri}
+                    />
+                </div>
 
                 <div class="flex items-center gap-3">
                     <div class="bg-border h-px w-full"></div>
-                    <span
-                        class="text-text-subtle text-xs font-light text-nowrap"
+                    <button
+                        onclick={swapSelections}
+                        class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                        title="Swap Before and After"
                     >
-                        COMPARE TO
-                    </span>
+                        <Fa icon={faRightLeft} />
+                        Swap
+                    </button>
                     <div class="bg-border h-px w-full"></div>
                 </div>
 
-                <DatasetAndGraphSelection
-                    bind:dataset={datasetB}
-                    bind:graph={graphB}
-                />
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                    <DatasetAndGraphSelection
+                        bind:dataset={datasetB}
+                        bind:graph={graphB}
+                    />
+                </div>
             {/if}
 
             {#if compareMode === CompareMode.FILE_TO_STORED}
-                <div
-                    class="border-border bg-background-subtle rounded border p-3"
-                >
-                    <FileSelectButton bind:file={fileA} />
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        {swapped ? "After" : "Before"}
+                    </span>
+                    <div class="border-border bg-background-subtle rounded border p-3">
+                        <FileSelectButton bind:file={fileA} />
+                    </div>
                 </div>
 
                 <div class="flex items-center gap-3">
                     <div class="bg-border h-px w-full"></div>
-                    <span
-                        class="text-text-subtle text-xs font-light text-nowrap"
+                    <button
+                        onclick={swapSelections}
+                        class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                        title="Swap Before and After"
                     >
-                        COMPARE TO
-                    </span>
+                        <Fa icon={faRightLeft} />
+                        Swap
+                    </button>
                     <div class="bg-border h-px w-full"></div>
                 </div>
 
-                <DatasetAndGraphSelection
-                    bind:dataset={datasetB}
-                    bind:graph={graphB}
-                    {lockedDatasetName}
-                    {lockedGraphUri}
-                />
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">
+                        {swapped ? "Before" : "After"}
+                    </span>
+                    <DatasetAndGraphSelection
+                        bind:dataset={datasetB}
+                        bind:graph={graphB}
+                        {lockedDatasetName}
+                        {lockedGraphUri}
+                    />
+                </div>
             {/if}
 
             {#if compareMode === CompareMode.FILE_TO_FILE}
-                <div
-                    class="border-border bg-background-subtle rounded border p-3"
-                >
-                    <FileSelectButton bind:file={fileA} />
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                    <div class="border-border bg-background-subtle rounded border p-3">
+                        <FileSelectButton bind:file={fileA} />
+                    </div>
                 </div>
 
                 <div class="flex items-center gap-3">
                     <div class="bg-border h-px w-full"></div>
-                    <span
-                        class="text-text-subtle text-xs font-light text-nowrap"
+                    <button
+                        onclick={swapSelections}
+                        class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                        title="Swap Before and After"
                     >
-                        COMPARE TO
-                    </span>
+                        <Fa icon={faRightLeft} />
+                        Swap
+                    </button>
                     <div class="bg-border h-px w-full"></div>
                 </div>
 
-                <div
-                    class="border-border bg-background-subtle rounded border p-3"
-                >
-                    <FileSelectButton
-                        bind:file={fileB}
-                        label="Select second file"
-                    />
+                <div class="flex flex-col gap-1.5">
+                    <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                    <div class="border-border bg-background-subtle rounded border p-3">
+                        <FileSelectButton
+                            bind:file={fileB}
+                            label="Select second file"
+                        />
+                    </div>
                 </div>
             {/if}
         </div>

--- a/frontend/src/routes/migrate/steps/SelectSchemas.svelte
+++ b/frontend/src/routes/migrate/steps/SelectSchemas.svelte
@@ -16,8 +16,10 @@
   -->
 
 <script>
+    import { faRightLeft } from "@fortawesome/free-solid-svg-icons";
     import { onMount } from "svelte";
     import { get } from "svelte/store";
+    import { Fa } from "svelte-fa";
 
     import DatasetAndGraphSelection from "$lib/components/DatasetAndGraphSelection.svelte";
     import FileSelectButton from "$lib/components/FileSelectButton.svelte";
@@ -33,6 +35,7 @@
         STORED_TO_STORED: 0,
         FILE_TO_STORED: 1,
         FILE_TO_FILE: 2,
+        STORED_TO_FILE: 3,
     });
 
     let compareMode = $state(CompareMode.FILE_TO_STORED);
@@ -58,6 +61,11 @@
             disabled: false,
         },
         {
+            value: CompareMode.STORED_TO_FILE,
+            label: "Stored → Uploaded",
+            disabled: false,
+        },
+        {
             value: CompareMode.FILE_TO_FILE,
             label: "Uploaded → Uploaded",
             disabled: false,
@@ -71,6 +79,10 @@
 
         if (compareMode === CompareMode.FILE_TO_STORED) {
             disableNext = !fileA || !datasetB || !graphB;
+        }
+
+        if (compareMode === CompareMode.STORED_TO_FILE) {
+            disableNext = !datasetA || !graphA || !fileA;
         }
 
         if (compareMode === CompareMode.STORED_TO_STORED) {
@@ -98,6 +110,27 @@
         fileB = null;
     }
 
+    function swapSelections() {
+        if (compareMode === CompareMode.STORED_TO_STORED) {
+            [datasetA, datasetB] = [datasetB, datasetA];
+            [graphA, graphB] = [graphB, graphA];
+        } else if (compareMode === CompareMode.FILE_TO_FILE) {
+            [fileA, fileB] = [fileB, fileA];
+        } else if (compareMode === CompareMode.FILE_TO_STORED) {
+            datasetA = datasetB;
+            graphA = graphB;
+            datasetB = null;
+            graphB = null;
+            compareMode = CompareMode.STORED_TO_FILE;
+        } else if (compareMode === CompareMode.STORED_TO_FILE) {
+            datasetB = datasetA;
+            graphB = graphA;
+            datasetA = null;
+            graphA = null;
+            compareMode = CompareMode.FILE_TO_STORED;
+        }
+    }
+
     export async function onNext() {
         let body = new FormData();
 
@@ -110,6 +143,10 @@
             body.append("fileA", fileA);
             body.append("datasetB", datasetB);
             body.append("graphB", graphB);
+        } else if (compareMode === CompareMode.STORED_TO_FILE) {
+            body.append("datasetA", datasetA);
+            body.append("graphA", graphA);
+            body.append("fileA", fileA);
         } else if (compareMode === CompareMode.FILE_TO_FILE) {
             body.append("fileA", fileA);
             body.append("fileB", fileB);
@@ -176,62 +213,125 @@
         </div>
 
         {#if compareMode === CompareMode.STORED_TO_STORED}
-            <DatasetAndGraphSelection
-                bind:dataset={datasetA}
-                bind:graph={graphA}
-            />
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                <DatasetAndGraphSelection
+                    bind:dataset={datasetA}
+                    bind:graph={graphA}
+                />
+            </div>
 
             <div class="flex items-center gap-3">
                 <div class="bg-border h-px w-full"></div>
-                <span class="text-text-subtle text-xs font-light text-nowrap">
-                    MIGRATE TO
-                </span>
+                <button
+                    onclick={swapSelections}
+                    class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                    title="Swap Before and After"
+                >
+                    <Fa icon={faRightLeft} />
+                    Swap
+                </button>
                 <div class="bg-border h-px w-full"></div>
             </div>
 
-            <DatasetAndGraphSelection
-                bind:dataset={datasetB}
-                bind:graph={graphB}
-            />
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                <DatasetAndGraphSelection
+                    bind:dataset={datasetB}
+                    bind:graph={graphB}
+                />
+            </div>
         {/if}
 
         {#if compareMode === CompareMode.FILE_TO_STORED}
-            <div class="border-border bg-background-subtle rounded border p-3">
-                <FileSelectButton bind:file={fileA} />
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                <div class="border-border bg-background-subtle rounded border p-3">
+                    <FileSelectButton bind:file={fileA} />
+                </div>
             </div>
 
             <div class="flex items-center gap-3">
                 <div class="bg-border h-px w-full"></div>
-                <span class="text-text-subtle text-xs font-light text-nowrap">
-                    MIGRATE TO
-                </span>
+                <button
+                    onclick={swapSelections}
+                    class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                    title="Swap Before and After"
+                >
+                    <Fa icon={faRightLeft} />
+                    Swap
+                </button>
                 <div class="bg-border h-px w-full"></div>
             </div>
 
-            <DatasetAndGraphSelection
-                bind:dataset={datasetB}
-                bind:graph={graphB}
-            />
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                <DatasetAndGraphSelection
+                    bind:dataset={datasetB}
+                    bind:graph={graphB}
+                />
+            </div>
+        {/if}
+
+        {#if compareMode === CompareMode.STORED_TO_FILE}
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                <DatasetAndGraphSelection
+                    bind:dataset={datasetA}
+                    bind:graph={graphA}
+                />
+            </div>
+
+            <div class="flex items-center gap-3">
+                <div class="bg-border h-px w-full"></div>
+                <button
+                    onclick={swapSelections}
+                    class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                    title="Swap Before and After"
+                >
+                    <Fa icon={faRightLeft} />
+                    Swap
+                </button>
+                <div class="bg-border h-px w-full"></div>
+            </div>
+
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                <div class="border-border bg-background-subtle rounded border p-3">
+                    <FileSelectButton bind:file={fileA} />
+                </div>
+            </div>
         {/if}
 
         {#if compareMode === CompareMode.FILE_TO_FILE}
-            <div class="border-border bg-background-subtle rounded border p-3">
-                <FileSelectButton bind:file={fileA} />
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                <div class="border-border bg-background-subtle rounded border p-3">
+                    <FileSelectButton bind:file={fileA} />
+                </div>
             </div>
 
             <div class="flex items-center gap-3">
                 <div class="bg-border h-px w-full"></div>
-                <span class="text-text-subtle text-xs font-light text-nowrap">
-                    MIGRATE TO
-                </span>
+                <button
+                    onclick={swapSelections}
+                    class="text-text-subtle hover:bg-background-subtle flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors text-nowrap"
+                    title="Swap Before and After"
+                >
+                    <Fa icon={faRightLeft} />
+                    Swap
+                </button>
                 <div class="bg-border h-px w-full"></div>
             </div>
 
-            <div class="border-border bg-background-subtle rounded border p-3">
-                <FileSelectButton
-                    bind:file={fileB}
-                    label="Select second file"
-                />
+            <div class="flex flex-col gap-1.5">
+                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                <div class="border-border bg-background-subtle rounded border p-3">
+                    <FileSelectButton
+                        bind:file={fileB}
+                        label="Select second file"
+                    />
+                </div>
             </div>
         {/if}
     </div>

--- a/frontend/src/routes/migrate/steps/SelectSchemas.svelte
+++ b/frontend/src/routes/migrate/steps/SelectSchemas.svelte
@@ -214,7 +214,9 @@
 
         {#if compareMode === CompareMode.STORED_TO_STORED}
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    Before
+                </span>
                 <DatasetAndGraphSelection
                     bind:dataset={datasetA}
                     bind:graph={graphA}
@@ -235,7 +237,9 @@
             </div>
 
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    After
+                </span>
                 <DatasetAndGraphSelection
                     bind:dataset={datasetB}
                     bind:graph={graphB}
@@ -245,8 +249,12 @@
 
         {#if compareMode === CompareMode.FILE_TO_STORED}
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
-                <div class="border-border bg-background-subtle rounded border p-3">
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    Before
+                </span>
+                <div
+                    class="border-border bg-background-subtle rounded border p-3"
+                >
                     <FileSelectButton bind:file={fileA} />
                 </div>
             </div>
@@ -265,7 +273,9 @@
             </div>
 
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    After
+                </span>
                 <DatasetAndGraphSelection
                     bind:dataset={datasetB}
                     bind:graph={graphB}
@@ -275,7 +285,9 @@
 
         {#if compareMode === CompareMode.STORED_TO_FILE}
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    Before
+                </span>
                 <DatasetAndGraphSelection
                     bind:dataset={datasetA}
                     bind:graph={graphA}
@@ -296,8 +308,12 @@
             </div>
 
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
-                <div class="border-border bg-background-subtle rounded border p-3">
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    After
+                </span>
+                <div
+                    class="border-border bg-background-subtle rounded border p-3"
+                >
                     <FileSelectButton bind:file={fileA} />
                 </div>
             </div>
@@ -305,8 +321,12 @@
 
         {#if compareMode === CompareMode.FILE_TO_FILE}
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">Before</span>
-                <div class="border-border bg-background-subtle rounded border p-3">
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    Before
+                </span>
+                <div
+                    class="border-border bg-background-subtle rounded border p-3"
+                >
                     <FileSelectButton bind:file={fileA} />
                 </div>
             </div>
@@ -325,8 +345,12 @@
             </div>
 
             <div class="flex flex-col gap-1.5">
-                <span class="text-text-subtle px-1 text-xs font-medium">After</span>
-                <div class="border-border bg-background-subtle rounded border p-3">
+                <span class="text-text-subtle px-1 text-xs font-medium">
+                    After
+                </span>
+                <div
+                    class="border-border bg-background-subtle rounded border p-3"
+                >
                     <FileSelectButton
                         bind:file={fileB}
                         label="Select second file"


### PR DESCRIPTION
## Summary

Adds Before / After labels to both schema selectors in the Compare dialog and the Migration schema-selection step, making the comparison direction explicit at a glance.

Replaces the static "COMPARE TO" / "MIGRATE TO" divider with a Swap button that reverses the direction. For stored↔stored and file↔file modes the selections are physically exchanged; for the file/stored mixed modes the button switches between the two explicit modes below.

Adds a new "Stored schema → Uploaded schema" (and "Stored → Uploaded" in migration) comparison type, closing the missing direction that was previously impossible without a workaround. The frontend inverts the comparison result for this mode; the backend gains a matching setMigrationContext(GraphIdentifier, MultipartFile) overload and detection branch so the migration flow also supports this direction end-to-end.

## Related Issues

Closes #152

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

Smoke tested compare.
