### PR TITLE
fix(navigation): show parent diagram when selecting a class with none open (GH-142)

### DIFF
--- a/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ClassEntry.svelte
@@ -70,6 +70,10 @@
     });
 
     function selectClass() {
+        if (!diagramId && !editorState.selectedDiagram.getProperty("id")) {
+            showClassInPackage();
+            return;
+        }
         if (!diagramId) {
             classNavEntry.parent?.open();
         }


### PR DESCRIPTION
## Summary

After importing a schema no diagram is rendered, so clicking a class in the package tree left the canvas on the empty "No diagram requested yet" state. When nothing is shown yet, open the class's parent package diagram and focus the class so a diagram is always visible.

## Related Issues

Closes #142

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
