### PR TITLE
fix(ui): use neutral color for dialog close buttons (GH-137)

### DIFF
--- a/frontend/src/lib/dialog/ActionDialog.svelte
+++ b/frontend/src/lib/dialog/ActionDialog.svelte
@@ -131,7 +131,7 @@
                 </div>
                 <div class="size-8">
                     <FaIconButton
-                        variant="danger"
+                        variant="contrast"
                         callOnClick={() => {
                             let onCloseRes = onClose();
                             if (onCloseRes || onCloseRes === undefined)

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -169,7 +169,7 @@
         <FaIconButton
             callOnClick={closeClassEditor}
             icon={faXmark}
-            variant="danger"
+            variant="contrast"
             text="Close"
             title="Close class editor"
         />


### PR DESCRIPTION
## Summary

Close buttons (the X in dialogs via ActionDialog and the class editor "Close" button) used the "danger" variant, rendering them in alarming red despite not triggering any dangerous action. Switch them to the neutral "contrast" variant; genuinely destructive actions (Delete, Discard) keep the danger styling.

<img width="612" height="193" alt="image" src="https://github.com/user-attachments/assets/9901b734-a683-4729-bf45-95e5ee8597d3" />

## Related Issues

Closes #137

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
