### PR TITLE
fix: reject creating an attribute whose IRI already exists (GH-146)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/attributes/AttributesService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/attributes/AttributesService.java
@@ -18,14 +18,17 @@
 package org.rdfarchitect.services.update.classes.attributes;
 
 import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.update.UpdateExecutionFactory;
 import org.apache.jena.update.UpdateRequest;
+import org.apache.jena.vocabulary.RDF;
 import org.rdfarchitect.api.dto.attributes.AttributeDTO;
 import org.rdfarchitect.api.dto.attributes.AttributeMapper;
 import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.database.inmemory.SessionDataStore;
+import org.rdfarchitect.exception.database.ResourceConflictException;
 import org.rdfarchitect.models.cim.queries.update.CIMUpdates;
 import org.rdfarchitect.models.cim.relations.model.CIMResourceUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,6 +63,7 @@ public class AttributesService implements CreateAttributeUseCase, UpdateAttribut
         var graphUri = graphIdentifier.graphUri();
         try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
             var graph = ctx.getRdfGraph();
+            assertAttributeUriIsFree(graph, cimAttribute.getUri().toNode());
             var update =
                     new UpdateRequest()
                             .add(
@@ -136,5 +140,22 @@ public class AttributesService implements CreateAttributeUseCase, UpdateAttribut
     private String findClassLabel(Graph graph, String domainUri) {
         var classResource = CIMResourceUtils.findResourceForUri(graph, domainUri);
         return CIMResourceUtils.findLabelForResource(classResource);
+    }
+
+    /**
+     * Guards against creating an attribute whose IRI is already taken by another property. An
+     * attribute's IRI is derived from its class and label ({@code <classIRI>.<label>}), so a second
+     * attribute with the same label on the same class would reuse that IRI. Without this guard the
+     * INSERT would stack a fresh {@code rdfa:uuid} (and any other diverging value) onto the
+     * existing property node, turning it into an ambiguous resource that the class editor then
+     * renders once per value combination.
+     */
+    private void assertAttributeUriIsFree(Graph graph, Node attributeUri) {
+        if (graph.contains(attributeUri, RDF.type.asNode(), RDF.Property.asNode())) {
+            throw new ResourceConflictException(
+                    "Cannot create attribute "
+                            + attributeUri.getURI()
+                            + " because a property with the same IRI already exists.");
+        }
     }
 }

--- a/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
+++ b/frontend/src/routes/mainpage/classEditor/components/attributes/AttributeEditorDialog.svelte
@@ -23,6 +23,7 @@
     import TextEditControl from "$lib/components/TextEditControl.svelte";
     import ViolationMessages from "$lib/components/ViolationMessages.svelte";
     import ModifyDataDialog from "$lib/dialog/ModifyDataDialog.svelte";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import { mapReactiveAttributeToAttributeDto } from "$lib/models/reactive/mapper/map-reactive-object-to-dto.js";
     import { ReactiveAttribute } from "$lib/models/reactive/models/reactive-attribute.svelte.js";
     import { getControlButtonsForReactiveObject } from "$lib/models/reactive/utils/reactive-objects-control-button-utils.js";
@@ -87,6 +88,12 @@
             isNewAttribute,
         );
         if (!result.ok) {
+            toastStore.error(
+                "Could not save attribute",
+                isNewAttribute
+                    ? `An attribute "${attribute.label.value}" may already exist on this class.`
+                    : "The attribute could not be saved.",
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary

An attribute's IRI is derived from its class and label (<classIRI>.<label>), so creating a second attribute with the same label on the same class reuses that IRI. AttributesService.createAttribute blindly inserted the new triples, stacking a fresh rdfa:uuid (and any other diverging value, e.g. a second cims:multiplicity) onto the existing property node. That ambiguous resource was then rendered once per value combination by the class-editor attribute query (which has no DISTINCT/dedup), so the attribute appeared multiple times.

createAttribute now rejects a colliding IRI with a ResourceConflictException, mirroring the IRI-collision guards in UpdateClassService.addClass, and the attribute editor surfaces the failure with a toast instead of silently swallowing it.

## Related Issues

Closes #146

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO
