### PR TITLE
fix(class-editor): restore comment Edit/Preview toggle button and fix asciidoc renderer (GH-171, GH-177)

### DIFF
--- a/frontend/src/routes/mainpage/classEditor/asciidocComment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/asciidocComment.svelte
@@ -16,10 +16,11 @@
   -->
 
 <script>
-    import Asciidoctor from "asciidoctor";
+    import AsciidoctorModule from "asciidoctor";
 
     const { comment } = $props();
-    const asciidoctor = Asciidoctor();
+    const createAsciidoctor = AsciidoctorModule.default ?? AsciidoctorModule;
+    const asciidoctor = createAsciidoctor();
     let convertedClassComment = $derived(
         comment ? asciidoctor.convert(comment, { safe: "secure" }) : "",
     );

--- a/frontend/src/routes/mainpage/classEditor/classEditor.svelte
+++ b/frontend/src/routes/mainpage/classEditor/classEditor.svelte
@@ -272,11 +272,11 @@
     });
 </script>
 
-<div class="relative h-screen w-full">
+<div class="relative h-full w-full">
     <Splitpanes
         theme="opencgmes-theme"
         horizontal
-        class="bg-window-background h-screen"
+        class="bg-window-background h-full"
     >
         {#if reactiveClass}
             <Pane

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -16,13 +16,12 @@
   -->
 <script>
     import { faEye, faGear } from "@fortawesome/free-solid-svg-icons";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { v4 as uuidv4 } from "uuid";
 
     import FaIconButton from "$lib/components/FaIconButton.svelte";
     import TextAreaControl from "$lib/components/TextAreaControl.svelte";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/utils/reactive-objects-control-button-utils.js";
-    import { editorState } from "$lib/sharedState.svelte.js";
 
     import AsciidocComment from "../asciidocComment.svelte";
 
@@ -32,17 +31,10 @@
     const id = uuidv4();
     let editClassComment = $state(false);
     let readonly = $derived(classEditorContext.readonly);
-
-    $effect(() => {
-        editorState.selectedDiagram.subscribe();
-        readonly = classEditorContext.readonly;
-    });
-
-    onMount(() => (readonly = classEditorContext.readonly));
 </script>
 
-<div class="flex min-h-0 flex-1 flex-col">
-    <div class="text-default-text flex h-full w-full flex-col">
+<div class="flex h-full min-h-0 flex-col">
+    <div class="text-default-text flex min-h-0 w-full flex-1 flex-col">
         <label for={id} class="text-blue block font-normal">Comment</label>
         {#if editClassComment}
             <div
@@ -69,13 +61,13 @@
             </div>
         {/if}
     </div>
+    {#if !readonly}
+        <div class="flex shrink-0 items-end justify-end space-x-1">
+            <FaIconButton
+                callOnClick={() => (editClassComment = !editClassComment)}
+                text={editClassComment ? "Edit" : "Preview"}
+                icon={editClassComment ? faGear : faEye}
+            />
+        </div>
+    {/if}
 </div>
-{#if !readonly}
-    <div class="flex shrink-0 items-end justify-end space-x-1">
-        <FaIconButton
-            callOnClick={() => (editClassComment = !editClassComment)}
-            text={editClassComment ? "Edit" : "Preview"}
-            icon={editClassComment ? faGear : faEye}
-        />
-    </div>
-{/if}

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -62,7 +62,7 @@
         {/if}
     </div>
     {#if !readonly}
-        <div class="flex shrink-0 items-end justify-end space-x-1">
+        <div class="mt-1 flex shrink-0 items-end justify-end space-x-1">
             <FaIconButton
                 callOnClick={() => (editClassComment = !editClassComment)}
                 text={editClassComment ? "Edit" : "Preview"}

--- a/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/Comment.svelte
@@ -36,7 +36,7 @@
 <div class="flex h-full min-h-0 flex-col">
     <div class="text-default-text flex min-h-0 w-full flex-1 flex-col">
         <label for={id} class="text-blue block font-normal">Comment</label>
-        {#if editClassComment}
+        {#if editClassComment || readonly}
             <div
                 class="text-default-text border-border min-h-0 flex-1 overflow-auto rounded-xs border border-solid p-2
                         {readonly


### PR DESCRIPTION
## Summary

- **Restore the Edit/Preview toggle button.** The class editor was sized with
  `h-screen` (100vh) even though it is mounted inside a shorter
  `overflow-auto` container, so the bottom comment pane (and its button) was
  pushed off screen and the comment textarea ran past the bottom of the page.
  The editor now uses `h-full` to fit its container. The comment component was
  also restructured into a single explicit `h-full` flex column (editor area
  `flex-1 min-h-0`, button row `shrink-0`) so the button's space is always
  reserved.

- **Fix the asciidoc preview crash.** Clicking Preview threw
  `Asciidoctor is not a function`. `asciidoctor@3` re-exports the ESM
  `@asciidoctor/core` (factory on the default export), so once bundled the
  default import is a module-namespace object rather than the callable factory.
  The interop is now normalized before invoking.

- **Render the comment as asciidoc in read-only mode.** The toggle is hidden
  when read-only, which left the raw textarea as the only view. Read-only
  comments now always render the asciidoc preview.

- **Add spacing** between the comment field and the Edit/Preview button.

## Related Issues

Closes #171 
Closes #177 

## Checklist

- [ ] Tests added or updated (or not applicable)
- [ ] Documentation updated (or not applicable)
- [ ] No breaking changes introduced (or described in the summary above)
- [ ] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
