### PR TITLE
fix: xsd:string and PRIMITVE datatypes fix

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
@@ -18,6 +18,7 @@
 package org.rdfarchitect.api.dto.attributes;
 
 import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.vocabulary.XSD;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -108,7 +109,7 @@ public interface AttributeMapper {
 
     default CIMSDataType buildDataType(DataTypeDTO dto) {
         URI uri;
-        if (dto.getType() == DataTypeDTO.Type.PRIMITIVE) {
+        if (dto.getPrefix().startsWith(XSD.getURI())) {
             uri = new URI(XSDDatatypeMapper.classLabelToDatatype(dto.getLabel()).getURI());
         } else {
             uri = new URI(dto.getPrefix() + dto.getLabel());

--- a/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
@@ -109,7 +109,7 @@ public interface AttributeMapper {
 
     default CIMSDataType buildDataType(DataTypeDTO dto) {
         URI uri;
-        if (dto.getPrefix().startsWith(XSD.getURI())) {
+        if (dto.getPrefix().equalsIgnoreCase(XSD.getURI())) {
             uri = new URI(XSDDatatypeMapper.classLabelToDatatype(dto.getLabel()).getURI());
         } else {
             uri = new URI(dto.getPrefix() + dto.getLabel());

--- a/backend/src/main/java/org/rdfarchitect/shacl/XSDDatatypeMapper.java
+++ b/backend/src/main/java/org/rdfarchitect/shacl/XSDDatatypeMapper.java
@@ -32,7 +32,9 @@ public class XSDDatatypeMapper {
         var typeListIterator = TypeMapper.getInstance().listTypes();
         while (typeListIterator.hasNext()) {
             var dt = typeListIterator.next();
-            if (dt.getURI().equalsIgnoreCase(xsdUri)) {
+            if (primitiveDatatypeClassLabel.equals("string")
+                    ? dt.getURI().equals(xsdUri)
+                    : dt.getURI().equalsIgnoreCase(xsdUri)) {
                 return dt;
             }
         }


### PR DESCRIPTION
## Summary

fixes that xsd:string was converted to xsd:String and that PRIMITIVE datatypes were converted to xsd datatypes

## Related Issues


## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes