### PR TITLE
fix(stereotypes): give feedback when entering the concrete stereotype (GH-136)

### DIFF
--- a/frontend/src/lib/models/reactive/models/reactive-class.svelte.js
+++ b/frontend/src/lib/models/reactive/models/reactive-class.svelte.js
@@ -28,6 +28,7 @@ import {
     isInvalidClassLabel,
     isInvalidNamespace,
     isInvalidStereotype,
+    isManuallyEnteredConcreteStereotype,
     isInvalidUuid,
     isInvalidPackage,
     isInvalidSuperClass,
@@ -35,8 +36,11 @@ import {
 } from "$lib/models/reactive/validity-rules/validityFunctions.js";
 
 function initializeStereotypeViolationChecks(stereotype, stereotypesArray) {
-    stereotype.violationChecks.push(stereotype =>
-        isInvalidStereotype(stereotype, stereotypesArray),
+    stereotype.violationChecks.push(value =>
+        isInvalidStereotype(value, stereotypesArray),
+    );
+    stereotype.violationChecks.push(value =>
+        isManuallyEnteredConcreteStereotype(value, stereotype.isModified),
     );
 }
 

--- a/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
+++ b/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
@@ -17,6 +17,7 @@
 import { validate as uuidValidate } from "uuid";
 import { IriValidationStrategy, validateIri } from "validate-iri";
 
+import { CONCRETE_STEREOTYPE } from "$lib/models/stereotype-constants.js";
 import { getNCNameViolations } from "$lib/rdf-syntax-grammar/namespace/prefix/index.js";
 
 export function isInvalidUuid(uuid) {
@@ -216,6 +217,23 @@ export function isInvalidStereotype(stereotype, existingStereotypes) {
         violations.push("must be unique");
     }
     return violations;
+}
+
+/**
+ * Flags a stereotype that the user has manually set to the concrete URI. The
+ * concrete stereotype is managed exclusively through the "Abstract" checkbox,
+ * so it must not be entered as a regular stereotype. Only modified entries are
+ * flagged, so a class loaded with a persisted concrete stereotype (which is
+ * surfaced via the checkbox and hidden from the list) stays valid.
+ * @param {string} stereotype - the current stereotype value
+ * @param {boolean} isModified - whether the entry differs from its saved value
+ * @returns {string[]} the violations
+ */
+export function isManuallyEnteredConcreteStereotype(stereotype, isModified) {
+    if (isModified && stereotype === CONCRETE_STEREOTYPE) {
+        return ['use the "Abstract" checkbox to mark a class as concrete'];
+    }
+    return [];
 }
 
 export function isNotEmptyValidation(value) {

--- a/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
+++ b/frontend/src/lib/models/reactive/validity-rules/validityFunctions.js
@@ -213,7 +213,10 @@ export function isInvalidStereotype(stereotype, existingStereotypes) {
     if (!stereotype || stereotype.trim() === "") {
         violations.push("must not be empty");
     }
-    if (existingStereotypes.filter(s => s.equals(stereotype)).length > 1) {
+    if (
+        stereotype !== CONCRETE_STEREOTYPE &&
+        existingStereotypes.filter(s => s.equals(stereotype)).length > 1
+    ) {
         violations.push("must be unique");
     }
     return violations;

--- a/frontend/src/lib/models/stereotype-constants.js
+++ b/frontend/src/lib/models/stereotype-constants.js
@@ -1,0 +1,25 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+/**
+ * The stereotype that marks a class as concrete. Its presence (or absence) is
+ * surfaced through the "Abstract" checkbox rather than as a regular stereotype,
+ * so it must not be added manually as a separate stereotype entry.
+ * @type {string}
+ */
+export const CONCRETE_STEREOTYPE =
+    "http://iec.ch/TC57/NonStandard/UML#concrete";

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/IsAbstract.svelte
@@ -19,17 +19,17 @@
     import { v4 as uuidv4 } from "uuid";
 
     import CheckBoxEditControl from "$lib/components/CheckBoxEditControl.svelte";
+    import { CONCRETE_STEREOTYPE } from "$lib/models/stereotype-constants.js";
     import { editorState } from "$lib/sharedState.svelte.js";
 
     const { classStereotypes } = $props();
 
-    const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
     const classEditorContext = getContext("classEditor");
     const id = uuidv4();
 
     let readonly = $derived(classEditorContext.readonly);
 
-    let isAbstract = $derived(!classStereotypes.contains(concreteStereotype));
+    let isAbstract = $derived(!classStereotypes.contains(CONCRETE_STEREOTYPE));
 
     $effect(() => {
         editorState.selectedDiagram.subscribe();
@@ -52,9 +52,9 @@
                 indicateChanges={isAbstract.isModified}
                 value={isAbstract}
                 callOnInputTrue={() =>
-                    classStereotypes.remove(concreteStereotype)}
+                    classStereotypes.remove(CONCRETE_STEREOTYPE)}
                 callOnInputFalse={() =>
-                    classStereotypes.append(concreteStereotype)}
+                    classStereotypes.append(CONCRETE_STEREOTYPE)}
                 disabled={readonly}
             />
         </div>

--- a/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/stereotypes/Stereotype.svelte
@@ -23,14 +23,26 @@
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/utils/reactive-objects-control-button-utils.js";
+    import { CONCRETE_STEREOTYPE } from "$lib/models/stereotype-constants.js";
     import { editorState } from "$lib/sharedState.svelte.js";
 
     let { classStereotypes, stereotype } = $props();
 
     const classEditorContext = getContext("classEditor");
-    const concreteStereotype = "http://iec.ch/TC57/NonStandard/UML#concrete";
-    let suggestedStereotypes = $derived(classEditorContext.stereotypes);
+
+    // The concrete stereotype is managed via the "Abstract" checkbox, so it
+    // must not be offered as a regular, manually selectable stereotype.
+    let suggestedStereotypes = $derived(
+        withoutConcrete(classEditorContext.stereotypes),
+    );
     let readonly = $derived(classEditorContext.readonly);
+
+    // The persisted concrete stereotype is surfaced by the "Abstract" checkbox
+    // and hidden from the list. A row the user has just edited to the concrete
+    // URI stays visible so its violation message can explain the checkbox.
+    let isManagedConcrete = $derived(
+        stereotype.value === CONCRETE_STEREOTYPE && !stereotype.isModified,
+    );
 
     $effect(() => {
         editorState.selectedDiagram.subscribe();
@@ -39,16 +51,20 @@
 
     $effect(() => {
         editorState.selectedContext.subscribe();
-        suggestedStereotypes = classEditorContext.stereotypes;
+        suggestedStereotypes = withoutConcrete(classEditorContext.stereotypes);
     });
 
     onMount(() => {
         readonly = classEditorContext.readonly;
-        suggestedStereotypes = classEditorContext.stereotypes;
+        suggestedStereotypes = withoutConcrete(classEditorContext.stereotypes);
     });
+
+    function withoutConcrete(stereotypes) {
+        return (stereotypes ?? []).filter(s => s !== CONCRETE_STEREOTYPE);
+    }
 </script>
 
-{#if stereotype.value !== concreteStereotype}
+{#if !isManagedConcrete}
     <tr>
         <td>
             <div class="flex gap-0.5">

--- a/frontend/tests/models/reactive/validity-rules/validityFunctions.test.js
+++ b/frontend/tests/models/reactive/validity-rules/validityFunctions.test.js
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+import { describe, expect, it } from "vitest";
+
+import { isManuallyEnteredConcreteStereotype } from "../../../../src/lib/models/reactive/validity-rules/validityFunctions.js";
+import { CONCRETE_STEREOTYPE } from "../../../../src/lib/models/stereotype-constants.js";
+
+describe("isManuallyEnteredConcreteStereotype", () => {
+    it("flags a modified entry set to the concrete URI", () => {
+        expect(
+            isManuallyEnteredConcreteStereotype(CONCRETE_STEREOTYPE, true),
+        ).toHaveLength(1);
+    });
+
+    it("does not flag a persisted (unmodified) concrete entry", () => {
+        // A class loaded as non-abstract carries the concrete stereotype; it is
+        // surfaced via the "Abstract" checkbox and must stay valid.
+        expect(
+            isManuallyEnteredConcreteStereotype(CONCRETE_STEREOTYPE, false),
+        ).toEqual([]);
+    });
+
+    it("does not flag a regular stereotype, modified or not", () => {
+        const regular = "http://example.org/some#stereotype";
+        expect(isManuallyEnteredConcreteStereotype(regular, true)).toEqual([]);
+        expect(isManuallyEnteredConcreteStereotype(regular, false)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

The concrete stereotype is managed via the "Abstract" checkbox, so any row whose value equalled the concrete URI was hidden. Typing it into a new stereotype row made the input vanish mid-typing with no feedback.

Use the entry's isModified flag to distinguish the persisted/checkbox-managed concrete (hidden, stays valid) from a manually entered one, which now stays visible and shows a violation pointing to the Abstract checkbox. Also drop the concrete URI from the suggestion dropdown and centralise the URI constant.

<img width="619" height="199" alt="image" src="https://github.com/user-attachments/assets/32de0d17-9cbc-4d57-8760-34e665c32d0d" />

## Related Issues

Closes #136

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
