### PR TITLE
fix(class-editor): collapse button labels to icons on narrow panel (GH-138, GH-139)

### DIFF
--- a/frontend/src/lib/components/FaIconButton.svelte
+++ b/frontend/src/lib/components/FaIconButton.svelte
@@ -23,15 +23,17 @@
         disabled = false,
         icon,
         text,
+        labelClass = "",
+        containerClass = "w-full",
         ...restProps
     } = $props();
 </script>
 
-<div class="w-full">
+<div class={containerClass}>
     <ButtonControl {disabled} {callOnClick} {...restProps}>
         <div class="flex size-full items-center justify-center gap-2">
             {#if text}
-                <p>
+                <p class={labelClass}>
                     {text}
                 </p>
             {/if}

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -134,7 +134,7 @@
             icon={faDiagramProject}
             text="Constraints"
             labelClass={labelHideClass}
-            containerClass="w-auto"
+            containerClass="flex-1"
             title="View Constraints (SHACL)"
         />
 
@@ -152,7 +152,7 @@
                 icon={faFloppyDisk}
                 text="Save"
                 labelClass={labelHideClass}
-                containerClass="w-auto"
+                containerClass="flex-1"
                 disabled={!reactiveClass.isValid || !reactiveClass.isModified}
                 title="Save class"
             />
@@ -162,7 +162,7 @@
                 disabled={!reactiveClass.isModified}
                 text="Reset"
                 labelClass={labelHideClass}
-                containerClass="w-auto"
+                containerClass="flex-1"
                 title="Reset changes"
             />
             <FaIconButton
@@ -171,7 +171,7 @@
                 variant="danger"
                 text="Delete"
                 labelClass={labelHideClass}
-                containerClass="w-auto"
+                containerClass="flex-1"
                 title="Delete class"
             />
             <DeleteDependenciesDialog

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -53,6 +53,14 @@
     let showDeleteDependenciesDialog = $state(false);
     let showSHACLClassDialog = $state(false);
     let readonly = $derived(classEditorContext.readonly);
+
+    // Hide the button labels (icon-only) once this row gets too narrow to fit
+    // them. Readonly mode only shows Constraints + Close, so it can keep the
+    // label far longer; edit mode has four labels and collapses earlier.
+    // Both branches must be complete literals so Tailwind's scanner emits them.
+    let labelHideClass = $derived(
+        readonly ? "@max-[12rem]:hidden" : "@max-[30rem]:hidden",
+    );
     let datasetName = $derived(classEditorContext.datasetName);
     let graphUri = $derived(classEditorContext.graphUri);
 
@@ -113,12 +121,20 @@
     }
 </script>
 
-<div class="flex gap-1">
-    <div class="w-1/5">
+<!--
+  - @container lets the labels collapse based on this row's own width (the
+  - class editor lives in a resizable split pane), not the viewport. Below
+  - ~28rem the labels are hidden via {labelHideClass} so the buttons stay
+  - readable as icon-only instead of clipping their text.
+-->
+<div class="@container flex items-center gap-1">
+    <div class="flex min-w-0 grow gap-1">
         <FaIconButton
             callOnClick={() => (showSHACLClassDialog = true)}
             icon={faDiagramProject}
             text="Constraints"
+            labelClass={labelHideClass}
+            containerClass="w-auto"
             title="View Constraints (SHACL)"
         />
 
@@ -129,32 +145,33 @@
             bind:showDialog={showSHACLClassDialog}
             class={reactiveClass}
         />
-    </div>
-    {#if !readonly}
-        <div class="w-1/5">
+
+        {#if !readonly}
             <FaIconButton
                 callOnClick={() => saveChanges(reactiveClass)}
                 icon={faFloppyDisk}
-                text={"Save"}
+                text="Save"
+                labelClass={labelHideClass}
+                containerClass="w-auto"
                 disabled={!reactiveClass.isValid || !reactiveClass.isModified}
                 title="Save class"
             />
-        </div>
-        <div class="w-1/5">
             <FaIconButton
                 callOnClick={() => reactiveClass.reset()}
                 icon={faRotateLeft}
                 disabled={!reactiveClass.isModified}
                 text="Reset"
+                labelClass={labelHideClass}
+                containerClass="w-auto"
                 title="Reset changes"
             />
-        </div>
-        <div class="w-1/5">
             <FaIconButton
                 callOnClick={() => (showDeleteDependenciesDialog = true)}
                 icon={faTrash}
                 variant="danger"
                 text="Delete"
+                labelClass={labelHideClass}
+                containerClass="w-auto"
                 title="Delete class"
             />
             <DeleteDependenciesDialog
@@ -163,17 +180,15 @@
                 resourceUuid={reactiveClass.uuid.value}
                 bind:showDialog={showDeleteDependenciesDialog}
             />
-        </div>
-    {/if}
-    <div class="ml-auto w-1/5">
-        <FaIconButton
-            callOnClick={closeClassEditor}
-            icon={faXmark}
-            variant="danger"
-            text="Close"
-            title="Close class editor"
-        />
+        {/if}
     </div>
+    <FaIconButton
+        callOnClick={closeClassEditor}
+        icon={faXmark}
+        variant="danger"
+        containerClass="w-auto"
+        title="Close class editor"
+    />
 </div>
 
 <DiscardCancelConfirmDialog

--- a/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/ClassEditorButtons.svelte
@@ -123,36 +123,30 @@
 
 <!--
   - @container lets the labels collapse based on this row's own width (the
-  - class editor lives in a resizable split pane), not the viewport. Below
-  - ~28rem the labels are hidden via {labelHideClass} so the buttons stay
+  - class editor lives in a resizable split pane), not the viewport. Once the
+  - row is too narrow, {labelHideClass} hides the labels so the buttons stay
   - readable as icon-only instead of clipping their text.
 -->
 <div class="@container flex items-center gap-1">
-    <div class="flex min-w-0 grow gap-1">
+    <!--
+      - grid-flow-col + auto-cols-fr makes every action button equal width
+      - (matching the widest), while the grid stays content-sized so the row
+      - is left-aligned instead of stretching to full width.
+    -->
+    <div class="grid grid-flow-col auto-cols-fr gap-1">
         <FaIconButton
             callOnClick={() => (showSHACLClassDialog = true)}
             icon={faDiagramProject}
             text="Constraints"
             labelClass={labelHideClass}
-            containerClass="flex-1"
             title="View Constraints (SHACL)"
         />
-
-        <SHACLClassSpecificPopUp
-            {datasetName}
-            {graphUri}
-            {reactiveClass}
-            bind:showDialog={showSHACLClassDialog}
-            class={reactiveClass}
-        />
-
         {#if !readonly}
             <FaIconButton
                 callOnClick={() => saveChanges(reactiveClass)}
                 icon={faFloppyDisk}
                 text="Save"
                 labelClass={labelHideClass}
-                containerClass="flex-1"
                 disabled={!reactiveClass.isValid || !reactiveClass.isModified}
                 title="Save class"
             />
@@ -162,7 +156,6 @@
                 disabled={!reactiveClass.isModified}
                 text="Reset"
                 labelClass={labelHideClass}
-                containerClass="flex-1"
                 title="Reset changes"
             />
             <FaIconButton
@@ -171,14 +164,7 @@
                 variant="danger"
                 text="Delete"
                 labelClass={labelHideClass}
-                containerClass="flex-1"
                 title="Delete class"
-            />
-            <DeleteDependenciesDialog
-                {datasetName}
-                {graphUri}
-                resourceUuid={reactiveClass.uuid.value}
-                bind:showDialog={showDeleteDependenciesDialog}
             />
         {/if}
     </div>
@@ -186,10 +172,24 @@
         callOnClick={closeClassEditor}
         icon={faXmark}
         variant="contrast"
-        containerClass="w-auto"
+        containerClass="ml-auto w-auto"
         title="Close class editor"
     />
 </div>
+
+<SHACLClassSpecificPopUp
+    {datasetName}
+    {graphUri}
+    {reactiveClass}
+    bind:showDialog={showSHACLClassDialog}
+    class={reactiveClass}
+/>
+<DeleteDependenciesDialog
+    {datasetName}
+    {graphUri}
+    resourceUuid={reactiveClass.uuid.value}
+    bind:showDialog={showDeleteDependenciesDialog}
+/>
 
 <DiscardCancelConfirmDialog
     bind:showDialog={showDiscardSaveConfirmDialog}

--- a/frontend/src/routes/mainpage/packageWindow.svelte
+++ b/frontend/src/routes/mainpage/packageWindow.svelte
@@ -23,7 +23,7 @@
     import ClassEditor from "./classEditor/classEditor.svelte";
     import RenderingWrapper from "./renderingWrapper.svelte";
 
-    let classEditorPaneWidth = $state(30);
+    let classEditorPaneWidth = $state(27);
     let paneSizeByPackage = $state({});
     let classDatasetName = $derived(
         editorState.selectedClassDataset.getValue() ??
@@ -56,7 +56,7 @@
         if (packageKey && paneSizeByPackage[packageKey]) {
             classEditorPaneWidth = paneSizeByPackage[packageKey];
         } else {
-            classEditorPaneWidth = 30;
+            classEditorPaneWidth = 27;
         }
     });
 


### PR DESCRIPTION
## Summary

The Close button in the property inspector was too wide because it
rendered the "Close" text alongside the X icon, causing other button
labels to truncate at normal inspector widths. Drop the text so it
matches the icon-only close affordance used in other dialogs; the
tooltip still describes the action.

<img width="524" height="216" alt="image" src="https://github.com/user-attachments/assets/a89a931c-72f5-4fc1-841e-51802dcbe0c0" />

<img width="417" height="254" alt="image" src="https://github.com/user-attachments/assets/35c2177f-86d1-4a3b-b735-1f34c186fb19" />

<img width="522" height="262" alt="image" src="https://github.com/user-attachments/assets/a3110aaa-3d60-47e4-9a31-dbf85b05502e" />


## Related Issues

Closes #138
Closes #139

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
