### PR TITLE
fix(mapper): stop rewriting all primitive attribute datatypes to xsd

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/attributes/AttributeMapper.java
@@ -107,14 +107,8 @@ public interface AttributeMapper {
     }
 
     default CIMSDataType buildDataType(DataTypeDTO dto) {
-        URI uri;
-        if (dto.getType() == DataTypeDTO.Type.PRIMITIVE) {
-            uri = new URI(XSDDatatypeMapper.classLabelToDatatype(dto.getLabel()).getURI());
-        } else {
-            uri = new URI(dto.getPrefix() + dto.getLabel());
-        }
         return new CIMSDataType(
-                uri,
+                new URI(dto.getPrefix() + dto.getLabel()),
                 new RDFSLabel(dto.getLabel(), "en"),
                 CIMSDataType.Type.valueOf(dto.getType().toString()));
     }

--- a/backend/src/test/java/org/rdfarchitect/api/dto/AttributeMapperTest.java
+++ b/backend/src/test/java/org/rdfarchitect/api/dto/AttributeMapperTest.java
@@ -60,7 +60,7 @@ class AttributeMapperTest {
                         .dataType(
                                 new CIMSDataType(
                                         new URI("http://www.w3.org/2001/XMLSchema#string"),
-                                        new RDFSLabel("String", "en"),
+                                        new RDFSLabel("string", "en"),
                                         CIMSDataType.Type.PRIMITIVE))
                         .stereotype(
                                 new CIMSStereotype("http://iec.ch/TC57/NonStandard/UML#attribute"))
@@ -78,7 +78,7 @@ class AttributeMapperTest {
                         .multiplicity("0...1")
                         .dataType(
                                 new DataTypeDTO(
-                                        "String",
+                                        "string",
                                         "http://www.w3.org/2001/XMLSchema#",
                                         DataTypeDTO.Type.PRIMITIVE))
                         .build();
@@ -170,7 +170,7 @@ class AttributeMapperTest {
                                             new CIMSDataType(
                                                     new URI(
                                                             "http://www.w3.org/2001/XMLSchema#string"),
-                                                    new RDFSLabel("String", "en"),
+                                                    new RDFSLabel("string", "en"),
                                                     CIMSDataType.Type.PRIMITIVE)),
                     () -> assertThat(mappedCIMAttribute.getComment()).isNull(),
                     () ->
@@ -218,7 +218,7 @@ class AttributeMapperTest {
                                             new CIMSDataType(
                                                     new URI(
                                                             "http://www.w3.org/2001/XMLSchema#string"),
-                                                    new RDFSLabel("String", "en"),
+                                                    new RDFSLabel("string", "en"),
                                                     CIMSDataType.Type.PRIMITIVE)),
                     () ->
                             assertThat(mappedCIMAttribute.getComment())


### PR DESCRIPTION
## Summary

buildDataType routed every PRIMITIVE datatype through XSDDatatypeMapper.classLabelToDatatype, whose fallback prepends the XSD namespace to any label. Non-XSD primitives (e.g. cim:String) lost their original prefix and were re-homed under the XSD namespace.

Restore the plain prefix + label concatenation. The comment-literal normalization from #163 lives in MappingUtils/GraphRewindable/ CIMModifyingUtils and is unaffected. The /api/primitiveDatatypes endpoint already serves canonical lowercase XSD URIs, so no case normalization is needed here; the test fixture is corrected to lowercase to match.

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO
