### PR TITLE
fix(menubar): make read-only toggle in Edit menu work (GH-167)

### DIFF
--- a/frontend/src/routes/layout/menu-bar/Edit.svelte
+++ b/frontend/src/routes/layout/menu-bar/Edit.svelte
@@ -34,6 +34,10 @@
     } from "@fortawesome/free-solid-svg-icons";
 
     import {
+        enableEditing,
+        disableEditing,
+    } from "$lib/actions/editingActions.js";
+    import {
         undo as doUndo,
         redo as doRedo,
     } from "$lib/actions/versionControlActions.js";
@@ -246,14 +250,6 @@
     }
     async function redo() {
         if (await doRedo()) reload();
-    }
-
-    async function enableEditing(datasetName) {
-        await bec.enableEditing(datasetName);
-    }
-
-    async function disableEditing(datasetName) {
-        await bec.disableEditing(datasetName);
     }
 
     function copyClass() {


### PR DESCRIPTION
## Summary

The Edit menubar defined local enableEditing/disableEditing wrappers that returned undefined instead of a boolean. The success guards in requestEnableEditing/requestDisableEditing therefore always treated the call as failed and returned early, skipping reload() and the reload triggers, so the UI never reflected the toggled state.

Import the shared editingActions helpers (as the context-menu and button call sites already do) which return true/false and surface toasts.

## Related Issues

Closes #167

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
