### PR TITLE
fix(ui): use consistent title case for menu labels and dialog titles (GH-144)

### DIFF
--- a/frontend/src/routes/FilterViewDialog.svelte
+++ b/frontend/src/routes/FilterViewDialog.svelte
@@ -62,7 +62,7 @@
     bind:showDialog
     primaryLabel="Save"
     onPrimary={submit}
-    title="Select filters"
+    title="Select Filters"
 >
     <div class="flex flex-col space-y-2">
         {#each options as option}

--- a/frontend/src/routes/NewGraphDialog.svelte
+++ b/frontend/src/routes/NewGraphDialog.svelte
@@ -166,9 +166,9 @@
     bind:showDialog
     {onOpen}
     {onClose}
-    primaryLabel="Add schema"
+    primaryLabel="Add Schema"
     onPrimary={addGraph}
-    title="Add schema"
+    title="Add Schema"
     disablePrimary={disableSubmit}
 >
     <div class="mx-2 flex h-full flex-col">

--- a/frontend/src/routes/mainpage/packageNavigation/GraphSection.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/GraphSection.svelte
@@ -215,7 +215,7 @@
                         }}
                         faIcon={faGear}
                     >
-                        Edit profile header
+                        Edit Profile Header
                     </ContextMenu.Item.Button>
                     <ContextMenu.Item.Button
                         onSelect={() => {
@@ -224,7 +224,7 @@
                         variant="danger"
                         faIcon={faTrash}
                     >
-                        Delete profile header
+                        Delete Profile Header
                     </ContextMenu.Item.Button>
                 {:else}
                     <ContextMenu.Item.Button
@@ -233,7 +233,7 @@
                         }}
                         faIcon={faPlus}
                     >
-                        Create profile header
+                        Create Profile Header
                     </ContextMenu.Item.Button>
                 {/if}
                 <ContextMenu.Separator />
@@ -244,7 +244,7 @@
                     }}
                     faIcon={faEye}
                 >
-                    View profile header
+                    View Profile Header
                 </ContextMenu.Item.Button>
                 <ContextMenu.Separator />
             {/if}

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomDatasetDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomDatasetDiagramDialog.svelte
@@ -222,7 +222,7 @@
     bind:showDialog
     {onOpen}
     {onClose}
-    title="Create/Edit custom diagram for dataset"
+    title="Create/Edit Custom Diagram for Dataset"
     primaryLabel="Save"
     onPrimary={submitDiagramClasses}
     disablePrimary={disableSubmit}

--- a/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomGraphDiagramDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/custom-diagram-dialogs/CustomGraphDiagramDialog.svelte
@@ -155,7 +155,7 @@
     bind:showDialog
     {onOpen}
     {onClose}
-    title={"Create/Edit custom diagram for profile"}
+    title={"Create/Edit Custom Diagram for Profile"}
     primaryLabel="Save"
     onPrimary={submitDiagramClasses}
     disablePrimary={disableSubmit}

--- a/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/AddKnownFieldsDialog.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/ontology-editor-dialog/AddKnownFieldsDialog.svelte
@@ -163,7 +163,7 @@
         showDialog = false;
     }}
     disablePrimary={disableSubmit}
-    title="Select fields to add"
+    title="Select Fields to Add"
 >
     <div class="flex flex-col pb-1">
         <div

--- a/frontend/src/routes/mainpage/packageNavigation/packageNavigation.svelte
+++ b/frontend/src/routes/mainpage/packageNavigation/packageNavigation.svelte
@@ -91,7 +91,7 @@
                 onSelect={() => (showNewGraphDialog = true)}
                 faIcon={faDiagramProject}
             >
-                Add schema
+                Add Schema
             </ContextMenu.Item.Button>
             <ContextMenu.Item.Button
                 onSelect={() => (showImportDialog = true)}


### PR DESCRIPTION
## Summary

Several context-menu items, dialog titles and a primary button label used sentence case ("Add schema") while the dominant convention across the app is title case ("Add Schema", "Import Schema"). Aligned the outliers so labels read consistently:

- "Add schema" context-menu item plus the new-schema dialog title and primary button label
- "Select filters" and "Select fields to add" dialog titles
- "Create/Edit custom diagram for dataset/profile" dialog titles
- "Edit/Delete/Create/View profile header" context-menu items

## Related Issues

Closes #144

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
