### PR TITLE
fix(import): notify when imported properties cannot be displayed (GH-141)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/GraphBulkContentRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/GraphBulkContentRESTController.java
@@ -84,9 +84,15 @@ public class GraphBulkContentRESTController {
         var msg = result.failedFileNames().isEmpty() ? "success" : "failed imports";
         return ResponseEntity.ok(
                 new GraphBulkImportResponse(
-                        msg, result.failedFileNames(), result.importedGraphUris()));
+                        msg,
+                        result.failedFileNames(),
+                        result.importedGraphUris(),
+                        result.warnings()));
     }
 
     public record GraphBulkImportResponse(
-            String message, List<String> failedImports, List<String> importedGraphUris) {}
+            String message,
+            List<String> failedImports,
+            List<String> importedGraphUris,
+            List<ImportGraphsUseCase.ImportWarning> warnings) {}
 }

--- a/backend/src/main/java/org/rdfarchitect/services/update/graph/ImportGraphsService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/graph/ImportGraphsService.java
@@ -21,11 +21,17 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.graph.Graph;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
 import org.jetbrains.annotations.NotNull;
 import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.exception.database.DataAccessException;
+import org.rdfarchitect.models.cim.rdf.resources.CIMS;
+import org.rdfarchitect.models.cim.rdf.resources.CIMStereotypes;
 import org.rdfarchitect.models.cim.rdf.resources.RDFA;
 import org.rdfarchitect.rdf.graph.source.builder.implementations.GraphFileSourceBuilderImpl;
 import org.rdfarchitect.services.dl.update.packagelayout.CreateDiagramLayoutUseCase;
@@ -43,6 +49,7 @@ import java.io.InputStream;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -103,20 +110,59 @@ public class ImportGraphsService implements ImportGraphsUseCase {
         try {
             var graphUri = normalizeGraphUri(requestedUri, file.getOriginalFilename());
             graphUri = ensureUniqueGraphUri(graphUri, reservedGraphUris);
-            var graphIdentifier = replaceGraph(datasetName, graphUri, file);
+            var graph = parseGraph(file, graphUri);
+            var undisplayableProperties = findUndisplayableProperties(graph);
+            var graphIdentifier = replaceGraph(datasetName, graphUri, graph);
             result.importedGraphUris().add(graphUri);
+            if (!undisplayableProperties.isEmpty()) {
+                result.warnings()
+                        .add(
+                                new ImportWarning(
+                                        file.getOriginalFilename(), undisplayableProperties));
+            }
             createDiagramLayoutUseCase.createDiagramLayout(graphIdentifier);
         } catch (RuntimeException _) {
             result.failedFileNames().add(file.getOriginalFilename());
         }
     }
 
-    private GraphIdentifier replaceGraph(String datasetName, String graphUri, MultipartFile file) {
+    private GraphIdentifier replaceGraph(String datasetName, String graphUri, Graph graph) {
         var graphIdentifier = new GraphIdentifier(datasetName, graphUri);
-        var graph = parseGraph(file, graphUri);
         databasePort.deleteGraph(graphIdentifier);
         databasePort.createGraph(graphIdentifier, graph);
         return graphIdentifier;
+    }
+
+    /**
+     * Finds properties that are imported but will not be displayed in the editor. RDFArchitect only
+     * renders an {@code rdf:Property} that has a domain as an attribute (when it carries the {@code
+     * UML#attribute} stereotype) or as an association (when it carries {@code
+     * cims:AssociationUsed}). A domain-bound property with neither marker is stored but stays
+     * invisible, so we surface it as a warning instead of dropping it silently.
+     *
+     * @param graph the parsed graph to inspect
+     * @return the names (labels, falling back to URIs) of properties that will not be displayed
+     */
+    private List<String> findUndisplayableProperties(Graph graph) {
+        var model = ModelFactory.createModelForGraph(graph);
+        var undisplayableProperties = new ArrayList<String>();
+        model.listSubjectsWithProperty(RDF.type, RDF.Property)
+                .filterKeep(Resource::isURIResource)
+                .filterKeep(property -> property.hasProperty(RDFS.domain))
+                .filterDrop(
+                        property -> property.hasProperty(CIMS.stereotype, CIMStereotypes.attribute))
+                .filterDrop(property -> property.hasProperty(CIMS.associationUsed))
+                .forEachRemaining(property -> undisplayableProperties.add(propertyName(property)));
+        return undisplayableProperties;
+    }
+
+    private String propertyName(Resource property) {
+        var label = property.getProperty(RDFS.label);
+        if (label != null && label.getObject().isLiteral()) {
+            return label.getString();
+        }
+        var localName = property.getLocalName();
+        return localName == null || localName.isBlank() ? property.getURI() : localName;
     }
 
     private void importZipFile(

--- a/backend/src/main/java/org/rdfarchitect/services/update/graph/ImportGraphsUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/graph/ImportGraphsUseCase.java
@@ -26,16 +26,30 @@ public interface ImportGraphsUseCase {
 
     /**
      * Result of a graph import operation, separating successfully imported graph URIs from the
-     * filenames of files that failed to import.
+     * filenames of files that failed to import and any non-fatal warnings raised while importing.
      *
      * @param importedGraphUris the URIs of successfully imported graphs
      * @param failedFileNames the original filenames of files that could not be imported
+     * @param warnings non-fatal warnings about content that was imported but cannot be displayed
      */
-    record ImportResult(List<String> importedGraphUris, List<String> failedFileNames) {
+    record ImportResult(
+            List<String> importedGraphUris,
+            List<String> failedFileNames,
+            List<ImportWarning> warnings) {
         public ImportResult() {
-            this(new ArrayList<>(), new ArrayList<>());
+            this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
         }
     }
+
+    /**
+     * Warning about a successfully imported file whose content is not fully representable in the
+     * editor. The triples are stored, but the listed properties will not be displayed as attributes
+     * or associations because they lack the CIM metadata RDFArchitect relies on.
+     *
+     * @param fileName the original filename the warning relates to
+     * @param undisplayableProperties names of the properties that will not be displayed
+     */
+    record ImportWarning(String fileName, List<String> undisplayableProperties) {}
 
     /**
      * Imports multiple graphs into the specified dataset.

--- a/backend/src/test/java/org/rdfarchitect/services/update/graph/ImportGraphsServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/graph/ImportGraphsServiceTest.java
@@ -145,8 +145,7 @@ class ImportGraphsServiceTest {
 
         var warning = result.warnings().getFirst();
         assertThat(warning.fileName()).isEqualTo("schema.ttl");
-        assertThat(warning.undisplayableProperties())
-                .containsExactlyInAnyOrder("color", "owner");
+        assertThat(warning.undisplayableProperties()).containsExactlyInAnyOrder("color", "owner");
     }
 
     @Test

--- a/backend/src/test/java/org/rdfarchitect/services/update/graph/ImportGraphsServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/graph/ImportGraphsServiceTest.java
@@ -89,4 +89,104 @@ class ImportGraphsServiceTest {
 
         verify(createDiagramLayoutUseCaseMock, times(2)).createDiagramLayout(any());
     }
+
+    @Test
+    void importGraphs_propertiesWithoutCimMetadata_areReportedAsUndisplayable() {
+        var datasetName = "ds";
+
+        // Gadget.color and Gadget.owner are plain rdf:Property declarations without the
+        // UML#attribute stereotype or cims:AssociationUsed, so they cannot be displayed.
+        // Gadget.size is a conformant attribute and Gadget.parent a conformant association.
+        var schema =
+                """
+                @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+                @prefix cims: <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+                @prefix uml:  <http://iec.ch/TC57/NonStandard/UML#> .
+                @prefix ex:   <http://example.com/> .
+
+                ex:Gadget a rdfs:Class ; rdfs:label "Gadget"@en .
+
+                ex:Gadget.color a rdf:Property ;
+                    rdfs:label  "color"@en ;
+                    rdfs:domain ex:Gadget ;
+                    rdfs:range  ex:String .
+
+                ex:Gadget.owner a rdf:Property ;
+                    rdfs:label  "owner"@en ;
+                    rdfs:domain ex:Gadget ;
+                    rdfs:range  ex:Owner .
+
+                ex:Gadget.size a rdf:Property ;
+                    rdfs:label      "size"@en ;
+                    rdfs:domain     ex:Gadget ;
+                    cims:stereotype uml:attribute ;
+                    rdfs:range      ex:String .
+
+                ex:Gadget.parent a rdf:Property ;
+                    rdfs:label           "parent"@en ;
+                    rdfs:domain          ex:Gadget ;
+                    cims:AssociationUsed "Yes" ;
+                    rdfs:range           ex:Gadget .
+                """;
+
+        var file =
+                new MockMultipartFile(
+                        "graph",
+                        "schema.ttl",
+                        "text/turtle",
+                        schema.getBytes(StandardCharsets.UTF_8));
+
+        var result = importGraphsUseCase.importGraphs(datasetName, List.of(file), null);
+
+        assertThat(result.failedFileNames()).isEmpty();
+        assertThat(result.importedGraphUris()).containsExactly(RDFA.GRAPH_URI + "schema");
+        assertThat(result.warnings()).hasSize(1);
+
+        var warning = result.warnings().getFirst();
+        assertThat(warning.fileName()).isEqualTo("schema.ttl");
+        assertThat(warning.undisplayableProperties())
+                .containsExactlyInAnyOrder("color", "owner");
+    }
+
+    @Test
+    void importGraphs_conformantSchema_producesNoWarnings() {
+        var datasetName = "ds";
+
+        var schema =
+                """
+                @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+                @prefix cims: <http://iec.ch/TC57/1999/rdf-schema-extensions-19990926#> .
+                @prefix uml:  <http://iec.ch/TC57/NonStandard/UML#> .
+                @prefix ex:   <http://example.com/> .
+
+                ex:Gadget a rdfs:Class ; rdfs:label "Gadget"@en .
+
+                ex:Gadget.size a rdf:Property ;
+                    rdfs:label      "size"@en ;
+                    rdfs:domain     ex:Gadget ;
+                    cims:stereotype uml:attribute ;
+                    rdfs:range      ex:String .
+
+                ex:Gadget.parent a rdf:Property ;
+                    rdfs:label           "parent"@en ;
+                    rdfs:domain          ex:Gadget ;
+                    cims:AssociationUsed "Yes" ;
+                    rdfs:range           ex:Gadget .
+                """;
+
+        var file =
+                new MockMultipartFile(
+                        "graph",
+                        "schema.ttl",
+                        "text/turtle",
+                        schema.getBytes(StandardCharsets.UTF_8));
+
+        var result = importGraphsUseCase.importGraphs(datasetName, List.of(file), null);
+
+        assertThat(result.failedFileNames()).isEmpty();
+        assertThat(result.importedGraphUris()).containsExactly(RDFA.GRAPH_URI + "schema");
+        assertThat(result.warnings()).isEmpty();
+    }
 }

--- a/frontend/src/routes/ImportDialog.svelte
+++ b/frontend/src/routes/ImportDialog.svelte
@@ -253,6 +253,29 @@
         } else {
             toastStore.success("Import complete", summary);
         }
+
+        notifyUndisplayableProperties(body.warnings ?? []);
+    }
+
+    function notifyUndisplayableProperties(warnings) {
+        if (warnings.length === 0) {
+            return;
+        }
+        const total = warnings.reduce(
+            (sum, warning) =>
+                sum + (warning.undisplayableProperties?.length ?? 0),
+            0,
+        );
+        const details = warnings
+            .map(
+                warning =>
+                    `${warning.fileName}: ${(warning.undisplayableProperties ?? []).join(", ")}`,
+            )
+            .join("; ");
+        toastStore.warning(
+            "Some properties could not be displayed",
+            `${total} propert${total === 1 ? "y" : "ies"} ${total === 1 ? "is" : "are"} missing the CIM stereotype or association metadata RDFArchitect needs to show ${total === 1 ? "it" : "them"} (${details}).`,
+        );
     }
 
     async function importGraphs() {


### PR DESCRIPTION
## Summary

An rdf:Property with an rdfs:domain but neither the UML#attribute stereotype nor cims:AssociationUsed was stored on import yet stayed invisible in the editor, since the attribute/association read queries never matched it. The import reported success, so the missing properties looked like silent data loss.

Detect these non-displayable properties while importing each file and return them as warnings in the bulk-import response. The Import dialog now raises a toast naming the affected file and properties, explaining they lack the CIM metadata RDFArchitect needs to render them.

## Related Issues

Closes #141

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
