### PR TITLE
fix(normalization): use lowercase xsd:string datatype for comment literals (GH-162)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/dto/MappingUtils.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/MappingUtils.java
@@ -34,6 +34,6 @@ public class MappingUtils {
         if (comment == null) {
             return null;
         }
-        return new RDFSComment(comment, new URI("http://www.w3.org/2001/XMLSchema#String"));
+        return new RDFSComment(comment, new URI("http://www.w3.org/2001/XMLSchema#string"));
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
@@ -107,8 +107,14 @@ public interface AttributeMapper {
     }
 
     default CIMSDataType buildDataType(DataTypeDTO dto) {
+        URI uri;
+        if (dto.getType() == DataTypeDTO.Type.PRIMITIVE) {
+            uri = new URI(XSDDatatypeMapper.classLabelToDatatype(dto.getLabel()).getURI());
+        } else {
+            uri = new URI(dto.getPrefix() + dto.getLabel());
+        }
         return new CIMSDataType(
-                new URI(dto.getPrefix() + dto.getLabel()),
+                uri,
                 new RDFSLabel(dto.getLabel(), "en"),
                 CIMSDataType.Type.valueOf(dto.getType().toString()));
     }

--- a/backend/src/test/java/org/rdfarchitect/api/dto/AssociationMapperTest.java
+++ b/backend/src/test/java/org/rdfarchitect/api/dto/AssociationMapperTest.java
@@ -105,7 +105,7 @@ class AssociationMapperTest {
         void toDTO_fullAssociation() {
             cimAssociation.setComment(
                     new RDFSComment(
-                            "Test Comment", new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            "Test Comment", new URI("http://www.w3.org/2001/XMLSchema#string")));
 
             var dto = associationMapper.toDTO(cimAssociation);
 
@@ -195,7 +195,7 @@ class AssociationMapperTest {
                                             new RDFSComment(
                                                     "Test Comment",
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"))),
+                                                            "http://www.w3.org/2001/XMLSchema#string"))),
                     () ->
                             assertThat(mappedCIMAssociation.getMultiplicity())
                                     .isEqualTo(

--- a/backend/src/test/java/org/rdfarchitect/api/dto/AttributeMapperTest.java
+++ b/backend/src/test/java/org/rdfarchitect/api/dto/AttributeMapperTest.java
@@ -59,7 +59,7 @@ class AttributeMapperTest {
                                         new RDFSLabel("TestClass", "en")))
                         .dataType(
                                 new CIMSDataType(
-                                        new URI("http://www.w3.org/2001/XMLSchema#String"),
+                                        new URI("http://www.w3.org/2001/XMLSchema#string"),
                                         new RDFSLabel("String", "en"),
                                         CIMSDataType.Type.PRIMITIVE))
                         .stereotype(
@@ -106,13 +106,13 @@ class AttributeMapperTest {
         void toDTO_fullAttribute() {
             cimAttribute.setComment(
                     new RDFSComment(
-                            "Test comment", new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            "Test comment", new URI("http://www.w3.org/2001/XMLSchema#string")));
             cimAttribute.setFixedValue(
                     new CIMSIsFixed(
-                            "FixedValue", new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            "FixedValue", new URI("http://www.w3.org/2001/XMLSchema#string")));
             cimAttribute.setDefaultValue(
                     new CIMSIsDefault(
-                            "DefaultValue", new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            "DefaultValue", new URI("http://www.w3.org/2001/XMLSchema#string")));
 
             var dto = attributeMapper.toDTO(cimAttribute);
 
@@ -169,7 +169,7 @@ class AttributeMapperTest {
                                     .isEqualTo(
                                             new CIMSDataType(
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"),
+                                                            "http://www.w3.org/2001/XMLSchema#string"),
                                                     new RDFSLabel("String", "en"),
                                                     CIMSDataType.Type.PRIMITIVE)),
                     () -> assertThat(mappedCIMAttribute.getComment()).isNull(),
@@ -217,7 +217,7 @@ class AttributeMapperTest {
                                     .isEqualTo(
                                             new CIMSDataType(
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"),
+                                                            "http://www.w3.org/2001/XMLSchema#string"),
                                                     new RDFSLabel("String", "en"),
                                                     CIMSDataType.Type.PRIMITIVE)),
                     () ->
@@ -226,7 +226,7 @@ class AttributeMapperTest {
                                             new RDFSComment(
                                                     "Test comment",
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"))),
+                                                            "http://www.w3.org/2001/XMLSchema#string"))),
                     () ->
                             assertThat(mappedCIMAttribute.getStereotype())
                                     .isEqualTo(

--- a/backend/src/test/java/org/rdfarchitect/api/dto/ClassUMLAdaptedMapperTest.java
+++ b/backend/src/test/java/org/rdfarchitect/api/dto/ClassUMLAdaptedMapperTest.java
@@ -93,7 +93,7 @@ class ClassUMLAdaptedMapperTest {
             cimClass.setComment(
                     new RDFSComment(
                             "This is a test class",
-                            new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            new URI("http://www.w3.org/2001/XMLSchema#string")));
             cimClass.setStereotypes(
                     List.of(
                             new CIMSStereotype("Entsoe"),
@@ -192,7 +192,7 @@ class ClassUMLAdaptedMapperTest {
                                             new RDFSComment(
                                                     "This is a test class",
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"))),
+                                                            "http://www.w3.org/2001/XMLSchema#string"))),
                     () ->
                             assertThat(mappedCIMClass.getStereotypes())
                                     .isEqualTo(

--- a/backend/src/test/java/org/rdfarchitect/api/dto/EnumEntryMapperTest.java
+++ b/backend/src/test/java/org/rdfarchitect/api/dto/EnumEntryMapperTest.java
@@ -84,7 +84,7 @@ class EnumEntryMapperTest {
         void toDTO_fullEnumEntry() {
             cimEnumEntry.setComment(
                     new RDFSComment(
-                            "Test comment", new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            "Test comment", new URI("http://www.w3.org/2001/XMLSchema#string")));
             cimEnumEntry.setStereotype(
                     new CIMSStereotype("http://iec.ch/TC57/NonStandard/UML#enumeration"));
 
@@ -156,7 +156,7 @@ class EnumEntryMapperTest {
                                             new RDFSComment(
                                                     "Test comment",
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"))),
+                                                            "http://www.w3.org/2001/XMLSchema#string"))),
                     () ->
                             assertThat(mappedCIMEnumEntry.getStereotype())
                                     .isEqualTo(

--- a/backend/src/test/java/org/rdfarchitect/api/dto/PackageMapperTest.java
+++ b/backend/src/test/java/org/rdfarchitect/api/dto/PackageMapperTest.java
@@ -81,7 +81,7 @@ class PackageMapperTest {
                             UUID.randomUUID());
             cimPackage.setComment(
                     new RDFSComment(
-                            "Test comment", new URI("http://www.w3.org/2001/XMLSchema#String")));
+                            "Test comment", new URI("http://www.w3.org/2001/XMLSchema#string")));
             cimPackage.setBelongsToCategory(belongsToCategory);
 
             var dto = packageMapper.toDTO(cimPackage);
@@ -159,7 +159,7 @@ class PackageMapperTest {
                                             new RDFSComment(
                                                     "Test comment",
                                                     new URI(
-                                                            "http://www.w3.org/2001/XMLSchema#String"))),
+                                                            "http://www.w3.org/2001/XMLSchema#string"))),
                     () ->
                             assertThat(mappedCIMPackage.getBelongsToCategory())
                                     .isEqualTo(expectedBelongsToCategory));

--- a/backend/src/test/java/org/rdfarchitect/services/update/UpdatePackageServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/UpdatePackageServiceTest.java
@@ -128,7 +128,7 @@ class UpdatePackageServiceTest {
                     .isEqualTo(
                             new RDFSComment(
                                     "This is a test package",
-                                    new URI("http://www.w3.org/2001/XMLSchema#String")));
+                                    new URI("http://www.w3.org/2001/XMLSchema#string")));
         }
     }
 

--- a/frontend/src/routes/UserSettingDialog.svelte
+++ b/frontend/src/routes/UserSettingDialog.svelte
@@ -99,7 +99,7 @@
         </USC.Section>
         <USC.Section title="Normalization">
             <CheckBoxEditControl
-                label="Normalize comments to xsd:String"
+                label="Normalize comments to xsd:string"
                 value={localSettings["normalizeComments"]}
                 callOnInputTrue={() =>
                     (localSettings["normalizeComments"] = true)}


### PR DESCRIPTION
## Summary

Changed xsd:String to xsd:string

## Related Issues

Closes #162

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
