### PR TITLE
fix: package diagram scope (RDFA-704)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/dto/rendering/svelteflow/sub/NodeDataDTO.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/rendering/svelteflow/sub/NodeDataDTO.java
@@ -36,6 +36,8 @@ public class NodeDataDTO {
      */
     private boolean external;
 
+    private boolean outsidePackage;
+
     private String belongsToCategory;
     private List<String> stereotypes;
     private List<AttributeDTO> attributes;

--- a/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/CIMClass.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/CIMClass.java
@@ -77,6 +77,19 @@ public class CIMClass extends CIMResource implements ICIMClass {
     }
 
     @Override
+    public List<ICIMClass> getSubClasses() {
+        return subClassesOf(this.getGraphUri(), this.getModel(), this.getJenaResource());
+    }
+
+    static List<ICIMClass> subClassesOf(String graphUri, Model model, Resource resource) {
+        var subClasses = new ArrayList<ICIMClass>();
+        for (var res : byUri(model.listSubjectsWithProperty(RDFS.subClassOf, resource))) {
+            subClasses.add(fromResource(graphUri, model, res));
+        }
+        return subClasses;
+    }
+
+    @Override
     public ICIMClassCategory getBelongsToCategory() {
         var category = getUniqueJenaProperty(CIMS.belongsToCategory);
         if (category == null) {

--- a/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/ExternalCIMClass.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/ExternalCIMClass.java
@@ -96,6 +96,11 @@ public class ExternalCIMClass implements ICIMClass {
     }
 
     @Override
+    public List<ICIMClass> getSubClasses() {
+        return CIMClass.subClassesOf(graphUri, model, resource);
+    }
+
+    @Override
     public ICIMClassCategory getBelongsToCategory() {
         return null;
     }

--- a/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/ICIMClass.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/ICIMClass.java
@@ -32,6 +32,8 @@ public interface ICIMClass extends ICIMResource {
 
     List<ICIMClass> getSuperClasses();
 
+    List<ICIMClass> getSubClasses();
+
     ICIMClassCategory getBelongsToCategory();
 
     List<CIMSStereotype> getStereotypes();

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
@@ -417,7 +417,7 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         }
 
         if (filter.isIncludeRelationsToExternalPackages()) {
-            addExternallyRelatedClasses(cimModel, filter, classes);
+            addExternallyRelatedClasses(filter, classes);
         }
 
         return classes;
@@ -430,13 +430,11 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         return UUID.fromString(filter.getPackageUUID());
     }
 
-    private void addExternallyRelatedClasses(
-            ICIMModelFacade cimModel, GraphFilter filter, Map<String, ICIMClass> classes) {
+    private void addExternallyRelatedClasses(GraphFilter filter, Map<String, ICIMClass> classes) {
         if (!filter.isIncludeAssociations() && !filter.isIncludeInheritance()) {
             return;
         }
         var classesInPackage = List.copyOf(classes.values());
-        var definedClasses = cimModel.getCIMClasses();
 
         if (filter.isIncludeAssociations()) {
             for (var cimClass : classesInPackage) {
@@ -449,24 +447,12 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         }
 
         if (filter.isIncludeInheritance()) {
-            var packageUris = classes.keySet();
             for (var cimClass : classesInPackage) {
                 for (var superClass : cimClass.getSuperClasses()) {
                     addExternallyRelatedClass(classes, superClass);
                 }
-            }
-            for (var cimClass : definedClasses) {
-                if (classes.containsKey(cimClass.getUri().toString())) {
-                    continue;
-                }
-                var extendsPackageClass =
-                        cimClass.getSuperClasses().stream()
-                                .anyMatch(
-                                        superClass ->
-                                                packageUris.contains(
-                                                        superClass.getUri().toString()));
-                if (extendsPackageClass) {
-                    classes.put(cimClass.getUri().toString(), cimClass);
+                for (var subClass : cimClass.getSubClasses()) {
+                    addExternallyRelatedClass(classes, subClass);
                 }
             }
         }

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
@@ -95,17 +95,18 @@ public class RenderCIMFacadeCollectionSvelteFlowService
             List<CIMProfileModel> otherProfiles,
             String primaryColor,
             String primaryKeyword) {
-        var classes = selectClasses(cimModel, filter);
-        if (classes.isEmpty()) {
+        var selection = selectClasses(cimModel, filter);
+        if (selection.classes().isEmpty()) {
             return createEmptyDiagram();
         }
 
         var renderContext =
                 new RenderContext(
-                        new ArrayList<>(classes.values()),
-                        classes.values().stream()
+                        new ArrayList<>(selection.classes().values()),
+                        selection.classes().values().stream()
                                 .map(ICIMClass::getUuid)
                                 .collect(Collectors.toSet()),
+                        selection.outsidePackageUris(),
                         filter,
                         layoutData,
                         cimModel.getGraphUri(),
@@ -392,7 +393,7 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         return SvelteFlowDTO.builder().nodes(List.of()).edges(List.of()).build();
     }
 
-    private Map<String, ICIMClass> selectClasses(ICIMModelFacade cimModel, GraphFilter filter) {
+    private SelectedClasses selectClasses(ICIMModelFacade cimModel, GraphFilter filter) {
         var classes = new LinkedHashMap<String, ICIMClass>();
 
         if (!CollectionUtils.isEmpty(filter.getAllowedUUIDs())) {
@@ -405,22 +406,29 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                     classes.put(cimClass.getUri().toString(), cimClass);
                 }
             }
-            return classes;
+            return new SelectedClasses(classes, Set.of());
         }
 
         var category = cimModel.getCIMClassCategory(resolvePackageUUID(filter));
         if (category == null) {
-            return classes;
+            return new SelectedClasses(classes, Set.of());
         }
         for (var cimClass : category.getClasses()) {
             classes.put(cimClass.getUri().toString(), cimClass);
         }
 
-        if (filter.isIncludeRelationsToExternalPackages()) {
-            addExternallyRelatedClasses(filter, classes);
+        if (!filter.isIncludeRelationsToExternalPackages()) {
+            return new SelectedClasses(classes, Set.of());
         }
 
-        return classes;
+        var packageUris = Set.copyOf(classes.keySet());
+        addExternallyRelatedClasses(filter, classes);
+        var outsidePackageUris =
+                classes.keySet().stream()
+                        .filter(uri -> !packageUris.contains(uri))
+                        .collect(Collectors.toSet());
+
+        return new SelectedClasses(classes, outsidePackageUris);
     }
 
     private UUID resolvePackageUUID(GraphFilter filter) {
@@ -497,6 +505,10 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                         .graphUri(cimClass.getGraphUri())
                         .label(cimClass.getLabel().getValue())
                         .external(cimClass.isExternal())
+                        .outsidePackage(
+                                renderContext
+                                        .outsidePackageUris()
+                                        .contains(cimClass.getUri().toString()))
                         .belongsToCategory(
                                 cimClass.getBelongsToCategory() != null
                                         ? cimClass.getBelongsToCategory().getLabel().getValue()
@@ -760,9 +772,13 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         };
     }
 
+    private record SelectedClasses(
+            Map<String, ICIMClass> classes, Set<String> outsidePackageUris) {}
+
     private record RenderContext(
             List<ICIMClass> classes,
             Set<UUID> nodeUUIDs,
+            Set<String> outsidePackageUris,
             GraphFilter filter,
             RenderingLayoutData layoutingData,
             String primaryGraphUri,

--- a/backend/src/test/java/org/rdfarchitect/models/cim/data/dto/facade/CIMFacadeTest.java
+++ b/backend/src/test/java/org/rdfarchitect/models/cim/data/dto/facade/CIMFacadeTest.java
@@ -182,6 +182,40 @@ class CIMFacadeTest {
     }
 
     @Test
+    @DisplayName("returns the direct sub classes of a class")
+    void subClasses() {
+        var recloser = model.createResource(NS + "Recloser");
+        recloser.addProperty(RDF.type, RDFS.Class);
+        recloser.addProperty(RDFA.uuid, RECLOSER_UUID.toString());
+        recloser.addProperty(RDFS.label, model.createLiteral("Recloser", "en"));
+        recloser.addProperty(RDFS.subClassOf, model.getResource(NS + "Breaker"));
+
+        var subClasses = new CIMClass(GRAPH_URI, model, SWITCH_UUID).getSubClasses();
+
+        assertThat(subClasses)
+                .singleElement()
+                .isInstanceOf(CIMClass.class)
+                .satisfies(subClass -> assertThat(subClass.getUuid()).isEqualTo(BREAKER_UUID));
+    }
+
+    @Test
+    @DisplayName("returns the sub classes of an external class")
+    void subClassesOfExternalClass() {
+        var externalBase =
+                new ExternalCIMClass(GRAPH_URI, model, model.getResource(NS + "ExternalBase"));
+
+        assertThat(externalBase.getSubClasses())
+                .singleElement()
+                .satisfies(subClass -> assertThat(subClass.getUuid()).isEqualTo(BREAKER_UUID));
+    }
+
+    @Test
+    @DisplayName("returns no sub classes for a class that is not extended")
+    void subClassesWithoutSubClasses() {
+        assertThat(breaker().getSubClasses()).isEmpty();
+    }
+
+    @Test
     @DisplayName("returns a referenced only super class as ExternalCIMClass even if it has a uuid")
     void superClassesWithReferencedOnlyResource() {
         var referencedOnly = model.createResource(NS + "ReferencedOnly");

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
@@ -453,6 +453,44 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
     }
 
     @Test
+    @DisplayName("marks only classes outside the rendered package as outsidePackage")
+    void marksClassesOutsideThePackage() {
+        var result =
+                (SvelteFlowDTO)
+                        renderer.renderUML(facade, coreFilter(), null, List.of(), null, null);
+
+        assertThat(result.getNodes())
+                .filteredOn(node -> node.getData().isOutsidePackage())
+                .extracting(node -> node.getData().getLabel())
+                .containsExactly("Terminal");
+        assertThat(nodeByLabel(result, "Child").getData().isOutsidePackage()).isFalse();
+    }
+
+    @Test
+    @DisplayName("marks no class as outsidePackage when external relations are disabled")
+    void marksNoClassOutsideThePackageWithoutExternalRelations() {
+        var filter = coreFilter();
+        filter.setIncludeRelationsToExternalPackages(false);
+
+        var result =
+                (SvelteFlowDTO) renderer.renderUML(facade, filter, null, List.of(), null, null);
+
+        assertThat(result.getNodes()).noneMatch(node -> node.getData().isOutsidePackage());
+    }
+
+    @Test
+    @DisplayName("marks no class as outsidePackage in a custom diagram")
+    void marksNoClassOutsideThePackageInCustomDiagram() {
+        var filter = new GraphFilter(true);
+        filter.setAllowedUUIDs(List.of(CHILD_UUID.toString(), TERMINAL_UUID.toString()));
+
+        var result =
+                (SvelteFlowDTO) renderer.renderUML(facade, filter, null, List.of(), null, null);
+
+        assertThat(result.getNodes()).noneMatch(node -> node.getData().isOutsidePackage());
+    }
+
+    @Test
     @DisplayName("omits classes of other packages that only share an external super class")
     void omitsSiblingClassesOfExternalSuperClass() {
         var other = model.getResource(NS + "OtherPackage");

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
@@ -453,6 +453,58 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
     }
 
     @Test
+    @DisplayName("omits classes of other packages that only share an external super class")
+    void omitsSiblingClassesOfExternalSuperClass() {
+        var other = model.getResource(NS + "OtherPackage");
+        var sharedBase = addClass("SharedBase", UUID.randomUUID(), other);
+        model.getResource(NS + "Root").addProperty(RDFS.subClassOf, sharedBase);
+        var sibling = addClass("Sibling", UUID.randomUUID(), other);
+        sibling.addProperty(RDFS.subClassOf, sharedBase);
+
+        var result =
+                (SvelteFlowDTO)
+                        renderer.renderUML(facade, coreFilter(), null, List.of(), null, null);
+
+        assertThat(result.getNodes())
+                .extracting(node -> node.getData().getLabel())
+                .contains("SharedBase")
+                .doesNotContain("Sibling");
+    }
+
+    @Test
+    @DisplayName("does not cascade beyond directly related classes of other packages")
+    void doesNotCascadeBeyondDirectlyRelatedClasses() {
+        var other = model.getResource(NS + "OtherPackage");
+        var terminalSpecialisation = addClass("TerminalSpecialisation", UUID.randomUUID(), other);
+        terminalSpecialisation.addProperty(RDFS.subClassOf, model.getResource(NS + "Terminal"));
+
+        var result =
+                (SvelteFlowDTO)
+                        renderer.renderUML(facade, coreFilter(), null, List.of(), null, null);
+
+        assertThat(result.getNodes())
+                .extracting(node -> node.getData().getLabel())
+                .contains("Terminal")
+                .doesNotContain("TerminalSpecialisation");
+    }
+
+    @Test
+    @DisplayName("renders classes of other packages that directly extend a package class")
+    void rendersDirectSubClassesFromOtherPackages() {
+        var other = model.getResource(NS + "OtherPackage");
+        var externalChild = addClass("ExternalChild", UUID.randomUUID(), other);
+        externalChild.addProperty(RDFS.subClassOf, model.getResource(NS + "Base"));
+
+        var result =
+                (SvelteFlowDTO)
+                        renderer.renderUML(facade, coreFilter(), null, List.of(), null, null);
+
+        assertThat(result.getNodes())
+                .extracting(node -> node.getData().getLabel())
+                .contains("ExternalChild");
+    }
+
+    @Test
     @DisplayName("renders classes without a category for the default package")
     void rendersDefaultPackage() {
         var filter = new GraphFilter(true);

--- a/frontend/src/lib/rendering/svelteflow/components/ClassNode.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/ClassNode.svelte
@@ -88,6 +88,7 @@
 
     const cursorClass = $derived(dragging ? "cursor-move" : "cursor-pointer");
     const isExternal = $derived(data.external === true);
+    const isOutsidePackage = $derived(data.outsidePackage === true);
 
     function graphUriOf(prop) {
         return prop.graphUri ?? "";
@@ -178,7 +179,11 @@
 
 <div
     class={`class-node-shell bg-class-node-upper-background relative isolate min-w-45 overflow-hidden rounded-md bg-clip-padding font-sans text-sm ${cursorClass} ${
-        isExternal ? "class-node-external" : ""
+        isExternal
+            ? "class-node-external"
+            : isOutsidePackage
+              ? "class-node-outside-package"
+              : ""
     } ${
         highlightState === "active"
             ? "class-node-highlighted"
@@ -367,6 +372,12 @@
         --color-class-node-upper-background: rgba(224, 224, 224, 0.45);
         --color-class-node-lower-background: rgba(242, 242, 242, 0.4);
         --color-default-text: #5a5a5a;
+    }
+
+    .class-node-outside-package {
+        --color-class-node-upper-background: #eeeeee;
+        --color-class-node-lower-background: #fafafa;
+        --color-default-text: #6a6a6a;
     }
 
     .class-node-external::after {


### PR DESCRIPTION
## Summary

The package diagram now only shows external classes that are directly connected to a class inside the package. Either via inheritance or associations

## Related Issues

#230 

## Checklist

- [x] Tests added or updated (or not applicable)
- [ ] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes
