### PR TITLE
feat: movable multiplicity labels (RDFA-586)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/GlobalLabelLayoutDataRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/GlobalLabelLayoutDataRESTController.java
@@ -88,6 +88,11 @@ public class GlobalLabelLayoutDataRESTController {
         updateLabelPositionsUseCase.updateLabelPositions(
                 datasetName, UUID.fromString(diagramUUID), labelPositionDTOList);
 
+        logger.info(
+                "Sending response to PUT request: \"/api/datasets/{{}}/layout/{{}}/labels\" from \"{}\".",
+                datasetName,
+                diagramUUID,
+                originURL);
         return "success";
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/GlobalLabelLayoutDataRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/GlobalLabelLayoutDataRESTController.java
@@ -1,0 +1,93 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.controller.datasets;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.RequiredArgsConstructor;
+
+import org.rdfarchitect.api.dto.dl.LabelPositionDTO;
+import org.rdfarchitect.services.dl.update.labellayout.UpdateLabelPositionsUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/datasets/{datasetName}/layout/{diagramUUID}/labels")
+@RequiredArgsConstructor
+public class GlobalLabelLayoutDataRESTController {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(GlobalLabelLayoutDataRESTController.class);
+
+    private final UpdateLabelPositionsUseCase updateLabelPositionsUseCase;
+
+    @Operation(
+            summary = "updates label positions on dataset level",
+            description =
+                    "Updates the offsets for all the labels provided in the request body. Labels without an offset are reset to their default placement.",
+            tags = {"diagram", "layout", "label"})
+    @PutMapping
+    public String updateDatasetLabelPositions(
+            @Parameter(description = "The name/url of the inquirer.")
+                    @RequestHeader(value = "origin", required = false, defaultValue = "unknown")
+                    String originURL,
+            @Parameter(description = "The literal name of the dataset.") @PathVariable
+                    String datasetName,
+            @Parameter(description = "The UUID of the package or custom diagram being updated.")
+                    @PathVariable
+                    String diagramUUID,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            description = "The DTO with necessary information for label reposition",
+                            content =
+                                    @Content(
+                                            array =
+                                                    @ArraySchema(
+                                                            schema =
+                                                                    @Schema(
+                                                                            implementation =
+                                                                                    LabelPositionDTO
+                                                                                            .class))))
+                    @RequestBody
+                    List<LabelPositionDTO> labelPositionDTOList) {
+
+        logger.info(
+                "Received PUT request: \"/api/datasets/{{}}/layout/{{}}/labels\" from \"{}\".",
+                datasetName,
+                diagramUUID,
+                originURL);
+
+        updateLabelPositionsUseCase.updateLabelPositions(
+                datasetName, UUID.fromString(diagramUUID), labelPositionDTOList);
+
+        return "success";
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/rendering/LabelLayoutDataRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/rendering/LabelLayoutDataRESTController.java
@@ -1,0 +1,108 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.controller.datasets.graphs.rendering;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.RequiredArgsConstructor;
+
+import org.rdfarchitect.api.dto.dl.LabelPositionDTO;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.services.ExpandURIUseCase;
+import org.rdfarchitect.services.dl.update.labellayout.UpdateLabelPositionsUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/datasets/{datasetName}/graphs/{graphURI}/layout/{diagramUUID}/labels")
+@RequiredArgsConstructor
+public class LabelLayoutDataRESTController {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(LabelLayoutDataRESTController.class);
+
+    private final ExpandURIUseCase expandURIUseCase;
+    private final UpdateLabelPositionsUseCase updateLabelPositionsUseCase;
+
+    @Operation(
+            summary = "updates label positions",
+            description =
+                    "Updates the offsets for all the labels provided in the request body. Labels without an offset are reset to their default placement.",
+            tags = {"diagram", "layout", "label"})
+    @PutMapping
+    public String updateLabelPositions(
+            @Parameter(description = "The name/url of the inquirer.")
+                    @RequestHeader(value = "origin", required = false, defaultValue = "unknown")
+                    String originURL,
+            @Parameter(description = "The literal name of the dataset.") @PathVariable
+                    String datasetName,
+            @Parameter(
+                            description =
+                                    "The url encoded uri of the graph, or \"default\" to access the default graph.")
+                    @PathVariable
+                    String graphURI,
+            @Parameter(description = "The UUID of the package or custom diagram being updated.")
+                    @PathVariable
+                    String diagramUUID,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            description = "The DTO with necessary information for label reposition",
+                            content =
+                                    @Content(
+                                            array =
+                                                    @ArraySchema(
+                                                            schema =
+                                                                    @Schema(
+                                                                            implementation =
+                                                                                    LabelPositionDTO
+                                                                                            .class))))
+                    @RequestBody
+                    List<LabelPositionDTO> labelPositionDTOList) {
+
+        logger.info(
+                "Received PUT request: \"/api/datasets/{{}}/graphs/{{}}/layout/{{}}/labels\" from \"{}\".",
+                datasetName,
+                graphURI,
+                diagramUUID,
+                originURL);
+
+        var extendedGraphURI = expandURIUseCase.expandUri(datasetName, graphURI);
+        var resolvedDiagramUUID =
+                !diagramUUID.equals("default") ? UUID.fromString(diagramUUID) : null;
+
+        updateLabelPositionsUseCase.updateLabelPositions(
+                new GraphIdentifier(datasetName, extendedGraphURI),
+                resolvedDiagramUUID,
+                labelPositionDTOList);
+
+        return "success";
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/rendering/LabelLayoutDataRESTController.java
+++ b/backend/src/main/java/org/rdfarchitect/api/controller/datasets/graphs/rendering/LabelLayoutDataRESTController.java
@@ -103,6 +103,12 @@ public class LabelLayoutDataRESTController {
                 resolvedDiagramUUID,
                 labelPositionDTOList);
 
+        logger.info(
+                "Sending response to PUT request: \"/api/datasets/{{}}/graphs/{{}}/layout/{{}}/labels\" from \"{}\".",
+                datasetName,
+                graphURI,
+                diagramUUID,
+                originURL);
         return "success";
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/api/dto/dl/LabelPositionDTO.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/dl/LabelPositionDTO.java
@@ -1,0 +1,46 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.dto.dl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/** DTO for repositioning a movable diagram label. */
+@Data
+@NoArgsConstructor
+public class LabelPositionDTO {
+
+    /** The UUID of the CIM resource the label belongs to, e.g. an association end. */
+    @JsonProperty("identifiedObjectUUID")
+    private UUID identifiedObjectUUID;
+
+    /** The label kind, e.g. {@code multiplicity}. Together with the UUID it identifies a label. */
+    @JsonProperty("kind")
+    private String kind;
+
+    /** Offset relative to the class the label is anchored to. Null resets it to its default. */
+    @JsonProperty("xOffset")
+    private Float xOffset;
+
+    @JsonProperty("yOffset")
+    private Float yOffset;
+}

--- a/backend/src/main/java/org/rdfarchitect/api/dto/dl/RenderingLayoutData.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/dl/RenderingLayoutData.java
@@ -21,6 +21,8 @@ import lombok.Builder;
 import lombok.Data;
 
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.XYOffset;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher.LabelKey;
 
 import java.util.Map;
 import java.util.UUID;
@@ -34,4 +36,7 @@ import java.util.UUID;
 public class RenderingLayoutData {
 
     Map<UUID, DiagramObjectPoint> classLayoutingData;
+
+    /** Manually placed labels, positioned as an offset relative to their class. */
+    Map<LabelKey, XYOffset> labelLayoutingData;
 }

--- a/backend/src/main/java/org/rdfarchitect/api/dto/rendering/svelteflow/sub/EdgeLabelDTO.java
+++ b/backend/src/main/java/org/rdfarchitect/api/dto/rendering/svelteflow/sub/EdgeLabelDTO.java
@@ -1,0 +1,54 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.api.dto.rendering.svelteflow.sub;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+/**
+ * DTO representing a label rendered next to one end of a SvelteFlow edge. Labels are rendered as
+ * their own nodes so they can be dragged independently of the edge.
+ */
+@Data
+@Builder
+public class EdgeLabelDTO {
+
+    /** The end of the edge a label is anchored to. */
+    public enum Anchor {
+        SOURCE,
+        TARGET
+    }
+
+    private Anchor anchor;
+
+    /** The UUID of the CIM resource this label belongs to, e.g. an association end. */
+    private UUID identifiedObjectUUID;
+
+    /** The label kind, e.g. {@code multiplicity}. Together with the UUID it identifies a label. */
+    private String kind;
+
+    private String text;
+
+    /**
+     * The manually placed position as an offset relative to the class the label is anchored to, or
+     * {@code null} when the label has never been moved and falls back to its default placement.
+     */
+    private PositionDTO offset;
+}

--- a/backend/src/main/java/org/rdfarchitect/dl/data/DLObjectFactory.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/data/DLObjectFactory.java
@@ -23,6 +23,7 @@ import org.apache.jena.query.QuerySolution;
 import org.rdfarchitect.dl.data.dto.Diagram;
 import org.rdfarchitect.dl.data.dto.DiagramObject;
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
 import org.rdfarchitect.dl.data.dto.relations.OrientationKind;
 import org.rdfarchitect.dl.queries.DLQuerySolutionParser;
 import org.rdfarchitect.dl.queries.DLQueryVars;
@@ -62,8 +63,10 @@ public class DLObjectFactory {
         return DiagramObject.builder()
                 .mRID(parser.getMRID(DLQueryVars.DO_MRID))
                 .name(parser.getName(DLQueryVars.DO_NAME))
+                .style(DiagramObjectStyle.byName(parser.getName(DLQueryVars.STYLE_NAME)))
                 .belongsToDiagram(parser.getMRID(DLQueryVars.DIAGRAM_MRID))
                 .belongsToIdentifiedObject(parser.getMRID(DLQueryVars.IO_MRID))
+                .offset(parser.getXYOffset())
                 .build();
     }
 

--- a/backend/src/main/java/org/rdfarchitect/dl/data/dto/DiagramObject.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/data/dto/DiagramObject.java
@@ -17,20 +17,31 @@
 
 package org.rdfarchitect.dl.data.dto;
 
-import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
 import org.rdfarchitect.dl.data.dto.relations.MRID;
+import org.rdfarchitect.dl.data.dto.relations.XYOffset;
 
 @Data
-@Builder(toBuilder = true)
+@SuperBuilder(toBuilder = true)
 public class DiagramObject {
 
     private MRID mRID;
 
+    /** The display name, only carried by objects that stand for a named resource. */
     private String name;
+
+    private DiagramObjectStyle style;
 
     private MRID belongsToDiagram;
 
     private MRID belongsToIdentifiedObject;
+
+    /**
+     * The placement relative to whatever the object is anchored to, for objects that are placed by
+     * an offset instead of by a {@link DiagramObjectPoint}.
+     */
+    private XYOffset offset;
 }

--- a/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/DiagramObjectStyle.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/DiagramObjectStyle.java
@@ -1,0 +1,72 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.dl.data.dto.relations;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * The kind of thing a {@code cim:DiagramObject} stands for. Every diagram object carries one, which
+ * is what lets the layout hold objects of different kinds side by side and query them apart.
+ *
+ * <p>The mRID is derived from the style name so that a style resolves to the same resource in every
+ * model without having to be looked up before it can be referenced.
+ */
+public enum DiagramObjectStyle {
+    CLASS("class"),
+    MULTIPLICITY("multiplicity");
+
+    private final String styleName;
+
+    DiagramObjectStyle(String styleName) {
+        this.styleName = styleName;
+    }
+
+    public String getStyleName() {
+        return styleName;
+    }
+
+    public MRID getMRID() {
+        return mridOf(styleName);
+    }
+
+    /**
+     * Resolves a style by its name, for styles that reach the backend as free text.
+     *
+     * @param styleName the name of the style
+     * @return the style, or null if no style carries that name
+     */
+    public static DiagramObjectStyle byName(String styleName) {
+        for (var style : values()) {
+            if (style.styleName.equals(styleName)) {
+                return style;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Derives the deterministic mRID a style with the given name is stored under.
+     *
+     * @param styleName the name of the style
+     * @return the mRID of the style
+     */
+    public static MRID mridOf(String styleName) {
+        return new MRID(UUID.nameUUIDFromBytes(styleName.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/DiagramObjectStyle.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/DiagramObjectStyle.java
@@ -32,9 +32,11 @@ public enum DiagramObjectStyle {
     MULTIPLICITY("multiplicity");
 
     private final String styleName;
+    private final MRID mRID;
 
     DiagramObjectStyle(String styleName) {
         this.styleName = styleName;
+        this.mRID = mridOf(styleName);
     }
 
     public String getStyleName() {
@@ -42,7 +44,7 @@ public enum DiagramObjectStyle {
     }
 
     public MRID getMRID() {
-        return mridOf(styleName);
+        return mRID;
     }
 
     /**

--- a/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/XYOffset.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/XYOffset.java
@@ -15,24 +15,13 @@
  *
  */
 
-package org.rdfarchitect.api.dto.rendering.svelteflow.sub;
+package org.rdfarchitect.dl.data.dto.relations;
 
-import lombok.Builder;
-import lombok.Data;
-
-import java.util.List;
-
-/** DTO representing the specific data object in a SvelteFlow edge. */
-@Data
-@Builder
-public class EdgeDataDTO {
-
-    /** The movable labels of both edge ends. */
-    private List<EdgeLabelDTO> labels;
-
-    private boolean useToAssociation;
-    private boolean useFromAssociation;
-    private String graphUri;
-    private String graphKeyword;
-    private String color;
-}
+/**
+ * A two dimensional offset of a diagram object relative to whatever it is anchored to. Unlike a
+ * {@link XYZPosition} this is not a coordinate within the diagram and carries no stacking order.
+ *
+ * @param x the offset along the x axis
+ * @param y the offset along the y axis
+ */
+public record XYOffset(float x, float y) {}

--- a/backend/src/main/java/org/rdfarchitect/dl/queries/DLQuerySolutionParser.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/queries/DLQuerySolutionParser.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.jena.query.QuerySolution;
 import org.rdfarchitect.dl.data.DLUtils;
 import org.rdfarchitect.dl.data.dto.relations.MRID;
+import org.rdfarchitect.dl.data.dto.relations.XYOffset;
 import org.rdfarchitect.dl.data.dto.relations.XYZPosition;
 
 /**
@@ -59,6 +60,20 @@ public class DLQuerySolutionParser {
             return null;
         }
         return qs.getLiteral(nameVar).getString();
+    }
+
+    /**
+     * Extracts the {@link XYOffset} from the query solution.
+     *
+     * @return The XYOffset or null, if the given variables don't exist in the solution.
+     */
+    public XYOffset getXYOffset() {
+        if (!qs.contains(DLQueryVars.OFFSET_X) || !qs.contains(DLQueryVars.OFFSET_Y)) {
+            return null;
+        }
+        return new XYOffset(
+                qs.getLiteral(DLQueryVars.OFFSET_X).getFloat(),
+                qs.getLiteral(DLQueryVars.OFFSET_Y).getFloat());
     }
 
     /**

--- a/backend/src/main/java/org/rdfarchitect/dl/queries/DLQueryVars.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/queries/DLQueryVars.java
@@ -37,6 +37,9 @@ public class DLQueryVars {
     public static final String DO_MRID = "?doMRID";
     public static final String DO_NAME = "?doName";
     public static final String IO_MRID = "?ioMRID";
+    public static final String STYLE_NAME = "?styleName";
+    public static final String OFFSET_X = "?offsetX";
+    public static final String OFFSET_Y = "?offsetY";
 
     // DIAGRAMOBJECTPOINT
     public static final String DOP_MRID = "?dopMRID";

--- a/backend/src/main/java/org/rdfarchitect/dl/queries/select/DLObjectFetcher.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/queries/select/DLObjectFetcher.java
@@ -117,11 +117,11 @@ public class DLObjectFetcher {
                       }
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
-                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
+                      STYLE_FILTER
                   }
                   """
                         .replace("DIAGRAM_MRID", diagramMRID)
-                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+                        .replace("STYLE_FILTER", classStyleFilter(true));
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -196,7 +196,7 @@ public class DLObjectFetcher {
                   PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                   PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
 
-                  SELECT ?doMRID ?doName ?ioMRID
+                  SELECT ?doMRID ?doName ?ioMRID ?styleName
                   WHERE {
                       ?diagramMRID rdf:type cim:Diagram .
 
@@ -205,13 +205,15 @@ public class DLObjectFetcher {
                             cim:IdentifiedObject.name ?doName ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
+                      STYLE_NAME_JOIN
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
-                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
+                      STYLE_FILTER
                   }
                   """
                         .replace("DIAGRAM_MRID", diagramMRID.getFullMRID())
-                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+                        .replace("STYLE_FILTER", classStyleFilter(true))
+                        .replace("STYLE_NAME_JOIN", STYLE_NAME_JOIN);
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -246,20 +248,22 @@ public class DLObjectFetcher {
                   PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                   PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
 
-                  SELECT ?doMRID ?doName ?diagramMRID
+                  SELECT ?doMRID ?doName ?diagramMRID ?styleName
                   WHERE {
                       ?doMRID rdf:type cim:DiagramObject ;
                             cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                             cim:IdentifiedObject.name ?doName ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
+                      STYLE_NAME_JOIN
 
                       FILTER(STR(?ioMRID) = "IO_MRID")
-                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
+                      STYLE_FILTER
                   }
                   """
                         .replace("IO_MRID", ioMRID)
-                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+                        .replace("STYLE_FILTER", classStyleFilter(true))
+                        .replace("STYLE_NAME_JOIN", STYLE_NAME_JOIN);
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -296,7 +300,7 @@ public class DLObjectFetcher {
                   PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                   PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
 
-                  SELECT ?doMRID ?doName
+                  SELECT ?doMRID ?doName ?styleName
                   WHERE {
                       ?diagramMRID rdf:type cim:Diagram .
 
@@ -305,15 +309,17 @@ public class DLObjectFetcher {
                             cim:IdentifiedObject.name ?doName ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
+                      STYLE_NAME_JOIN
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
                       FILTER(STR(?ioMRID) = "IO_MRID")
-                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
+                      STYLE_FILTER
                   }
                   """
                         .replace("IO_MRID", ioMRID)
                         .replace("DIAGRAM_MRID", diagramMRID)
-                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+                        .replace("STYLE_FILTER", classStyleFilter(true))
+                        .replace("STYLE_NAME_JOIN", STYLE_NAME_JOIN);
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -370,11 +376,11 @@ public class DLObjectFetcher {
                       ?styleMRID cim:IdentifiedObject.name ?styleName .
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
-                      FILTER(STR(?styleMRID) != "CLASS_STYLE_MRID")
+                      STYLE_FILTER
                   }
                   """
                         .replace("DIAGRAM_MRID", new MRID(diagramUUID).getFullMRID())
-                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+                        .replace("STYLE_FILTER", classStyleFilter(false));
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -409,12 +415,13 @@ public class DLObjectFetcher {
                   PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                   PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
 
-                  SELECT ?doMRID
+                  SELECT ?doMRID ?styleName
                   WHERE {
                       ?doMRID rdf:type cim:DiagramObject ;
                             cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID ;
                             cim:DiagramObject.Diagram ?diagramMRID .
+                      STYLE_NAME_JOIN
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
                       FILTER(STR(?ioMRID) = "IO_MRID")
@@ -423,7 +430,8 @@ public class DLObjectFetcher {
                   """
                         .replace("DIAGRAM_MRID", new MRID(diagramUUID).getFullMRID())
                         .replace("IO_MRID", new MRID(labelKey.identifiedObjectUUID()).getFullMRID())
-                        .replace("STYLE_MRID", labelKey.style().getMRID().getFullMRID());
+                        .replace("STYLE_MRID", labelKey.style().getMRID().getFullMRID())
+                        .replace("STYLE_NAME_JOIN", STYLE_NAME_JOIN);
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -461,17 +469,19 @@ public class DLObjectFetcher {
                   PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                   PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
 
-                  SELECT ?doMRID ?ioMRID ?diagramMRID
+                  SELECT ?doMRID ?ioMRID ?diagramMRID ?styleName
                   WHERE {
                       ?doMRID rdf:type cim:DiagramObject ;
                             cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
+                      STYLE_NAME_JOIN
 
-                      FILTER(STR(?styleMRID) != "CLASS_STYLE_MRID")
+                      STYLE_FILTER
                   }
                   """
-                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+                        .replace("STYLE_FILTER", classStyleFilter(false))
+                        .replace("STYLE_NAME_JOIN", STYLE_NAME_JOIN);
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -484,7 +494,20 @@ public class DLObjectFetcher {
         }
     }
 
-    private String classStyleMRID() {
-        return DiagramObjectStyle.CLASS.getMRID().getFullMRID();
+    /**
+     * Joins a diagram object's style resource to its name, so {@link
+     * org.rdfarchitect.dl.data.DLObjectFactory#createDiagramObject} can resolve a {@link
+     * DiagramObjectStyle}. Optional because the style-vs-not-style filters below only need the bare
+     * {@code ?styleMRID}, and some legacy layout data may not have the name triple.
+     */
+    private static final String STYLE_NAME_JOIN =
+            "OPTIONAL { ?styleMRID cim:IdentifiedObject.name ?styleName . }";
+
+    /** A filter restricting {@code ?styleMRID} to (or, negated, away from) the class style. */
+    private static String classStyleFilter(boolean isClassStyle) {
+        return "FILTER(STR(?styleMRID) %s \"%s\")"
+                .formatted(
+                        isClassStyle ? "=" : "!=",
+                        DiagramObjectStyle.CLASS.getMRID().getFullMRID());
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/dl/queries/select/DLObjectFetcher.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/queries/select/DLObjectFetcher.java
@@ -25,7 +25,9 @@ import org.rdfarchitect.dl.data.DLObjectFactory;
 import org.rdfarchitect.dl.data.dto.Diagram;
 import org.rdfarchitect.dl.data.dto.DiagramObject;
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
 import org.rdfarchitect.dl.data.dto.relations.MRID;
+import org.rdfarchitect.dl.data.dto.relations.XYOffset;
 import org.rdfarchitect.dl.queries.DLQuerySolutionParser;
 import org.rdfarchitect.dl.queries.DLQueryVars;
 
@@ -102,6 +104,7 @@ public class DLObjectFetcher {
                       ?diagramMRID rdf:type cim:Diagram .
 
                       ?doMRID rdf:type cim:DiagramObject ;
+                                     cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                                      cim:DiagramObject.IdentifiedObject ?ioMRID ;
                                      cim:DiagramObject.Diagram ?diagramMRID .
 
@@ -114,9 +117,11 @@ public class DLObjectFetcher {
                       }
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
+                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
                   }
                   """
-                        .replace("DIAGRAM_MRID", diagramMRID);
+                        .replace("DIAGRAM_MRID", diagramMRID)
+                        .replace("CLASS_STYLE_MRID", classStyleMRID());
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -196,14 +201,17 @@ public class DLObjectFetcher {
                       ?diagramMRID rdf:type cim:Diagram .
 
                       ?doMRID rdf:type cim:DiagramObject ;
+                            cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                             cim:IdentifiedObject.name ?doName ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
+                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
                   }
                   """
-                        .replace("DIAGRAM_MRID", diagramMRID.getFullMRID());
+                        .replace("DIAGRAM_MRID", diagramMRID.getFullMRID())
+                        .replace("CLASS_STYLE_MRID", classStyleMRID());
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -241,14 +249,17 @@ public class DLObjectFetcher {
                   SELECT ?doMRID ?doName ?diagramMRID
                   WHERE {
                       ?doMRID rdf:type cim:DiagramObject ;
+                            cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                             cim:IdentifiedObject.name ?doName ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
 
                       FILTER(STR(?ioMRID) = "IO_MRID")
+                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
                   }
                   """
-                        .replace("IO_MRID", ioMRID);
+                        .replace("IO_MRID", ioMRID)
+                        .replace("CLASS_STYLE_MRID", classStyleMRID());
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -290,16 +301,19 @@ public class DLObjectFetcher {
                       ?diagramMRID rdf:type cim:Diagram .
 
                       ?doMRID rdf:type cim:DiagramObject ;
+                            cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
                             cim:IdentifiedObject.name ?doName ;
                             cim:DiagramObject.Diagram ?diagramMRID ;
                             cim:DiagramObject.IdentifiedObject ?ioMRID .
 
                       FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
                       FILTER(STR(?ioMRID) = "IO_MRID")
+                      FILTER(STR(?styleMRID) = "CLASS_STYLE_MRID")
                   }
                   """
                         .replace("IO_MRID", ioMRID)
-                        .replace("DIAGRAM_MRID", diagramMRID);
+                        .replace("DIAGRAM_MRID", diagramMRID)
+                        .replace("CLASS_STYLE_MRID", classStyleMRID());
 
         try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
             var results = qexec.execSelect();
@@ -316,5 +330,161 @@ public class DLObjectFetcher {
             }
             return null;
         }
+    }
+
+    /**
+     * Key of a movable label in a diagram. A label belongs to the CIM resource whose text it
+     * displays, an association end for multiplicities, and is distinguished from other labels of
+     * that same resource by its style.
+     *
+     * @param identifiedObjectUUID the UUID of the CIM resource the label belongs to
+     * @param style the style of the label
+     */
+    public record LabelKey(UUID identifiedObjectUUID, DiagramObjectStyle style) {}
+
+    /**
+     * Fetches the offsets of all manually placed labels of a diagram. A label is a diagram object
+     * whose style is not the one classes carry. Its placement is an offset relative to the class
+     * the label is anchored to, not a coordinate within the diagram, which is why it is held in
+     * {@code DiagramObject.offsetX/offsetY} instead of in a {@code DiagramObjectPoint}.
+     *
+     * @param diagramLayout the model from where the offsets will be fetched
+     * @param diagramUUID the diagram whose labels are fetched
+     * @return a map from label key to the offset of that label
+     */
+    public Map<LabelKey, XYOffset> fetchLabelOffsets(Model diagramLayout, UUID diagramUUID) {
+        var query =
+                """
+                  PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                  PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
+
+                  SELECT ?ioMRID ?styleName ?offsetX ?offsetY
+                  WHERE {
+                      ?doMRID rdf:type cim:DiagramObject ;
+                            cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
+                            cim:DiagramObject.IdentifiedObject ?ioMRID ;
+                            cim:DiagramObject.Diagram ?diagramMRID ;
+                            cim:DiagramObject.offsetX ?offsetX ;
+                            cim:DiagramObject.offsetY ?offsetY .
+
+                      ?styleMRID cim:IdentifiedObject.name ?styleName .
+
+                      FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
+                      FILTER(STR(?styleMRID) != "CLASS_STYLE_MRID")
+                  }
+                  """
+                        .replace("DIAGRAM_MRID", new MRID(diagramUUID).getFullMRID())
+                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+
+        try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
+            var results = qexec.execSelect();
+
+            Map<LabelKey, XYOffset> resultMap = new HashMap<>();
+            while (results.hasNext()) {
+                var querySolution = results.next();
+                var parser = new DLQuerySolutionParser(querySolution);
+                var style = DiagramObjectStyle.byName(parser.getName(DLQueryVars.STYLE_NAME));
+                if (style == null) {
+                    continue;
+                }
+                resultMap.put(
+                        new LabelKey(parser.getMRID(DLQueryVars.IO_MRID).getUuid(), style),
+                        parser.getXYOffset());
+            }
+            return resultMap;
+        }
+    }
+
+    /**
+     * Fetches the diagram object of one label, so it can be replaced or deleted.
+     *
+     * @param diagramLayout the model from where the object will be fetched
+     * @param diagramUUID the diagram the label belongs to
+     * @param labelKey the key of the label
+     * @return the {@link DiagramObject} of the label, or null if the label has no stored placement
+     */
+    public DiagramObject fetchLabelDO(Model diagramLayout, UUID diagramUUID, LabelKey labelKey) {
+        var query =
+                """
+                  PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                  PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
+
+                  SELECT ?doMRID
+                  WHERE {
+                      ?doMRID rdf:type cim:DiagramObject ;
+                            cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
+                            cim:DiagramObject.IdentifiedObject ?ioMRID ;
+                            cim:DiagramObject.Diagram ?diagramMRID .
+
+                      FILTER(STR(?diagramMRID) = "DIAGRAM_MRID")
+                      FILTER(STR(?ioMRID) = "IO_MRID")
+                      FILTER(STR(?styleMRID) = "STYLE_MRID")
+                  }
+                  """
+                        .replace("DIAGRAM_MRID", new MRID(diagramUUID).getFullMRID())
+                        .replace("IO_MRID", new MRID(labelKey.identifiedObjectUUID()).getFullMRID())
+                        .replace("STYLE_MRID", labelKey.style().getMRID().getFullMRID());
+
+        try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
+            var results = qexec.execSelect();
+            if (!results.hasNext()) {
+                return null;
+            }
+            return DLObjectFactory.createDiagramObject(results.next());
+        }
+    }
+
+    /**
+     * Fetches the labels of one diagram, so they can be dropped together with it.
+     *
+     * @param diagramLayout the model from where the objects will be fetched
+     * @param diagramUUID the diagram whose labels are fetched
+     * @return a list of the label {@link DiagramObject DiagramObjects} of that diagram
+     */
+    public List<DiagramObject> fetchDiagramLabelDOs(Model diagramLayout, UUID diagramUUID) {
+        var diagramMRID = new MRID(diagramUUID);
+        return fetchAllLabelDOs(diagramLayout).stream()
+                .filter(label -> diagramMRID.equals(label.getBelongsToDiagram()))
+                .toList();
+    }
+
+    /**
+     * Fetches every label of the model, across all diagrams. Unlike {@link #fetchLabelOffsets} this
+     * cannot be keyed on the label, because the same label may be placed in more than one diagram.
+     *
+     * @param diagramLayout the model from where the objects will be fetched
+     * @return a list of the label {@link DiagramObject DiagramObjects}
+     */
+    public List<DiagramObject> fetchAllLabelDOs(Model diagramLayout) {
+        var query =
+                """
+                  PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                  PREFIX  cim:    <http://iec.ch/TC57/CIM100#>
+
+                  SELECT ?doMRID ?ioMRID ?diagramMRID
+                  WHERE {
+                      ?doMRID rdf:type cim:DiagramObject ;
+                            cim:DiagramObject.DiagramObjectStyle ?styleMRID ;
+                            cim:DiagramObject.Diagram ?diagramMRID ;
+                            cim:DiagramObject.IdentifiedObject ?ioMRID .
+
+                      FILTER(STR(?styleMRID) != "CLASS_STYLE_MRID")
+                  }
+                  """
+                        .replace("CLASS_STYLE_MRID", classStyleMRID());
+
+        try (var qexec = QueryExecutionFactory.create(query, diagramLayout)) {
+            var results = qexec.execSelect();
+
+            List<DiagramObject> diagramObjects = new ArrayList<>();
+            while (results.hasNext()) {
+                diagramObjects.add(DLObjectFactory.createDiagramObject(results.next()));
+            }
+            return diagramObjects;
+        }
+    }
+
+    private String classStyleMRID() {
+        return DiagramObjectStyle.CLASS.getMRID().getFullMRID();
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/dl/queries/update/DLUpdates.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/queries/update/DLUpdates.java
@@ -25,6 +25,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.rdfarchitect.dl.data.dto.Diagram;
 import org.rdfarchitect.dl.data.dto.DiagramObject;
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
 import org.rdfarchitect.dl.data.dto.relations.MRID;
 import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
 import org.rdfarchitect.dl.rdf.resources.CIM;
@@ -52,12 +53,23 @@ public class DLUpdates {
         deleteBase(model, diagramMRID);
     }
 
+    /**
+     * Inserts a diagram object together with the style that says what it stands for. Objects
+     * without a name or without an offset are written without those triples, which is what keeps
+     * the different kinds of diagram object queryable apart.
+     *
+     * @param model the model into which the diagram object is inserted
+     * @param diagramObject the diagram object to insert
+     */
     public void insertDiagramObject(Model model, DiagramObject diagramObject) {
+        insertDiagramObjectStyle(model, diagramObject.getStyle());
+
         var newDiagramObject = model.createResource(diagramObject.getMRID().getFullMRID());
 
         newDiagramObject.addProperty(RDF.type, DL.diagramObjectType);
         newDiagramObject.addProperty(
-                CIM.ioName, ResourceFactory.createPlainLiteral(diagramObject.getName()));
+                DL.diagramObjectStyle,
+                ResourceFactory.createResource(diagramObject.getStyle().getMRID().getFullMRID()));
         newDiagramObject.addProperty(
                 DL.belongsToDiagram,
                 ResourceFactory.createResource(diagramObject.getBelongsToDiagram().getFullMRID()));
@@ -66,7 +78,42 @@ public class DLUpdates {
                 ResourceFactory.createResource(
                         diagramObject.getBelongsToIdentifiedObject().getFullMRID()));
 
+        if (diagramObject.getName() != null) {
+            newDiagramObject.addProperty(
+                    CIM.ioName, ResourceFactory.createPlainLiteral(diagramObject.getName()));
+        }
+        if (diagramObject.getOffset() != null) {
+            newDiagramObject.addProperty(
+                    DL.offsetX,
+                    ResourceFactory.createPlainLiteral(
+                            String.valueOf(diagramObject.getOffset().x())));
+            newDiagramObject.addProperty(
+                    DL.offsetY,
+                    ResourceFactory.createPlainLiteral(
+                            String.valueOf(diagramObject.getOffset().y())));
+        }
+
         model.add(newDiagramObject.listProperties());
+    }
+
+    /**
+     * Inserts a style unless the model already holds it. Styles are shared by every diagram object
+     * of their kind and are addressed by an mRID derived from their name, so inserting one twice
+     * would only repeat the triples it already has.
+     *
+     * @param model the model into which the style is inserted
+     * @param style the style to insert
+     */
+    public void insertDiagramObjectStyle(Model model, DiagramObjectStyle style) {
+        var styleResource = model.getResource(style.getMRID().getFullMRID());
+        if (model.contains(styleResource, RDF.type, DL.diagramObjectStyleType)) {
+            return;
+        }
+        styleResource.addProperty(RDF.type, DL.diagramObjectStyleType);
+        styleResource.addProperty(
+                CIM.ioName, ResourceFactory.createPlainLiteral(style.getStyleName()));
+
+        model.add(styleResource.listProperties());
     }
 
     public void updateDiagramObjectName(Model model, DiagramObject diagramObject, String name) {
@@ -77,10 +124,19 @@ public class DLUpdates {
         resource.addProperty(CIM.ioName, name);
     }
 
+    /**
+     * Deletes a diagram object together with its point, if it has one. Objects that are placed by
+     * an offset carry no point, so the point is optional here.
+     *
+     * @param model the model from which the diagram object is removed
+     * @param doMRID the mRID of the diagram object to remove
+     */
     public void deleteDiagramObjectCascade(Model model, MRID doMRID) {
         DiagramObjectPoint dop = DLObjectFetcher.fetchDOPForDO(model, doMRID);
         deleteDiagramObject(model, doMRID);
-        deleteDiagramObjectPoint(model, dop.getMRID());
+        if (dop != null) {
+            deleteDiagramObjectPoint(model, dop.getMRID());
+        }
     }
 
     public void deleteDiagramObject(Model model, MRID doMRID) {

--- a/backend/src/main/java/org/rdfarchitect/dl/rdf/resources/DL.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/rdf/resources/DL.java
@@ -45,6 +45,16 @@ public class DL {
             ResourceFactory.createProperty(
                     constructDLNamespacedTerm("DiagramObjectPoint.DiagramObject"));
 
+    public final Property diagramObjectStyle =
+            ResourceFactory.createProperty(
+                    constructDLNamespacedTerm("DiagramObject.DiagramObjectStyle"));
+
+    public final Property offsetX =
+            ResourceFactory.createProperty(constructDLNamespacedTerm("DiagramObject.offsetX"));
+
+    public final Property offsetY =
+            ResourceFactory.createProperty(constructDLNamespacedTerm("DiagramObject.offsetY"));
+
     public final Property xPosition =
             ResourceFactory.createProperty(
                     constructDLNamespacedTerm("DiagramObjectPoint.xPosition"));
@@ -63,6 +73,9 @@ public class DL {
 
     public final Resource diagramObjectType =
             ResourceFactory.createResource(constructDLNamespacedTerm("DiagramObject"));
+
+    public final Resource diagramObjectStyleType =
+            ResourceFactory.createResource(constructDLNamespacedTerm("DiagramObjectStyle"));
 
     public final Resource diagramObjectPointType =
             ResourceFactory.createResource(constructDLNamespacedTerm("DiagramObjectPoint"));

--- a/backend/src/main/java/org/rdfarchitect/services/GetRenderingDataService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/GetRenderingDataService.java
@@ -28,10 +28,10 @@ import org.rdfarchitect.database.DatabasePort;
 import org.rdfarchitect.database.GraphContext;
 import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.database.inmemory.diagrams.ClassInDiagram;
-import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
 import org.rdfarchitect.models.cim.data.dto.facade.CIMModelFacade;
 import org.rdfarchitect.models.cim.rendering.GraphFilter;
 import org.rdfarchitect.rdf.graph.GraphUtils;
+import org.rdfarchitect.services.dl.select.FetchRenderingLayoutDataUseCase;
 import org.rdfarchitect.services.rendering.CIMProfileModels;
 import org.rdfarchitect.services.rendering.RenderCIMFacadeCollectionUseCase;
 import org.rdfarchitect.services.select.ListGraphsUseCase;
@@ -48,6 +48,7 @@ public class GetRenderingDataService implements GetRenderingDataUseCase {
     private final DatabasePort databasePort;
     private final RenderCIMFacadeCollectionUseCase renderer;
     private final ListGraphsUseCase listGraphsUseCase;
+    private final FetchRenderingLayoutDataUseCase fetchRenderingLayoutDataUseCase;
 
     @Override
     public RenderingDataDTO getRenderingData(
@@ -93,14 +94,8 @@ public class GetRenderingDataService implements GetRenderingDataUseCase {
     }
 
     private RenderingLayoutData fetchLayoutData(GraphContext ctx, UUID diagramUUID) {
-        var diagramLayout = ctx.getDiagramLayout();
-        var diagramLayoutModel = diagramLayout.getDiagramLayoutModel();
-        var classLayoutingData =
-                diagramUUID == null
-                        ? DLObjectFetcher.fetchDiagramDOPPerClass(
-                                diagramLayoutModel, diagramLayout.getDefaultPackageMRID().getUuid())
-                        : DLObjectFetcher.fetchDiagramDOPPerClass(diagramLayoutModel, diagramUUID);
-        return RenderingLayoutData.builder().classLayoutingData(classLayoutingData).build();
+        return fetchRenderingLayoutDataUseCase.fetchRenderingLayoutData(
+                ctx.getDiagramLayout(), diagramUUID);
     }
 
     private RenderingDataDTO render(

--- a/backend/src/main/java/org/rdfarchitect/services/diagrams/CrossProfileUtils.java
+++ b/backend/src/main/java/org/rdfarchitect/services/diagrams/CrossProfileUtils.java
@@ -35,12 +35,11 @@ public class CrossProfileUtils {
     private static final float RANGE_BRIGHTNESS = 0.4f;
 
     /**
-     * The uuid the merged class of a class uri carries in the cross profile view. It is derived
-     * from the uri, because the merged class exists in no graph and therefore has no uuid of its
-     * own.
+     * The uuid a merged resource carries in the cross profile view. It is derived from the uri,
+     * because the merged resource exists in no graph and therefore has no uuid of its own.
      */
-    public static UUID mergedClassUuid(String classUri) {
-        return UUID.nameUUIDFromBytes(classUri.getBytes(StandardCharsets.UTF_8));
+    public static UUID mergedUuid(String uri) {
+        return UUID.nameUUIDFromBytes(uri.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String generateRandomDarkColor() {

--- a/backend/src/main/java/org/rdfarchitect/services/diagrams/CustomDiagramService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/diagrams/CustomDiagramService.java
@@ -115,7 +115,7 @@ public class CustomDiagramService
 
             for (var cimClass : profile.model().getCIMClasses()) {
                 var classUri = cimClass.getUri().toString();
-                var mergedUuid = CrossProfileUtils.mergedClassUuid(classUri);
+                var mergedUuid = CrossProfileUtils.mergedUuid(classUri);
 
                 var merged =
                         mergeMap.computeIfAbsent(

--- a/backend/src/main/java/org/rdfarchitect/services/dl/select/QueryDiagramLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/select/QueryDiagramLayoutService.java
@@ -22,12 +22,10 @@ import lombok.RequiredArgsConstructor;
 import org.apache.jena.rdf.model.Model;
 import org.rdfarchitect.api.dto.dl.RenderingLayoutData;
 import org.rdfarchitect.database.DatabasePort;
-import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
 import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
 import org.rdfarchitect.rdf.graph.wrapper.DiagramLayoutDelta;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -55,15 +53,14 @@ public class QueryDiagramLayoutService implements FetchRenderingLayoutDataUseCas
     private RenderingLayoutData fetchRenderingLayoutData(
             UUID defaultPackageUUID, Model diagramLayoutModel, UUID diagramId) {
 
-        Map<UUID, DiagramObjectPoint> classLayoutingData;
-        if (diagramId == null) {
-            classLayoutingData =
-                    DLObjectFetcher.fetchDiagramDOPPerClass(diagramLayoutModel, defaultPackageUUID);
-        } else {
-            classLayoutingData =
-                    DLObjectFetcher.fetchDiagramDOPPerClass(diagramLayoutModel, diagramId);
-        }
+        var resolvedDiagramId = diagramId != null ? diagramId : defaultPackageUUID;
 
-        return RenderingLayoutData.builder().classLayoutingData(classLayoutingData).build();
+        return RenderingLayoutData.builder()
+                .classLayoutingData(
+                        DLObjectFetcher.fetchDiagramDOPPerClass(
+                                diagramLayoutModel, resolvedDiagramId))
+                .labelLayoutingData(
+                        DLObjectFetcher.fetchLabelOffsets(diagramLayoutModel, resolvedDiagramId))
+                .build();
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/DiagramLayoutServiceUtils.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/DiagramLayoutServiceUtils.java
@@ -23,6 +23,7 @@ import org.apache.jena.rdf.model.Model;
 import org.rdfarchitect.dl.data.dto.Diagram;
 import org.rdfarchitect.dl.data.dto.DiagramObject;
 import org.rdfarchitect.dl.data.dto.DiagramObjectPoint;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
 import org.rdfarchitect.dl.data.dto.relations.MRID;
 import org.rdfarchitect.dl.data.dto.relations.OrientationKind;
 import org.rdfarchitect.dl.data.dto.relations.XYZPosition;
@@ -69,6 +70,7 @@ public class DiagramLayoutServiceUtils {
                 DiagramObject.builder()
                         .mRID(diagramObjectMRID)
                         .name(className)
+                        .style(DiagramObjectStyle.CLASS)
                         .belongsToDiagram(new MRID(packageUUID))
                         .belongsToIdentifiedObject(new MRID(classUUID))
                         .build();

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/UpdateClassLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/UpdateClassLayoutService.java
@@ -20,11 +20,11 @@ package org.rdfarchitect.services.dl.update.classlayout;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.jena.graph.Graph;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDFS;
 import org.rdfarchitect.api.dto.dl.ClassLayoutPositionDTO;
 import org.rdfarchitect.api.dto.dl.ClassPositionDTO;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
@@ -39,7 +39,10 @@ import org.rdfarchitect.dl.data.dto.relations.XYZPosition;
 import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
 import org.rdfarchitect.dl.queries.update.DLUpdates;
 import org.rdfarchitect.models.cim.data.dto.facade.CIMModelFacade;
+import org.rdfarchitect.models.cim.rdf.resources.CIMS;
 import org.rdfarchitect.models.cim.rdf.resources.RDFA;
+import org.rdfarchitect.models.cim.relations.model.CIMResourceUtils;
+import org.rdfarchitect.models.cim.relations.model.properties.CIMPropertyUtils;
 import org.rdfarchitect.services.diagrams.CrossProfileUtils;
 import org.rdfarchitect.services.dl.update.DiagramLayoutServiceUtils;
 import org.rdfarchitect.services.rendering.MergedClasses;
@@ -251,26 +254,64 @@ public class UpdateClassLayoutService
             for (var diagramObject : DLObjectFetcher.fetchAllDOs(diagramLayoutModel, classUUID)) {
                 DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, diagramObject.getMRID());
             }
-            deleteOrphanedLabels(diagramLayoutModel, ctx.getRdfGraph());
+            deleteOrphanedLabels(diagramLayoutModel, ctx.getRdfGraph(), classUUID);
             ctx.commit();
         }
     }
 
     /**
-     * Drops the layout of labels whose resource no longer exists. Labels are anchored to the
-     * resource whose text they display, e.g. an association end, so deleting a class leaves the
-     * labels of its associations behind. Sweeping the graph-scoped layout after a deletion covers
-     * that without every delete path having to know which labels it invalidates.
+     * Drops the layout of labels anchored to an association end of the deleted class. Labels are
+     * anchored to the resource whose text they display, e.g. an association end, so deleting a
+     * class leaves the labels of its associations behind: {@code CIMUpdates.deleteClass} never
+     * cascades to a class's associations, so their own {@code rdfa:uuid} outlives the class.
      */
-    private void deleteOrphanedLabels(Model diagramLayoutModel, Graph rdfGraph) {
+    private void deleteOrphanedLabels(Model diagramLayoutModel, Graph rdfGraph, UUID classUUID) {
+        var danglingAssociationEndUuids = danglingAssociationEndUuids(rdfGraph, classUUID);
+        if (danglingAssociationEndUuids.isEmpty()) {
+            return;
+        }
         for (var label : DLObjectFetcher.fetchAllLabelDOs(diagramLayoutModel)) {
-            var uuidNode =
-                    NodeFactory.createLiteralString(
-                            label.getBelongsToIdentifiedObject().getUuid().toString());
-            if (!rdfGraph.contains(Node.ANY, RDFA.uuid.asNode(), uuidNode)) {
+            if (danglingAssociationEndUuids.contains(
+                    label.getBelongsToIdentifiedObject().getUuid())) {
                 DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, label.getMRID());
             }
         }
+    }
+
+    /**
+     * Finds the UUIDs of both ends of every association still pointing at the deleted class as its
+     * domain or range, so their multiplicity labels can be dropped. Includes each association's
+     * inverse end, since a label may be anchored to either side of the pair.
+     */
+    private Set<UUID> danglingAssociationEndUuids(Graph rdfGraph, UUID classUUID) {
+        var model = ModelFactory.createModelForGraph(rdfGraph);
+        var classResource =
+                model.listSubjectsWithProperty(RDFA.uuid, classUUID.toString())
+                        .nextOptional()
+                        .orElse(null);
+        if (classResource == null) {
+            return Set.of();
+        }
+
+        Set<Resource> associationEnds = new LinkedHashSet<>();
+        associationEnds.addAll(
+                model.listSubjectsWithProperty(RDFS.domain, classResource)
+                        .filterKeep(CIMPropertyUtils::isAssociation)
+                        .toList());
+        associationEnds.addAll(
+                model.listSubjectsWithProperty(RDFS.range, classResource)
+                        .filterKeep(CIMPropertyUtils::isAssociation)
+                        .toList());
+
+        Set<UUID> uuids = new HashSet<>();
+        for (var end : associationEnds) {
+            uuids.add(CIMResourceUtils.findUuidForResource(end));
+            var inverse = end.getProperty(CIMS.inverseRoleName);
+            if (inverse != null && inverse.getObject().isResource()) {
+                uuids.add(CIMResourceUtils.findUuidForResource(inverse.getObject().asResource()));
+            }
+        }
+        return uuids;
     }
 
     @Override

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/UpdateClassLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/classlayout/UpdateClassLayoutService.java
@@ -19,6 +19,9 @@ package org.rdfarchitect.services.dl.update.classlayout;
 
 import lombok.RequiredArgsConstructor;
 
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -36,6 +39,7 @@ import org.rdfarchitect.dl.data.dto.relations.XYZPosition;
 import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
 import org.rdfarchitect.dl.queries.update.DLUpdates;
 import org.rdfarchitect.models.cim.data.dto.facade.CIMModelFacade;
+import org.rdfarchitect.models.cim.rdf.resources.RDFA;
 import org.rdfarchitect.services.diagrams.CrossProfileUtils;
 import org.rdfarchitect.services.dl.update.DiagramLayoutServiceUtils;
 import org.rdfarchitect.services.rendering.MergedClasses;
@@ -247,7 +251,25 @@ public class UpdateClassLayoutService
             for (var diagramObject : DLObjectFetcher.fetchAllDOs(diagramLayoutModel, classUUID)) {
                 DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, diagramObject.getMRID());
             }
+            deleteOrphanedLabels(diagramLayoutModel, ctx.getRdfGraph());
             ctx.commit();
+        }
+    }
+
+    /**
+     * Drops the layout of labels whose resource no longer exists. Labels are anchored to the
+     * resource whose text they display, e.g. an association end, so deleting a class leaves the
+     * labels of its associations behind. Sweeping the graph-scoped layout after a deletion covers
+     * that without every delete path having to know which labels it invalidates.
+     */
+    private void deleteOrphanedLabels(Model diagramLayoutModel, Graph rdfGraph) {
+        for (var label : DLObjectFetcher.fetchAllLabelDOs(diagramLayoutModel)) {
+            var uuidNode =
+                    NodeFactory.createLiteralString(
+                            label.getBelongsToIdentifiedObject().getUuid().toString());
+            if (!rdfGraph.contains(Node.ANY, RDFA.uuid.asNode(), uuidNode)) {
+                DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, label.getMRID());
+            }
         }
     }
 
@@ -282,7 +304,7 @@ public class UpdateClassLayoutService
         for (var cls : classes) {
             var classUri = classUriByUuid.get(cls.getUuid());
             if (classUri != null) {
-                mergedUuids.add(CrossProfileUtils.mergedClassUuid(classUri));
+                mergedUuids.add(CrossProfileUtils.mergedUuid(classUri));
             }
         }
         return mergedUuids;
@@ -333,8 +355,7 @@ public class UpdateClassLayoutService
                 return true;
             }
             var classUri = classUriByUuid.get(cls.getUuid());
-            return classUri != null
-                    && classUUIDs.contains(CrossProfileUtils.mergedClassUuid(classUri));
+            return classUri != null && classUUIDs.contains(CrossProfileUtils.mergedUuid(classUri));
         };
     }
 

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/labellayout/UpdateLabelLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/labellayout/UpdateLabelLayoutService.java
@@ -34,7 +34,9 @@ import org.rdfarchitect.dl.queries.update.DLUpdates;
 import org.rdfarchitect.services.dl.update.DiagramLayoutServiceUtils;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -91,13 +93,14 @@ public class UpdateLabelLayoutService implements UpdateLabelPositionsUseCase {
         if (DLObjectFetcher.fetchDiagram(diagramLayoutModel, diagramUUID) == null) {
             DiagramLayoutServiceUtils.insertDiagram(diagramLayoutModel, diagramUUID, "");
         }
+        var existingLabelsByKey = existingLabelsByKey(diagramLayoutModel, diagramUUID);
         for (var labelPosition : labelPositions) {
             var style = DiagramObjectStyle.byName(labelPosition.getKind());
             if (style == null || style == DiagramObjectStyle.CLASS) {
                 continue;
             }
             var labelKey = new LabelKey(labelPosition.getIdentifiedObjectUUID(), style);
-            var existing = DLObjectFetcher.fetchLabelDO(diagramLayoutModel, diagramUUID, labelKey);
+            var existing = existingLabelsByKey.get(labelKey);
             if (existing != null) {
                 DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, existing.getMRID());
             }
@@ -106,6 +109,24 @@ public class UpdateLabelLayoutService implements UpdateLabelPositionsUseCase {
             }
             insertLabel(diagramLayoutModel, diagramUUID, labelPosition, style);
         }
+    }
+
+    /**
+     * Fetches every existing label of the diagram in one query instead of one {@code fetchLabelDO}
+     * query per label being applied.
+     */
+    private Map<LabelKey, DiagramObject> existingLabelsByKey(
+            Model diagramLayoutModel, UUID diagramUUID) {
+        Map<LabelKey, DiagramObject> byKey = new HashMap<>();
+        for (var label : DLObjectFetcher.fetchDiagramLabelDOs(diagramLayoutModel, diagramUUID)) {
+            if (label.getStyle() == null) {
+                continue;
+            }
+            byKey.put(
+                    new LabelKey(label.getBelongsToIdentifiedObject().getUuid(), label.getStyle()),
+                    label);
+        }
+        return byKey;
     }
 
     private void insertLabel(

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/labellayout/UpdateLabelLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/labellayout/UpdateLabelLayoutService.java
@@ -1,0 +1,129 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl.update.labellayout;
+
+import lombok.RequiredArgsConstructor;
+
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.rdf.model.Model;
+import org.rdfarchitect.api.dto.dl.LabelPositionDTO;
+import org.rdfarchitect.database.DatabasePort;
+import org.rdfarchitect.database.GraphIdentifier;
+import org.rdfarchitect.dl.data.dto.DiagramObject;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
+import org.rdfarchitect.dl.data.dto.relations.MRID;
+import org.rdfarchitect.dl.data.dto.relations.XYOffset;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher.LabelKey;
+import org.rdfarchitect.dl.queries.update.DLUpdates;
+import org.rdfarchitect.services.dl.update.DiagramLayoutServiceUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Stores the manual placement of movable diagram labels. A label is a {@code cim:DiagramObject}
+ * whose style says what kind of label it is and which is anchored to the CIM resource whose text it
+ * displays. It holds an offset relative to the class it is drawn at rather than a coordinate within
+ * the diagram, so a label keeps its placement when its class is moved.
+ */
+@Service
+@RequiredArgsConstructor
+public class UpdateLabelLayoutService implements UpdateLabelPositionsUseCase {
+
+    private final DatabasePort databasePort;
+
+    @Override
+    public void updateLabelPositions(
+            GraphIdentifier graphIdentifier,
+            UUID diagramUUID,
+            List<LabelPositionDTO> labelPositionDTOList) {
+        try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
+            var diagramLayout = ctx.getDiagramLayout();
+            var resolvedDiagramUUID =
+                    diagramUUID != null
+                            ? diagramUUID
+                            : diagramLayout.getDefaultPackageMRID().getUuid();
+
+            applyLabelPositions(
+                    diagramLayout.getDiagramLayoutModel(),
+                    resolvedDiagramUUID,
+                    labelPositionDTOList);
+            ctx.commit();
+        }
+    }
+
+    @Override
+    public void updateLabelPositions(
+            String datasetName, UUID diagramUUID, List<LabelPositionDTO> labelPositionDTOList) {
+        applyLabelPositions(
+                databasePort.getDatasetDiagramLayout(datasetName).getDiagramLayoutModel(),
+                diagramUUID,
+                labelPositionDTOList);
+    }
+
+    /**
+     * Replaces each addressed label wholesale instead of patching its position, which keeps the
+     * stored text in sync with the model and makes a reset (an entry without an offset) fall out of
+     * the same code path.
+     */
+    private void applyLabelPositions(
+            Model diagramLayoutModel, UUID diagramUUID, List<LabelPositionDTO> labelPositions) {
+        if (labelPositions.isEmpty()) {
+            return;
+        }
+        if (DLObjectFetcher.fetchDiagram(diagramLayoutModel, diagramUUID) == null) {
+            DiagramLayoutServiceUtils.insertDiagram(diagramLayoutModel, diagramUUID, "");
+        }
+        for (var labelPosition : labelPositions) {
+            var style = DiagramObjectStyle.byName(labelPosition.getKind());
+            if (style == null || style == DiagramObjectStyle.CLASS) {
+                continue;
+            }
+            var labelKey = new LabelKey(labelPosition.getIdentifiedObjectUUID(), style);
+            var existing = DLObjectFetcher.fetchLabelDO(diagramLayoutModel, diagramUUID, labelKey);
+            if (existing != null) {
+                DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, existing.getMRID());
+            }
+            if (labelPosition.getXOffset() == null || labelPosition.getYOffset() == null) {
+                continue;
+            }
+            insertLabel(diagramLayoutModel, diagramUUID, labelPosition, style);
+        }
+    }
+
+    private void insertLabel(
+            Model diagramLayoutModel,
+            UUID diagramUUID,
+            LabelPositionDTO labelPosition,
+            DiagramObjectStyle style) {
+        DLUpdates.insertDiagramObject(
+                diagramLayoutModel,
+                DiagramObject.builder()
+                        .mRID(new MRID(UUID.randomUUID()))
+                        .style(style)
+                        .belongsToDiagram(new MRID(diagramUUID))
+                        .belongsToIdentifiedObject(
+                                new MRID(labelPosition.getIdentifiedObjectUUID()))
+                        .offset(
+                                new XYOffset(
+                                        labelPosition.getXOffset(), labelPosition.getYOffset()))
+                        .build());
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/labellayout/UpdateLabelPositionsUseCase.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/labellayout/UpdateLabelPositionsUseCase.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl.update.labellayout;
+
+import org.rdfarchitect.api.dto.dl.LabelPositionDTO;
+import org.rdfarchitect.database.GraphIdentifier;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UpdateLabelPositionsUseCase {
+
+    /**
+     * Updates the offsets of movable labels within the diagram associated with the given package.
+     *
+     * @param graphIdentifier the identifier of the graph
+     * @param diagramUUID the UUID of the package identifying the diagram
+     * @param labelPositionDTOList the labels to reposition; entries without an offset are reset to
+     *     their default placement
+     */
+    void updateLabelPositions(
+            GraphIdentifier graphIdentifier,
+            UUID diagramUUID,
+            List<LabelPositionDTO> labelPositionDTOList);
+
+    /**
+     * Updates the offsets of movable labels within the diagram associated with the given custom
+     * diagram.
+     *
+     * @param datasetName the literal name of the dataset
+     * @param diagramUUID the UUID of the custom diagram identifying the diagram
+     * @param labelPositionDTOList the labels to reposition; entries without an offset are reset to
+     *     their default placement
+     */
+    void updateLabelPositions(
+            String datasetName, UUID diagramUUID, List<LabelPositionDTO> labelPositionDTOList);
+}

--- a/backend/src/main/java/org/rdfarchitect/services/dl/update/packagelayout/UpdatePackageLayoutService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/dl/update/packagelayout/UpdatePackageLayoutService.java
@@ -81,6 +81,11 @@ public class UpdatePackageLayoutService
                 DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, diagramObject.getMRID());
             }
 
+            for (var label :
+                    DLObjectFetcher.fetchDiagramLabelDOs(diagramLayoutModel, packageUUID)) {
+                DLUpdates.deleteDiagramObjectCascade(diagramLayoutModel, label.getMRID());
+            }
+
             DLUpdates.deleteDiagram(diagramLayoutModel, new MRID(packageUUID));
             ctx.commit();
         }

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/MergedClasses.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/MergedClasses.java
@@ -31,8 +31,7 @@ import java.util.UUID;
 /**
  * Resolution helpers for classes that are merged across the profiles of a dataset. A merged class
  * has no uuid of its own in any graph and is keyed by the uuid {@link
- * org.rdfarchitect.services.diagrams.CrossProfileUtils#mergedClassUuid(String)} derives from its
- * IRI.
+ * org.rdfarchitect.services.diagrams.CrossProfileUtils#mergedUuid(String)} derives from its IRI.
  */
 public final class MergedClasses {
 

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMCollectionSvelteFlowService.java
@@ -333,15 +333,19 @@ public class RenderCIMCollectionSvelteFlowService implements RenderCIMCollection
         var sourceUUID = renderContext.uriToUUIDMap.get(from.getDomain().getUri().toString());
         var targetUUID = renderContext.uriToUUIDMap.get(from.getRange().getUri().toString());
 
-        var fromMultiplicity = extractMultiplicityString(from.getMultiplicity());
-        var toMultiplicity = extractMultiplicityString(to.getMultiplicity());
+        var layoutData = renderContext.layoutingData();
         var useToAssociation = getAssociationUsedValue(from.getAssociationUsed());
         var useFromAssociation = getAssociationUsedValue(to.getAssociationUsed());
 
         var edgeDataDTO =
                 EdgeDataDTO.builder()
-                        .toMultiplicity(toMultiplicity)
-                        .fromMultiplicity(fromMultiplicity)
+                        .labels(
+                                SvelteFlowLabels.forAssociation(
+                                        to.getUuid(),
+                                        extractMultiplicityString(to.getMultiplicity()),
+                                        from.getUuid(),
+                                        extractMultiplicityString(from.getMultiplicity()),
+                                        layoutData))
                         .useToAssociation(useToAssociation)
                         .useFromAssociation(useFromAssociation)
                         .build();

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
@@ -153,7 +153,7 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         for (var merged : renderedClasses.values()) {
             nodes.add(assembleMergedNode(merged, mergedClasses, layoutData));
         }
-        var edges = assembleMergedEdges(renderedClasses);
+        var edges = assembleMergedEdges(renderedClasses, layoutData);
 
         return SvelteFlowDTO.builder().nodes(nodes).edges(edges).build();
     }
@@ -188,7 +188,7 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                                         new MergedFacadeClass(
                                                 classUri,
                                                 cimClass.getLabel().getValue(),
-                                                CrossProfileUtils.mergedClassUuid(classUri),
+                                                CrossProfileUtils.mergedUuid(classUri),
                                                 new ArrayList<>()));
                 entry.sources()
                         .add(
@@ -328,10 +328,11 @@ public class RenderCIMFacadeCollectionSvelteFlowService
         return new ArrayList<>(refs.values());
     }
 
-    private List<EdgeDTO> assembleMergedEdges(Map<String, MergedFacadeClass> mergedClasses) {
+    private List<EdgeDTO> assembleMergedEdges(
+            Map<String, MergedFacadeClass> mergedClasses, RenderingLayoutData layoutData) {
         var edges = new ArrayList<EdgeDTO>();
         edges.addAll(assembleMergedInheritanceEdges(mergedClasses));
-        edges.addAll(assembleMergedAssociationEdges(mergedClasses));
+        edges.addAll(assembleMergedAssociationEdges(mergedClasses, layoutData));
         return edges;
     }
 
@@ -358,7 +359,7 @@ public class RenderCIMFacadeCollectionSvelteFlowService
     }
 
     private List<EdgeDTO> assembleMergedAssociationEdges(
-            Map<String, MergedFacadeClass> mergedClasses) {
+            Map<String, MergedFacadeClass> mergedClasses, RenderingLayoutData layoutData) {
         var edges = new ArrayList<EdgeDTO>();
         var handledAssociationUris = new HashSet<String>();
         for (var merged : mergedClasses.values()) {
@@ -378,11 +379,17 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                     handledAssociationUris.add(inverse.getUri().toString());
                     var edgeData =
                             EdgeDataDTO.builder()
-                                    .fromMultiplicity(
-                                            extractMultiplicityString(
-                                                    association.getMultiplicity()))
-                                    .toMultiplicity(
-                                            extractMultiplicityString(inverse.getMultiplicity()))
+                                    .labels(
+                                            SvelteFlowLabels.forAssociation(
+                                                    CrossProfileUtils.mergedUuid(
+                                                            inverse.getUri().toString()),
+                                                    extractMultiplicityString(
+                                                            inverse.getMultiplicity()),
+                                                    CrossProfileUtils.mergedUuid(
+                                                            association.getUri().toString()),
+                                                    extractMultiplicityString(
+                                                            association.getMultiplicity()),
+                                                    layoutData))
                                     .useToAssociation(
                                             getAssociationUsedValue(
                                                     association.getAssociationUsed()))
@@ -743,7 +750,8 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                 }
                 var to = from.getInverseAssociation();
 
-                associationEdgeDTOList.add(assembleAssociationEdgeDTO(cimClass, from, to));
+                associationEdgeDTOList.add(
+                        assembleAssociationEdgeDTO(renderContext, cimClass, from, to));
 
                 handledAssociationUris.add(from.getUri().toString());
                 handledAssociationUris.add(to.getUri().toString());
@@ -753,11 +761,20 @@ public class RenderCIMFacadeCollectionSvelteFlowService
     }
 
     private EdgeDTO assembleAssociationEdgeDTO(
-            ICIMClass sourceClass, ICIMAssociation from, ICIMAssociation to) {
+            RenderContext renderContext,
+            ICIMClass sourceClass,
+            ICIMAssociation from,
+            ICIMAssociation to) {
+        var layoutData = renderContext.layoutingData();
         var edgeDataDTO =
                 EdgeDataDTO.builder()
-                        .fromMultiplicity(extractMultiplicityString(from.getMultiplicity()))
-                        .toMultiplicity(extractMultiplicityString(to.getMultiplicity()))
+                        .labels(
+                                SvelteFlowLabels.forAssociation(
+                                        to.getUuid(),
+                                        extractMultiplicityString(to.getMultiplicity()),
+                                        from.getUuid(),
+                                        extractMultiplicityString(from.getMultiplicity()),
+                                        layoutData))
                         .useToAssociation(getAssociationUsedValue(from.getAssociationUsed()))
                         .useFromAssociation(getAssociationUsedValue(to.getAssociationUsed()))
                         .build();

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/SvelteFlowLabels.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/SvelteFlowLabels.java
@@ -1,0 +1,99 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.rendering.svelteflow;
+
+import lombok.experimental.UtilityClass;
+
+import org.rdfarchitect.api.dto.dl.RenderingLayoutData;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeLabelDTO;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeLabelDTO.Anchor;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.PositionDTO;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher.LabelKey;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Assembles the movable labels of an association end. A label is identified by the CIM resource it
+ * belongs to plus its kind, which is what lets further kinds (role names, association names) be
+ * added here without touching the layout storage.
+ */
+@UtilityClass
+public class SvelteFlowLabels {
+
+    /**
+     * Builds the labels of an association edge. A multiplicity is rendered at the class its
+     * association points to, so the multiplicity of the association leaving the source class ends
+     * up at the target end and vice versa.
+     *
+     * @param sourceAssociation the UUID of the association end whose multiplicity sits at the
+     *     source class
+     * @param sourceMultiplicity the multiplicity text at the source class
+     * @param targetAssociation the UUID of the association end whose multiplicity sits at the
+     *     target class
+     * @param targetMultiplicity the multiplicity text at the target class
+     * @param layoutData the layout data holding manually placed label positions, may be null
+     * @return the labels of the edge
+     */
+    public List<EdgeLabelDTO> forAssociation(
+            UUID sourceAssociation,
+            String sourceMultiplicity,
+            UUID targetAssociation,
+            String targetMultiplicity,
+            RenderingLayoutData layoutData) {
+        var labels = new ArrayList<EdgeLabelDTO>();
+        addMultiplicity(labels, Anchor.SOURCE, sourceAssociation, sourceMultiplicity, layoutData);
+        addMultiplicity(labels, Anchor.TARGET, targetAssociation, targetMultiplicity, layoutData);
+        return labels;
+    }
+
+    private void addMultiplicity(
+            List<EdgeLabelDTO> labels,
+            Anchor anchor,
+            UUID association,
+            String multiplicity,
+            RenderingLayoutData layoutData) {
+        if (association == null || multiplicity == null || multiplicity.isBlank()) {
+            return;
+        }
+        labels.add(
+                EdgeLabelDTO.builder()
+                        .anchor(anchor)
+                        .identifiedObjectUUID(association)
+                        .kind(DiagramObjectStyle.MULTIPLICITY.getStyleName())
+                        .text(multiplicity)
+                        .offset(
+                                offsetFor(
+                                        layoutData,
+                                        new LabelKey(association, DiagramObjectStyle.MULTIPLICITY)))
+                        .build());
+    }
+
+    private PositionDTO offsetFor(RenderingLayoutData layoutData, LabelKey key) {
+        if (layoutData == null || layoutData.getLabelLayoutingData() == null) {
+            return null;
+        }
+        var offset = layoutData.getLabelLayoutingData().get(key);
+        if (offset == null) {
+            return null;
+        }
+        return PositionDTO.builder().x(offset.x()).y(offset.y()).build();
+    }
+}

--- a/backend/src/main/java/org/rdfarchitect/services/select/ClassLocatorService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/select/ClassLocatorService.java
@@ -100,7 +100,7 @@ public class ClassLocatorService implements LocateClassUseCase {
                 var model = ModelFactory.createModelForGraph(ctx.getRdfGraph());
                 for (var cimClass : new CIMModelFacade(graphUri, model).getCIMClasses()) {
                     var classUri = cimClass.getUri().toString();
-                    if (CrossProfileUtils.mergedClassUuid(classUri).toString().equals(classUUID)) {
+                    if (CrossProfileUtils.mergedUuid(classUri).toString().equals(classUUID)) {
                         return new LocatedClass(graphUri, classUri, cimClass.getUuid());
                     }
                 }

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
@@ -117,8 +117,8 @@ public class UpdateClassService
 
         String newClassUri = newClass.getPrefix() + newClass.getLabel();
         if (!oldClassUri.equals(newClassUri)) {
-            var oldMergedUuid = CrossProfileUtils.mergedClassUuid(oldClassUri);
-            var newMergedUuid = CrossProfileUtils.mergedClassUuid(newClassUri);
+            var oldMergedUuid = CrossProfileUtils.mergedUuid(oldClassUri);
+            var newMergedUuid = CrossProfileUtils.mergedUuid(newClassUri);
             crossProfileDiagramLayoutUseCase.migrateLayoutToNewClassUri(
                     graphIdentifier.datasetName(), oldMergedUuid, newMergedUuid, newClassUri);
         }

--- a/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateClassLayoutServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateClassLayoutServiceTest.java
@@ -69,7 +69,7 @@ class UpdateClassLayoutServiceTest extends DiagramLayoutServicesTestBase {
                         .getDiagramLayoutModel();
         assertThat(
                         DLObjectFetcher.fetchDiagramDOForClass(
-                                model, diagramUUID, CrossProfileUtils.mergedClassUuid(CLASS_A_URI)))
+                                model, diagramUUID, CrossProfileUtils.mergedUuid(CLASS_A_URI)))
                 .isNotNull();
         assertThat(DLObjectFetcher.fetchDiagramDOForClass(model, diagramUUID, CLASS_A_UUID))
                 .isNull();
@@ -83,7 +83,7 @@ class UpdateClassLayoutServiceTest extends DiagramLayoutServicesTestBase {
                 datasetName, diagramUUID, List.of(classAInDiagram()));
 
         service.removeClassesFromCustomDatasetDiagram(
-                datasetName, diagramUUID, List.of(CrossProfileUtils.mergedClassUuid(CLASS_A_URI)));
+                datasetName, diagramUUID, List.of(CrossProfileUtils.mergedUuid(CLASS_A_URI)));
 
         assertThat(databasePort.getDatasetDiagrams(datasetName).get(diagramUUID).getClasses())
                 .isEmpty();
@@ -93,7 +93,7 @@ class UpdateClassLayoutServiceTest extends DiagramLayoutServicesTestBase {
                                         .getDatasetDiagramLayout(datasetName)
                                         .getDiagramLayoutModel(),
                                 diagramUUID,
-                                CrossProfileUtils.mergedClassUuid(CLASS_A_URI)))
+                                CrossProfileUtils.mergedUuid(CLASS_A_URI)))
                 .isNull();
     }
 

--- a/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateLabelLayoutServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateLabelLayoutServiceTest.java
@@ -19,9 +19,12 @@ package org.rdfarchitect.services.dl.update;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +39,8 @@ import org.rdfarchitect.dl.queries.select.DLObjectFetcher.LabelKey;
 import org.rdfarchitect.dl.queries.update.DLUpdates;
 import org.rdfarchitect.dl.rdf.resources.CIM;
 import org.rdfarchitect.dl.rdf.resources.DL;
+import org.rdfarchitect.models.cim.rdf.resources.CIMS;
+import org.rdfarchitect.models.cim.rdf.resources.RDFA;
 import org.rdfarchitect.services.dl.DiagramLayoutServicesTestBase;
 import org.rdfarchitect.services.dl.update.classlayout.UpdateClassLayoutService;
 import org.rdfarchitect.services.dl.update.labellayout.UpdateLabelLayoutService;
@@ -56,6 +61,11 @@ class UpdateLabelLayoutServiceTest extends DiagramLayoutServicesTestBase {
 
     private static final UUID OTHER_ASSOCIATION_END_UUID =
             UUID.fromString("9c8e7d6a-5b4c-4321-9876-0fedcba98765");
+
+    private static final String CLASS_A_URI = "http://example.com#classA";
+    private static final String CLASS_B_URI = "http://example.com#classB";
+    private static final String ASSOCIATION_URI = "http://example.com#classA.classB";
+    private static final String INVERSE_ASSOCIATION_URI = "http://example.com#classB.classA";
 
     private static UpdateLabelLayoutService service;
     private static UpdateClassLayoutService classLayoutService;
@@ -192,12 +202,83 @@ class UpdateLabelLayoutServiceTest extends DiagramLayoutServicesTestBase {
 
     @Test
     void deleteClassLayoutData_classDeleted_dropsTheLabelsOfItsAssociations() {
+        insertAssociationFixture();
+        var inverseEndLabel = new LabelPositionDTO();
+        inverseEndLabel.setIdentifiedObjectUUID(OTHER_ASSOCIATION_END_UUID);
+        inverseEndLabel.setKind(DiagramObjectStyle.MULTIPLICITY.getStyleName());
+        inverseEndLabel.setXOffset(5F);
+        inverseEndLabel.setYOffset(6F);
+        var unrelatedLabel = new LabelPositionDTO();
+        unrelatedLabel.setIdentifiedObjectUUID(PACKAGE_A_UUID);
+        unrelatedLabel.setKind(DiagramObjectStyle.MULTIPLICITY.getStyleName());
+        unrelatedLabel.setXOffset(3F);
+        unrelatedLabel.setYOffset(4F);
+
         service.updateLabelPositions(
-                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+                graphIdentifier,
+                PACKAGE_A_UUID,
+                List.of(labelPosition(-37.5F, 62.25F), inverseEndLabel, unrelatedLabel));
 
         classLayoutService.deleteClassLayoutData(graphIdentifier, CLASS_A_UUID);
 
-        assertThat(storedOffsets()).isEmpty();
+        assertThat(storedOffsets())
+                .containsOnlyKeys(new LabelKey(PACKAGE_A_UUID, DiagramObjectStyle.MULTIPLICITY));
+    }
+
+    /**
+     * Sets up classA, classB and the association pair between them (with classA as domain), whose
+     * two ends carry {@link #ASSOCIATION_END_UUID} and {@link #OTHER_ASSOCIATION_END_UUID}. {@code
+     * package.ttl} only contains a package, not a class, so the CIM data a delete needs to cascade
+     * against is added directly rather than through a shared fixture file other tests also load.
+     */
+    private static void insertAssociationFixture() {
+        var classA = NodeFactory.createURI(CLASS_A_URI);
+        var classB = NodeFactory.createURI(CLASS_B_URI);
+        var association = NodeFactory.createURI(ASSOCIATION_URI);
+        var inverseAssociation = NodeFactory.createURI(INVERSE_ASSOCIATION_URI);
+
+        try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
+            var graph = ctx.getRdfGraph();
+
+            graph.add(classA, RDF.type.asNode(), RDFS.Class.asNode());
+            graph.add(
+                    classA,
+                    RDFA.uuid.asNode(),
+                    NodeFactory.createLiteralString(CLASS_A_UUID.toString()));
+            graph.add(classB, RDF.type.asNode(), RDFS.Class.asNode());
+            graph.add(
+                    classB,
+                    RDFA.uuid.asNode(),
+                    NodeFactory.createLiteralString(UUID.randomUUID().toString()));
+
+            graph.add(association, RDF.type.asNode(), RDF.Property.asNode());
+            graph.add(
+                    association,
+                    RDFA.uuid.asNode(),
+                    NodeFactory.createLiteralString(ASSOCIATION_END_UUID.toString()));
+            graph.add(association, RDFS.domain.asNode(), classA);
+            graph.add(association, RDFS.range.asNode(), classB);
+            graph.add(
+                    association,
+                    CIMS.associationUsed.asNode(),
+                    NodeFactory.createLiteralString("Yes"));
+            graph.add(association, CIMS.inverseRoleName.asNode(), inverseAssociation);
+
+            graph.add(inverseAssociation, RDF.type.asNode(), RDF.Property.asNode());
+            graph.add(
+                    inverseAssociation,
+                    RDFA.uuid.asNode(),
+                    NodeFactory.createLiteralString(OTHER_ASSOCIATION_END_UUID.toString()));
+            graph.add(inverseAssociation, RDFS.domain.asNode(), classB);
+            graph.add(inverseAssociation, RDFS.range.asNode(), classA);
+            graph.add(
+                    inverseAssociation,
+                    CIMS.associationUsed.asNode(),
+                    NodeFactory.createLiteralString("Yes"));
+            graph.add(inverseAssociation, CIMS.inverseRoleName.asNode(), association);
+
+            ctx.commit();
+        }
     }
 
     @Test

--- a/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateLabelLayoutServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/dl/update/UpdateLabelLayoutServiceTest.java
@@ -1,0 +1,237 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.rdfarchitect.services.dl.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rdfarchitect.api.dto.dl.ClassPositionDTO;
+import org.rdfarchitect.api.dto.dl.LabelPositionDTO;
+import org.rdfarchitect.dl.data.dto.DiagramObject;
+import org.rdfarchitect.dl.data.dto.relations.DiagramObjectStyle;
+import org.rdfarchitect.dl.data.dto.relations.MRID;
+import org.rdfarchitect.dl.data.dto.relations.XYOffset;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
+import org.rdfarchitect.dl.queries.select.DLObjectFetcher.LabelKey;
+import org.rdfarchitect.dl.queries.update.DLUpdates;
+import org.rdfarchitect.dl.rdf.resources.CIM;
+import org.rdfarchitect.dl.rdf.resources.DL;
+import org.rdfarchitect.services.dl.DiagramLayoutServicesTestBase;
+import org.rdfarchitect.services.dl.update.classlayout.UpdateClassLayoutService;
+import org.rdfarchitect.services.dl.update.labellayout.UpdateLabelLayoutService;
+import org.rdfarchitect.services.dl.update.packagelayout.UpdatePackageLayoutService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+class UpdateLabelLayoutServiceTest extends DiagramLayoutServicesTestBase {
+
+    /**
+     * The association end a multiplicity belongs to. Any UUID does, the layout only ever stores it
+     * as the resource the label is anchored to.
+     */
+    private static final UUID ASSOCIATION_END_UUID =
+            UUID.fromString("1d3f5b8a-2c47-4e91-8f0d-6b2a9c4e7351");
+
+    private static final UUID OTHER_ASSOCIATION_END_UUID =
+            UUID.fromString("9c8e7d6a-5b4c-4321-9876-0fedcba98765");
+
+    private static UpdateLabelLayoutService service;
+    private static UpdateClassLayoutService classLayoutService;
+    private static UpdatePackageLayoutService packageLayoutService;
+
+    @BeforeAll
+    static void setUpServices() {
+        service = new UpdateLabelLayoutService(databasePort);
+        classLayoutService = new UpdateClassLayoutService(databasePort, packageMapper);
+        packageLayoutService =
+                new UpdatePackageLayoutService(databasePort, packageMapper, converter);
+    }
+
+    @BeforeEach
+    void setUp() {
+        addGraphFromFile("package.ttl");
+        updateDiagramLayoutService.createDiagramLayout(graphIdentifier);
+    }
+
+    @Test
+    void updateLabelPositions_labelMoved_storesTheOffset() {
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+
+        assertThat(storedOffsets()).containsExactly(entryOf(new XYOffset(-37.5F, 62.25F)));
+    }
+
+    @Test
+    void updateLabelPositions_labelIsPlacedAsADiagramObjectWithoutAPoint() {
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(10F, 20F)));
+
+        var labelDO =
+                DLObjectFetcher.fetchLabelDO(
+                        model(),
+                        PACKAGE_A_UUID,
+                        new LabelKey(ASSOCIATION_END_UUID, DiagramObjectStyle.MULTIPLICITY));
+        assertThat(labelDO).isNotNull();
+        assertThat(DLObjectFetcher.fetchDOPForDO(model(), labelDO.getMRID())).isNull();
+
+        var labelResource = model().getResource(labelDO.getMRID().getFullMRID());
+        assertThat(labelResource.hasProperty(RDF.type, DL.diagramObjectType)).isTrue();
+        assertThat(labelResource.hasProperty(CIM.ioName)).isFalse();
+        assertThat(
+                        labelResource.hasProperty(
+                                DL.diagramObjectStyle,
+                                ResourceFactory.createResource(
+                                        DiagramObjectStyle.MULTIPLICITY.getMRID().getFullMRID())))
+                .isTrue();
+    }
+
+    @Test
+    void updateLabelPositions_labelMovedTwice_replacesTheOffsetWithoutDuplicating() {
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(10F, -20F)));
+
+        assertThat(storedOffsets()).containsExactly(entryOf(new XYOffset(10F, -20F)));
+    }
+
+    @Test
+    void updateLabelPositions_offsetIsNull_resetsTheLabelToItsDefaultPlacement() {
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(null, null)));
+
+        assertThat(storedOffsets()).isEmpty();
+    }
+
+    @Test
+    void updateLabelPositions_severalLabels_shareOneStyleResource() {
+        var second = new LabelPositionDTO();
+        second.setIdentifiedObjectUUID(OTHER_ASSOCIATION_END_UUID);
+        second.setKind(DiagramObjectStyle.MULTIPLICITY.getStyleName());
+        second.setXOffset(1F);
+        second.setYOffset(2F);
+
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-1F, -2F), second));
+
+        assertThat(storedOffsets()).hasSize(2);
+        assertThat(model().listSubjectsWithProperty(RDF.type, DL.diagramObjectStyleType).toList())
+                .hasSize(1);
+    }
+
+    @Test
+    void updateLabelPositions_labelPlaced_isInvisibleToTheClassLayout() {
+        var classPosition = new ClassPositionDTO();
+        classPosition.setClassUUID(CLASS_A_UUID);
+        classPosition.setXPosition(11F);
+        classPosition.setYPosition(22F);
+        classLayoutService.updateClassPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(classPosition));
+
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+
+        assertThat(DLObjectFetcher.fetchDiagramDOPPerClass(model(), PACKAGE_A_UUID))
+                .containsOnlyKeys(CLASS_A_UUID);
+        assertThat(DLObjectFetcher.fetchDiagramDOs(model(), new MRID(PACKAGE_A_UUID)))
+                .extracting(diagramObject -> diagramObject.getBelongsToIdentifiedObject().getUuid())
+                .containsExactly(CLASS_A_UUID);
+        assertThat(DLObjectFetcher.fetchAllDOs(model(), ASSOCIATION_END_UUID)).isEmpty();
+    }
+
+    /**
+     * Labels are told apart from classes by their style. Nothing forces a future kind of label to
+     * stay nameless, so the class queries have to ignore one that does carry a name.
+     */
+    @Test
+    void fetchDiagramDOs_labelCarriesAName_isStillIgnoredByTheClassQueries() {
+        DLUpdates.insertDiagramObject(
+                model(),
+                DiagramObject.builder()
+                        .mRID(new MRID(UUID.randomUUID()))
+                        .name("0..n")
+                        .style(DiagramObjectStyle.MULTIPLICITY)
+                        .belongsToDiagram(new MRID(PACKAGE_A_UUID))
+                        .belongsToIdentifiedObject(new MRID(ASSOCIATION_END_UUID))
+                        .offset(new XYOffset(5F, 5F))
+                        .build());
+
+        assertThat(DLObjectFetcher.fetchDiagramDOs(model(), new MRID(PACKAGE_A_UUID))).isEmpty();
+        assertThat(DLObjectFetcher.fetchAllDOs(model(), ASSOCIATION_END_UUID)).isEmpty();
+        assertThat(
+                        DLObjectFetcher.fetchDiagramDOForClass(
+                                model(), PACKAGE_A_UUID, ASSOCIATION_END_UUID))
+                .isNull();
+    }
+
+    @Test
+    void deleteClassLayoutData_classDeleted_dropsTheLabelsOfItsAssociations() {
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+
+        classLayoutService.deleteClassLayoutData(graphIdentifier, CLASS_A_UUID);
+
+        assertThat(storedOffsets()).isEmpty();
+    }
+
+    @Test
+    void deletePackageLayoutData_packageDeleted_dropsTheLabelsOfItsDiagram() {
+        service.updateLabelPositions(
+                graphIdentifier, PACKAGE_A_UUID, List.of(labelPosition(-37.5F, 62.25F)));
+
+        packageLayoutService.deletePackageLayoutData(graphIdentifier, PACKAGE_A_UUID);
+
+        assertThat(storedOffsets()).isEmpty();
+    }
+
+    private static LabelPositionDTO labelPosition(Float xOffset, Float yOffset) {
+        var labelPosition = new LabelPositionDTO();
+        labelPosition.setIdentifiedObjectUUID(ASSOCIATION_END_UUID);
+        labelPosition.setKind(DiagramObjectStyle.MULTIPLICITY.getStyleName());
+        labelPosition.setXOffset(xOffset);
+        labelPosition.setYOffset(yOffset);
+        return labelPosition;
+    }
+
+    private static Map.Entry<LabelKey, XYOffset> entryOf(XYOffset offset) {
+        return Map.entry(
+                new LabelKey(ASSOCIATION_END_UUID, DiagramObjectStyle.MULTIPLICITY), offset);
+    }
+
+    private static Map<LabelKey, XYOffset> storedOffsets() {
+        return DLObjectFetcher.fetchLabelOffsets(model(), PACKAGE_A_UUID);
+    }
+
+    private static Model model() {
+        return databasePort
+                .getGraphWithContext(graphIdentifier)
+                .getDiagramLayout()
+                .getDiagramLayoutModelDirect();
+    }
+}

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMCollectionSvelteFlowServiceTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.*;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.junit.jupiter.api.Test;
 import org.rdfarchitect.api.dto.rendering.svelteflow.SvelteFlowDTO;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeLabelDTO;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeLabelDTO.Anchor;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EnumEntryDTO;
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSBelongsToCategory;
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSMultiplicity;
@@ -190,8 +192,9 @@ class RenderCIMCollectionSvelteFlowServiceTest extends RenderCIMCollectionTestBa
         // Assert
         var associationEdgeDTO = result.getEdges().getFirst();
         assertThat(result.getEdges()).hasSize(1);
-        assertThat(associationEdgeDTO.getData().getFromMultiplicity()).isEqualTo("0...n");
-        assertThat(associationEdgeDTO.getData().getToMultiplicity()).isEqualTo("1...1");
+        assertThat(associationEdgeDTO.getData().getLabels())
+                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getText)
+                .containsExactly(tuple(Anchor.SOURCE, "1...1"), tuple(Anchor.TARGET, "0...n"));
         assertThat(associationEdgeDTO.getData().isUseFromAssociation()).isFalse();
         assertThat(associationEdgeDTO.getData().isUseToAssociation()).isTrue();
     }

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.rdfarchitect.api.dto.rendering.svelteflow.SvelteFlowDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.AttributeDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeDTO;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeLabelDTO;
+import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EdgeLabelDTO.Anchor;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.EnumEntryDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.NodeDTO;
 import org.rdfarchitect.api.dto.rendering.svelteflow.sub.SuperClassDTO;
@@ -347,8 +349,9 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
         var edge = associationEdges.getFirst();
         assertThat(edge.getSource()).isEqualTo(CHILD_UUID);
         assertThat(edge.getTarget()).isEqualTo(TERMINAL_UUID);
-        assertThat(edge.getData().getFromMultiplicity()).isEqualTo("0..n");
-        assertThat(edge.getData().getToMultiplicity()).isEqualTo("1..1");
+        assertThat(edge.getData().getLabels())
+                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getText)
+                .containsExactly(tuple(Anchor.SOURCE, "1..1"), tuple(Anchor.TARGET, "0..n"));
         assertThat(edge.getData().isUseToAssociation()).isTrue();
         assertThat(edge.getData().isUseFromAssociation()).isFalse();
     }
@@ -910,10 +913,7 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
                             assertThat(List.of(edge.getSource(), edge.getTarget()))
                                     .containsExactlyInAnyOrder(
                                             mergedUuid("Child"), mergedUuid("Terminal"));
-                            assertThat(
-                                            List.of(
-                                                    edge.getData().getFromMultiplicity(),
-                                                    edge.getData().getToMultiplicity()))
+                            assertThat(multiplicityTexts(edge))
                                     .containsExactlyInAnyOrder("0..n", "1..1");
                         });
     }
@@ -969,6 +969,10 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
 
         assertThat(result.getNodes()).isEmpty();
         assertThat(result.getEdges()).isEmpty();
+    }
+
+    private List<String> multiplicityTexts(EdgeDTO edge) {
+        return edge.getData().getLabels().stream().map(EdgeLabelDTO::getText).toList();
     }
 
     private List<EdgeDTO> mergedAssociationEdges(List<CIMProfileModel> profiles) {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -970,6 +970,34 @@
         },
         "type" : "object"
       },
+      "LabelPositionDTO" : {
+        "properties" : {
+          "identifiedObjectUUID" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "kind" : {
+            "type" : "string"
+          },
+          "xOffset" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "xoffset" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "yOffset" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "yoffset" : {
+            "format" : "float",
+            "type" : "number"
+          }
+        },
+        "type" : "object"
+      },
       "ListPackagesResponse" : {
         "properties" : {
           "externalPackageList" : {
@@ -5882,6 +5910,83 @@
         ]
       }
     },
+    "/api/datasets/{datasetName}/graphs/{graphURI}/layout/{diagramUUID}/labels" : {
+      "put" : {
+        "description" : "Updates the offsets for all the labels provided in the request body. Labels without an offset are reset to their default placement.",
+        "operationId" : "updateLabelPositions",
+        "parameters" : [
+          {
+            "description" : "The name/url of the inquirer.",
+            "in" : "header",
+            "name" : "origin",
+            "required" : false,
+            "schema" : {
+              "default" : "unknown",
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "The literal name of the dataset.",
+            "in" : "path",
+            "name" : "datasetName",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "The url encoded uri of the graph, or \"default\" to access the default graph.",
+            "in" : "path",
+            "name" : "graphURI",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "The UUID of the package or custom diagram being updated.",
+            "in" : "path",
+            "name" : "diagramUUID",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "items" : {
+                  "$ref" : "#/components/schemas/LabelPositionDTO"
+                },
+                "type" : "array"
+              }
+            }
+          },
+          "description" : "The DTO with necessary information for label reposition",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "OK"
+          }
+        },
+        "summary" : "updates label positions",
+        "tags" : [
+          "diagram",
+          "layout",
+          "label"
+        ]
+      }
+    },
     "/api/datasets/{datasetName}/graphs/{graphURI}/ontology" : {
       "delete" : {
         "description" : "Deletes the currently stored ontology.",
@@ -7742,6 +7847,74 @@
           "diagram",
           "layout",
           "class"
+        ]
+      }
+    },
+    "/api/datasets/{datasetName}/layout/{diagramUUID}/labels" : {
+      "put" : {
+        "description" : "Updates the offsets for all the labels provided in the request body. Labels without an offset are reset to their default placement.",
+        "operationId" : "updateDatasetLabelPositions",
+        "parameters" : [
+          {
+            "description" : "The name/url of the inquirer.",
+            "in" : "header",
+            "name" : "origin",
+            "required" : false,
+            "schema" : {
+              "default" : "unknown",
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "The literal name of the dataset.",
+            "in" : "path",
+            "name" : "datasetName",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "The UUID of the package or custom diagram being updated.",
+            "in" : "path",
+            "name" : "diagramUUID",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "items" : {
+                  "$ref" : "#/components/schemas/LabelPositionDTO"
+                },
+                "type" : "array"
+              }
+            }
+          },
+          "description" : "The DTO with necessary information for label reposition",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "OK"
+          }
+        },
+        "summary" : "updates label positions on dataset level",
+        "tags" : [
+          "diagram",
+          "layout",
+          "label"
         ]
       }
     },

--- a/frontend/src/lib/rendering/svelteflow/PackageSnapshotCanvas.svelte
+++ b/frontend/src/lib/rendering/svelteflow/PackageSnapshotCanvas.svelte
@@ -26,12 +26,14 @@
 
     import AssociationEdge from "./components/AssociationEdge.svelte";
     import ClassNode from "./components/ClassNode.svelte";
+    import DiagramLabelNode from "./components/DiagramLabelNode.svelte";
     import EdgeMarkers from "./components/EdgeMarkers.svelte";
     import InheritanceEdge from "./components/InheritanceEdge.svelte";
     import {
         decorateEdges,
         hasDefaultNodeLayout,
     } from "./diagram/diagramElements.js";
+    import { buildLabelNodes, LABEL_NODE_TYPE } from "./diagram/labelNodes.js";
     import { getLayoutedNodes } from "./layout/elkLayout.js";
 
     let {
@@ -41,7 +43,7 @@
         size = $bindable(null),
     } = $props();
 
-    const nodeTypes = { class: ClassNode };
+    const nodeTypes = { class: ClassNode, label: DiagramLabelNode };
     const edgeTypes = {
         association: AssociationEdge,
         inheritance: InheritanceEdge,
@@ -66,15 +68,24 @@
             nodes = [...layouted];
         }
 
+        nodes = [...nodes, ...buildLabelNodes(nodes, edges)];
+
         const padding = 60;
+        // A label can sit well outside its class, so it has to count towards the bounds. It has
+        // not been measured yet at this point, but it is positioned by its centre and the padding
+        // covers the half of it that sticks out.
+        const nodeWidth = n =>
+            n.type === LABEL_NODE_TYPE
+                ? 0
+                : (n.measured?.width ?? n.width ?? 200);
+        const nodeHeight = n =>
+            n.type === LABEL_NODE_TYPE
+                ? 0
+                : (n.measured?.height ?? n.height ?? 100);
         const xs = nodes.map(n => n.position.x);
         const ys = nodes.map(n => n.position.y);
-        const rights = nodes.map(
-            n => n.position.x + (n.measured?.width ?? n.width ?? 200),
-        );
-        const bottoms = nodes.map(
-            n => n.position.y + (n.measured?.height ?? n.height ?? 100),
-        );
+        const rights = nodes.map(n => n.position.x + nodeWidth(n));
+        const bottoms = nodes.map(n => n.position.y + nodeHeight(n));
         const minX = Math.min(...xs);
         const minY = Math.min(...ys);
         const width = Math.max(...rights) - minX + padding * 2;

--- a/frontend/src/lib/rendering/svelteflow/components/AssociationEdge.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/AssociationEdge.svelte
@@ -16,28 +16,46 @@
   -->
 
 <script>
-    import {
-        BaseEdge,
-        EdgeLabel,
-        getStraightPath,
-        useInternalNode,
-    } from "@xyflow/svelte";
+    import { BaseEdge, getStraightPath, useInternalNode } from "@xyflow/svelte";
 
     import { renderOptions } from "$lib/renderOptions.svelte.js";
 
     import { getEdgeParams } from "./edgeUtils.ts";
+    import { labelHighlight } from "../interaction/labelHighlight.svelte.js";
 
     let { id, source, target, data } = $props();
+
+    /**
+     * The highlight rises quickly and decays slowly, which is what makes a short press read as a
+     * pulse rather than as a state the edge sits in. The transition of the state being entered is
+     * the one that runs, so these are not interchangeable.
+     */
+    const HIGHLIGHT_IN_TRANSITION =
+        "transition: stroke 120ms ease-out, stroke-width 120ms ease-out;";
+    const HIGHLIGHT_OUT_TRANSITION =
+        "transition: stroke 450ms ease-out, stroke-width 450ms ease-out;";
+
+    /** The widths an edge swells between while one of its labels is pressed. */
+    const BASE_STROKE_WIDTH = "2px";
+    const HIGHLIGHT_STROKE_WIDTH = "3.2px";
+
     let markerEnd = data.useToAssociation ? "url(#associationTo)" : "";
     let markerStart = data.useFromAssociation ? "url(#associationFrom)" : "";
     let sourceNode = useInternalNode(source);
     let targetNode = useInternalNode(target);
 
-    let style = $derived(
-        renderOptions.get("useColoredPropertiesInMergedView") && data.color
-            ? `stroke-width: 2px; stroke: ${data.color};`
-            : "stroke-width: 2px; stroke: #000;",
-    );
+    let held = $derived(labelHighlight.isHeld(data.labels));
+
+    let style = $derived.by(() => {
+        const stroke =
+            renderOptions.get("useColoredPropertiesInMergedView") && data.color
+                ? data.color
+                : "#000";
+        return held
+            ? `${HIGHLIGHT_IN_TRANSITION} stroke-width: ${HIGHLIGHT_STROKE_WIDTH};` +
+                  " stroke: var(--color-class-node-highlighted);"
+            : `${HIGHLIGHT_OUT_TRANSITION} stroke-width: ${BASE_STROKE_WIDTH}; stroke: ${stroke};`;
+    });
 
     let edgeParams = $derived.by(() => {
         if (sourceNode.current && targetNode.current) {
@@ -75,49 +93,3 @@
 </script>
 
 <BaseEdge {id} {path} {markerStart} {markerEnd} {style} />
-<EdgeLabel>
-    {#if data.toMultiplicity}
-        {#if target === source && sourceNode.current}
-            {@const pos = sourceNode.current.internals.positionAbsolute ?? {
-                x: 0,
-                y: 0,
-            }}
-            {@const w = sourceNode.current.measured.width ?? 100}
-            <div
-                style:transform={`translate(-50%, -50%) translate(${pos.x + w * 0.25 - 12}px, ${pos.y - 30}px)`}
-                class="nodrag nopan pointer-events-auto absolute z-50 cursor-pointer rounded bg-white/80 px-2 py-0.5 text-xs font-medium text-[#303030] shadow-sm"
-            >
-                {data.toMultiplicity}
-            </div>
-        {:else}
-            <div
-                style:transform={`translate(-50%, -50%) translate(${edgeParams.sx + edgeParams.startX}px, ${edgeParams.sy + edgeParams.startY}px)`}
-                class="nodrag nopan pointer-events-auto absolute z-50 cursor-pointer rounded bg-white/80 px-2 py-0.5 text-xs font-medium text-[#303030] shadow-sm"
-            >
-                {data.toMultiplicity}
-            </div>
-        {/if}
-    {/if}
-    {#if data.fromMultiplicity}
-        {#if target === source && targetNode.current}
-            {@const pos = targetNode.current.internals.positionAbsolute ?? {
-                x: 0,
-                y: 0,
-            }}
-            {@const w = targetNode.current.measured.width ?? 100}
-            <div
-                style:transform={`translate(-50%, -50%) translate(${pos.x + w * 0.75 + 12}px, ${pos.y - 30}px)`}
-                class="nodrag nopan pointer-events-auto absolute z-50 cursor-pointer rounded bg-white/80 px-2 py-0.5 text-xs font-medium text-[#303030] shadow-sm"
-            >
-                {data.fromMultiplicity}
-            </div>
-        {:else}
-            <div
-                style:transform={`translate(-50%, -50%) translate(${edgeParams.tx + edgeParams.endX}px, ${edgeParams.ty + edgeParams.endY}px)`}
-                class="nodrag nopan pointer-events-auto absolute z-50 cursor-pointer rounded bg-white/80 px-2 py-0.5 text-xs font-medium text-[#303030] shadow-sm"
-            >
-                {data.fromMultiplicity}
-            </div>
-        {/if}
-    {/if}
-</EdgeLabel>

--- a/frontend/src/lib/rendering/svelteflow/components/DiagramLabelNode.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/DiagramLabelNode.svelte
@@ -1,0 +1,43 @@
+<!--
+  -    Copyright (c) 2024-2026 SOPTIM AG
+  -
+  -    Licensed under the Apache License, Version 2.0 (the "License");
+  -    you may not use this file except in compliance with the License.
+  -    You may obtain a copy of the License at
+  -
+  -        http://www.apache.org/licenses/LICENSE-2.0
+  -
+  -    Unless required by applicable law or agreed to in writing, software
+  -    distributed under the License is distributed on an "AS IS" BASIS,
+  -    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -    See the License for the specific language governing permissions and
+  -    limitations under the License.
+  -
+  -->
+
+<script>
+    import { labelHighlight } from "../interaction/labelHighlight.svelte.js";
+
+    let { id, data, draggable } = $props();
+
+    /**
+     * Lights the association up while the label is pressed. The release is taken from the window
+     * because the pointer is let go wherever it happens to be, which after a drag is rarely over
+     * the label itself.
+     */
+    function handlePointerDown() {
+        labelHighlight.press(id);
+        window.addEventListener("pointerup", () => labelHighlight.release(), {
+            once: true,
+        });
+    }
+</script>
+
+<div
+    class="rounded bg-white/80 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-[#303030] shadow-sm select-none"
+    class:cursor-move={draggable}
+    onpointerdown={handlePointerDown}
+    role="presentation"
+>
+    {data.text}
+</div>

--- a/frontend/src/lib/rendering/svelteflow/components/DiagramLabelNode.svelte
+++ b/frontend/src/lib/rendering/svelteflow/components/DiagramLabelNode.svelte
@@ -27,9 +27,13 @@
      */
     function handlePointerDown() {
         labelHighlight.press(id);
-        window.addEventListener("pointerup", () => labelHighlight.release(), {
-            once: true,
-        });
+        const release = () => {
+            labelHighlight.release();
+            window.removeEventListener("pointerup", release);
+            window.removeEventListener("pointercancel", release);
+        };
+        window.addEventListener("pointerup", release);
+        window.addEventListener("pointercancel", release);
     }
 </script>
 

--- a/frontend/src/lib/rendering/svelteflow/components/edgeUtils.ts
+++ b/frontend/src/lib/rendering/svelteflow/components/edgeUtils.ts
@@ -15,7 +15,17 @@
  *
  */
 
-import { type InternalNode } from "@xyflow/svelte";
+import { type InternalNode, type Node } from "@xyflow/svelte";
+
+/**
+ * Edge endpoints are read from the rendered internal nodes inside an edge component and from the
+ * plain nodes when label nodes are laid out, which position themselves relative to an endpoint.
+ */
+type EdgeEndpointNode = Node & Partial<Pick<InternalNode, "internals">>;
+
+function nodePosition(node: EdgeEndpointNode) {
+    return node.internals?.positionAbsolute ?? node.position ?? { x: 0, y: 0 };
+}
 
 /**
  * Calculates the intersection point between a line (from the target to the node center)
@@ -24,15 +34,12 @@ import { type InternalNode } from "@xyflow/svelte";
  * See: https://svelteflow.dev/examples/nodes/easy-connect
  */
 function getNodeIntersection(
-    intersectionNode: InternalNode,
-    targetNode: InternalNode,
+    intersectionNode: EdgeEndpointNode,
+    targetNode: EdgeEndpointNode,
     offsetY: number = 0,
 ) {
-    const intersectionPos = intersectionNode.internals.positionAbsolute || {
-        x: 0,
-        y: 0,
-    };
-    const targetPos = targetNode.internals.positionAbsolute || { x: 0, y: 0 };
+    const intersectionPos = nodePosition(intersectionNode);
+    const targetPos = nodePosition(targetNode);
 
     const w = (intersectionNode.measured.width ?? 0) / 2;
     const h = (intersectionNode.measured.height ?? 0) / 2;
@@ -96,8 +103,8 @@ function getLabelOffsets(sx: number, sy: number, tx: number, ty: number) {
  * Contains the start/end points of the edge as well as the calculated label positions.
  */
 export function getEdgeParams(
-    source: InternalNode,
-    target: InternalNode,
+    source: EdgeEndpointNode,
+    target: EdgeEndpointNode,
     offsetY: number = 0,
 ) {
     const sourceIntersection = getNodeIntersection(source, target);

--- a/frontend/src/lib/rendering/svelteflow/diagram/diagramElements.js
+++ b/frontend/src/lib/rendering/svelteflow/diagram/diagramElements.js
@@ -15,16 +15,19 @@
  *
  */
 
+import { LABEL_NODE_TYPE } from "./labelNodes.js";
+
 export const EDGE_Z_INDEX = -1;
 
 const offsetEdgeIdCache = new WeakMap();
 
 export function hasDefaultNodeLayout(diagramNodes) {
+    const classNodes = diagramNodes.filter(
+        node => node.type !== LABEL_NODE_TYPE,
+    );
     return (
-        diagramNodes.length > 0 &&
-        diagramNodes.every(
-            node => node.position.x === 0 && node.position.y === 0,
-        )
+        classNodes.length > 0 &&
+        classNodes.every(node => node.position.x === 0 && node.position.y === 0)
     );
 }
 

--- a/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
+++ b/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
@@ -61,8 +61,15 @@ function anchorClassId(edge, label) {
  * @param edges the current edges, carrying the labels of both of their ends
  * @param offsetOverrides offsets of labels moved in this session, keyed by label node id; an entry
  *     holding null resets that label to its default placement
+ * @param placementCache memoizes the edge-intersection geometry per class pair, keyed by node id,
+ *     so dragging one class does not recompute the placement of every other edge in the diagram
  */
-export function buildLabelNodes(nodes, edges, offsetOverrides = new Map()) {
+export function buildLabelNodes(
+    nodes,
+    edges,
+    offsetOverrides = new Map(),
+    placementCache = new Map(),
+) {
     const classNodes = new Map();
     const labelSizes = new Map();
     for (const node of nodes) {
@@ -81,7 +88,7 @@ export function buildLabelNodes(nodes, edges, offsetOverrides = new Map()) {
             continue;
         }
 
-        const placements = edgePlacements(source, target);
+        const placements = cachedEdgePlacements(source, target, placementCache);
         for (const label of edge.data?.labels ?? []) {
             const atSource = label.anchor === SOURCE_ANCHOR;
             labelNodes.push(
@@ -138,7 +145,7 @@ function buildLabelNode(
         selectable: false,
         // Carried over because SvelteFlow takes a node's dimensions from the node object it is
         // given: rebuilding without them hides the label until it has been measured again.
-        measured: labelSizes.get(labelNodeId(label)),
+        measured: labelSizes.get(id),
         data: {
             text: label.text,
             identifiedObjectUUID: label.identifiedObjectUUID,
@@ -165,6 +172,40 @@ export function clampToAnchor(position, anchorPoint) {
         x: anchorPoint.x + dx * scale,
         y: anchorPoint.y + dy * scale,
     };
+}
+
+/**
+ * Reuses the previous placement of a class pair when neither class has moved or resized, so
+ * dragging one class does not recompute the edge-intersection geometry of every other edge.
+ */
+function cachedEdgePlacements(source, target, cache) {
+    const key = `${source.id}|${target.id}`;
+    const cached = cache.get(key);
+    if (cached && samePlacementInputs(cached, source, target)) {
+        return cached.placements;
+    }
+    const placements = edgePlacements(source, target);
+    cache.set(key, {
+        placements,
+        sourcePosition: source.position,
+        sourceMeasured: source.measured,
+        targetPosition: target.position,
+        targetMeasured: target.measured,
+    });
+    return placements;
+}
+
+function samePlacementInputs(cached, source, target) {
+    return (
+        cached.sourcePosition.x === source.position.x &&
+        cached.sourcePosition.y === source.position.y &&
+        cached.targetPosition.x === target.position.x &&
+        cached.targetPosition.y === target.position.y &&
+        cached.sourceMeasured.width === source.measured.width &&
+        cached.sourceMeasured.height === source.measured.height &&
+        cached.targetMeasured.width === target.measured.width &&
+        cached.targetMeasured.height === target.measured.height
+    );
 }
 
 /**

--- a/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
+++ b/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
@@ -1,0 +1,217 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { getEdgeParams } from "../components/edgeUtils.ts";
+
+export const LABEL_NODE_TYPE = "label";
+
+/**
+ * Labels are rendered above every class, including a selected one, so that a label stays readable
+ * where it overlaps a class. See NodeOrderController for the z indices classes are given.
+ */
+const LABEL_Z_INDEX = 2_000_000;
+
+/** Radius of the invisible circle a label may be dragged within, around its anchor point. */
+const LABEL_MAX_DISTANCE = 120;
+
+const SELF_LOOP_LABEL_OFFSET = { x: 12, y: -30 };
+
+const SOURCE_ANCHOR = "SOURCE";
+
+export function labelNodeId(label) {
+    return `${label.identifiedObjectUUID}:${label.kind}`;
+}
+
+/** All labels of a diagram together with the class each of them is anchored to. */
+export function collectLabels(edges) {
+    const labels = [];
+    for (const edge of edges) {
+        for (const label of edge.data?.labels ?? []) {
+            labels.push({ label, anchorClassId: anchorClassId(edge, label) });
+        }
+    }
+    return labels;
+}
+
+function anchorClassId(edge, label) {
+    return label.anchor === SOURCE_ANCHOR ? edge.source : edge.target;
+}
+
+/**
+ * Builds the nodes for all movable labels. A label that has been placed manually sits at its
+ * stored offset relative to its class, so it follows the class but neither the edge routing nor
+ * the anchor point wandering along the class border. Labels without a stored offset fall back to
+ * their default placement next to the anchor point.
+ *
+ * @param nodes the current nodes, used for the class positions and the measured label sizes
+ * @param edges the current edges, carrying the labels of both of their ends
+ * @param offsetOverrides offsets of labels moved in this session, keyed by label node id; an entry
+ *     holding null resets that label to its default placement
+ */
+export function buildLabelNodes(nodes, edges, offsetOverrides = new Map()) {
+    const classNodes = new Map();
+    const labelSizes = new Map();
+    for (const node of nodes) {
+        if (node.type === LABEL_NODE_TYPE) {
+            labelSizes.set(node.id, node.measured);
+        } else {
+            classNodes.set(node.id, node);
+        }
+    }
+
+    const labelNodes = [];
+    for (const edge of edges) {
+        const source = classNodes.get(edge.source);
+        const target = classNodes.get(edge.target);
+        if (!source?.measured || !target?.measured) {
+            continue;
+        }
+
+        const placements = edgePlacements(source, target);
+        for (const label of edge.data?.labels ?? []) {
+            const atSource = label.anchor === SOURCE_ANCHOR;
+            labelNodes.push(
+                buildLabelNode(
+                    label,
+                    atSource ? source : target,
+                    atSource ? placements.source : placements.target,
+                    offsetOverrides,
+                    labelSizes,
+                ),
+            );
+        }
+    }
+    return labelNodes;
+}
+
+/** The offset a label at the given position has relative to the class it is anchored to. */
+export function offsetFromClass(labelNode, anchorClass) {
+    return {
+        x: labelNode.position.x - anchorClass.position.x,
+        y: labelNode.position.y - anchorClass.position.y,
+    };
+}
+
+export function effectiveOffset(label, offsetOverrides) {
+    const id = labelNodeId(label);
+    return offsetOverrides.has(id) ? offsetOverrides.get(id) : label.offset;
+}
+
+function buildLabelNode(
+    label,
+    anchorClass,
+    placement,
+    offsetOverrides,
+    labelSizes,
+) {
+    const id = labelNodeId(label);
+    const offset = effectiveOffset(label, offsetOverrides);
+    const position = offset
+        ? {
+              x: anchorClass.position.x + offset.x,
+              y: anchorClass.position.y + offset.y,
+          }
+        : placement.defaultCenter;
+
+    return {
+        id,
+        type: LABEL_NODE_TYPE,
+        position,
+        // A label is positioned by its centre, which is what both the default placement and the
+        // stored offset describe.
+        origin: [0.5, 0.5],
+        zIndex: LABEL_Z_INDEX,
+        selectable: false,
+        // Carried over because SvelteFlow takes a node's dimensions from the node object it is
+        // given: rebuilding without them hides the label until it has been measured again.
+        measured: labelSizes.get(labelNodeId(label)),
+        data: {
+            text: label.text,
+            identifiedObjectUUID: label.identifiedObjectUUID,
+            kind: label.kind,
+            anchorClassId: anchorClass.id,
+            anchorPoint: placement.anchor,
+        },
+    };
+}
+
+/**
+ * Holds a label within its maximum distance from the anchor point. SvelteFlow can only constrain a
+ * node to a rectangle, so a dragged label is clamped here instead of through its extent.
+ */
+export function clampToAnchor(position, anchorPoint) {
+    const dx = position.x - anchorPoint.x;
+    const dy = position.y - anchorPoint.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance <= LABEL_MAX_DISTANCE) {
+        return position;
+    }
+    const scale = LABEL_MAX_DISTANCE / distance;
+    return {
+        x: anchorPoint.x + dx * scale,
+        y: anchorPoint.y + dy * scale,
+    };
+}
+
+/**
+ * Anchor points and default label placements of both edge ends. The anchor point is where the
+ * edge meets the class; the default placement is the one the labels had before they became
+ * movable.
+ */
+function edgePlacements(source, target) {
+    if (source.id === target.id) {
+        const position = source.position;
+        const width = source.measured.width ?? 100;
+        return {
+            source: placement(
+                position.x + width * 0.25,
+                position.y,
+                -SELF_LOOP_LABEL_OFFSET.x,
+                SELF_LOOP_LABEL_OFFSET.y,
+            ),
+            target: placement(
+                position.x + width * 0.75,
+                position.y,
+                SELF_LOOP_LABEL_OFFSET.x,
+                SELF_LOOP_LABEL_OFFSET.y,
+            ),
+        };
+    }
+
+    const edgeParams = getEdgeParams(source, target);
+    return {
+        source: placement(
+            edgeParams.sx,
+            edgeParams.sy,
+            edgeParams.startX,
+            edgeParams.startY,
+        ),
+        target: placement(
+            edgeParams.tx,
+            edgeParams.ty,
+            edgeParams.endX,
+            edgeParams.endY,
+        ),
+    };
+}
+
+function placement(anchorX, anchorY, offsetX, offsetY) {
+    return {
+        anchor: { x: anchorX, y: anchorY },
+        defaultCenter: { x: anchorX + offsetX, y: anchorY + offsetY },
+    };
+}

--- a/frontend/src/lib/rendering/svelteflow/interaction/labelHighlight.svelte.js
+++ b/frontend/src/lib/rendering/svelteflow/interaction/labelHighlight.svelte.js
@@ -1,0 +1,87 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { labelNodeId } from "../diagram/labelNodes.js";
+
+/**
+ * The label a user is pressing, so its association can light up to show which one the label
+ * belongs to. Module state rather than something the diagram owns, because the edge components are
+ * rendered by SvelteFlow and receive no props from it.
+ *
+ * A press lights the association and a release lets it go, which covers a click and a drag alike:
+ * both start on pointer down and end on pointer up.
+ */
+export const labelHighlight = createLabelHighlight();
+
+/**
+ * How long a press stays lit at the least. A click is over within a few milliseconds, so without a
+ * floor the association would only blink. Kept short on purpose: the edge rises into the highlight
+ * and decays out of it on its own, and this is only the plateau in between, which reads as the
+ * edge being stuck once it grows.
+ */
+const MIN_HIGHLIGHT_DURATION = 350;
+
+function createLabelHighlight() {
+    let heldLabelId = $state(null);
+    let pressedAt = 0;
+    let releaseTimeout = null;
+
+    function matches(labelId, labels) {
+        return (
+            !!labelId &&
+            (labels ?? []).some(label => labelNodeId(label) === labelId)
+        );
+    }
+
+    function clear() {
+        if (releaseTimeout !== null) {
+            clearTimeout(releaseTimeout);
+            releaseTimeout = null;
+        }
+        heldLabelId = null;
+    }
+
+    return {
+        /** Lights the association of a label up, for as long as the label is pressed. */
+        press(labelId) {
+            clear();
+            heldLabelId = labelId;
+            pressedAt = Date.now();
+        },
+        /** Ends a press, keeping the light on for the rest of the minimum duration. */
+        release() {
+            if (heldLabelId === null || releaseTimeout !== null) {
+                return;
+            }
+            const remaining = MIN_HIGHLIGHT_DURATION - (Date.now() - pressedAt);
+            if (remaining <= 0) {
+                clear();
+                return;
+            }
+            releaseTimeout = setTimeout(() => {
+                releaseTimeout = null;
+                heldLabelId = null;
+            }, remaining);
+        },
+        /** Drops the highlight at once, without honouring the minimum duration. */
+        clear,
+        /** Whether one of the given labels is lit. */
+        isHeld(labels) {
+            return matches(heldLabelId, labels);
+        },
+    };
+}

--- a/frontend/src/lib/rendering/svelteflow/interaction/nodeOrder.svelte.js
+++ b/frontend/src/lib/rendering/svelteflow/interaction/nodeOrder.svelte.js
@@ -21,6 +21,8 @@ import {
 } from "$lib/api/generated/index.ts";
 import { editorState } from "$lib/sharedState.svelte.js";
 
+import { LABEL_NODE_TYPE } from "../diagram/labelNodes.js";
+
 const NODE_SELECTED_Z_OFFSET = 1_000_000;
 
 export class NodeOrderController {
@@ -74,6 +76,9 @@ export class NodeOrderController {
         const tempFrontRank = this.#nodeOrder.length + 1;
         const selectedIds = this.#getSelectedIds?.() ?? new Set();
         return diagramNodes.map(node => {
+            if (node.type === LABEL_NODE_TYPE) {
+                return node;
+            }
             const rank =
                 node.id === this.#temporaryFrontNodeId
                     ? tempFrontRank

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -29,6 +29,8 @@
     import {
         updateClassPositions,
         updateDatasetClassPositions,
+        updateDatasetLabelPositions,
+        updateLabelPositions,
     } from "$lib/api/generated/index.ts";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
     import {
@@ -40,6 +42,7 @@
 
     import AssociationEdge from "./components/AssociationEdge.svelte";
     import ClassNode from "./components/ClassNode.svelte";
+    import DiagramLabelNode from "./components/DiagramLabelNode.svelte";
     import EdgeMarkers from "./components/EdgeMarkers.svelte";
     import InheritanceEdge from "./components/InheritanceEdge.svelte";
     import SvelteFlowClassContextMenu from "./components/SvelteFlowClassContextMenu.svelte";
@@ -48,8 +51,18 @@
         decorateEdges,
         hasDefaultNodeLayout,
     } from "./diagram/diagramElements.js";
+    import {
+        buildLabelNodes,
+        clampToAnchor,
+        collectLabels,
+        effectiveOffset,
+        LABEL_NODE_TYPE,
+        labelNodeId,
+        offsetFromClass,
+    } from "./diagram/labelNodes.js";
     import { ContextMenuController } from "./interaction/contextMenus.svelte.js";
     import { DiagramSelectionController } from "./interaction/diagramSelection.svelte.js";
+    import { labelHighlight } from "./interaction/labelHighlight.svelte.js";
     import { NodeOrderController } from "./interaction/nodeOrder.svelte.js";
     import { PanController } from "./interaction/panController.svelte.js";
     import { getLayoutedNodes } from "./layout/elkLayout.js";
@@ -63,6 +76,7 @@
 
     const nodeTypes = {
         class: ClassNode,
+        label: DiagramLabelNode,
     };
     const edgeTypes = {
         association: AssociationEdge,
@@ -109,6 +123,13 @@
 
     let selectionZFrame = null;
     let boxSelecting = false;
+    // Offsets of labels moved in this session, so a drag takes effect without refetching the
+    // diagram. An entry holding null resets that label to its default placement.
+    let labelOffsets = new Map();
+    let labelDragActive = false;
+    let classNodes = $derived(
+        nodes.filter(node => node.type !== LABEL_NODE_TYPE),
+    );
     let hasDefaultLayout = $derived(hasDefaultNodeLayout(nodes));
     let applyLayout = $derived(
         nodesInit.current && !layouted && hasDefaultLayout,
@@ -124,6 +145,10 @@
     $effect(() => {
         forceReloadTrigger.subscribe();
         applyAutoLayoutIfNeeded();
+    });
+
+    $effect(() => {
+        syncLabelNodes(nodes, edges);
     });
 
     $effect(() => {
@@ -222,6 +247,7 @@
             return;
         }
         lastSelectedDiagramId = diagramId;
+        labelHighlight.clear();
         pan.clearBoxMode();
         multiSelectState.clear();
     }
@@ -262,6 +288,7 @@
     }
 
     function syncDiagramElements() {
+        labelOffsets = new Map();
         const nextNodes = [...inputNodes];
         const nextHasDefaultLayout = hasDefaultNodeLayout(nextNodes);
 
@@ -318,8 +345,164 @@
         });
     }
 
+    /**
+     * Rebuilds the label nodes whenever the classes they are anchored to move. Skipped while a
+     * label itself is being dragged, which would otherwise pull it back to its stored offset.
+     */
+    function syncLabelNodes(currentNodes, currentEdges) {
+        if (labelDragActive) {
+            return;
+        }
+        const nextLabelNodes = buildLabelNodes(
+            currentNodes,
+            currentEdges,
+            labelOffsets,
+        );
+        if (!labelNodesChanged(currentNodes, nextLabelNodes)) {
+            return;
+        }
+        nodes = [
+            ...currentNodes.filter(node => node.type !== LABEL_NODE_TYPE),
+            ...nextLabelNodes,
+        ];
+    }
+
+    function labelNodesChanged(currentNodes, nextLabelNodes) {
+        const current = currentNodes.filter(
+            node => node.type === LABEL_NODE_TYPE,
+        );
+        if (current.length !== nextLabelNodes.length) {
+            return true;
+        }
+        const currentById = new Map(current.map(node => [node.id, node]));
+        return nextLabelNodes.some(next => {
+            const node = currentById.get(next.id);
+            return (
+                !node ||
+                node.data.text !== next.data.text ||
+                node.position.x !== next.position.x ||
+                node.position.y !== next.position.y ||
+                node.data.anchorPoint.x !== next.data.anchorPoint.x ||
+                node.data.anchorPoint.y !== next.data.anchorPoint.y
+            );
+        });
+    }
+
+    /**
+     * Holds a dragged label within its maximum distance from the anchor point. SvelteFlow can only
+     * constrain a node to a rectangle, so the radial limit is applied per drag event instead.
+     *
+     * This relies on the drag event firing after SvelteFlow has written its own position, so that
+     * the clamped one is what the frame ends on. The drag itself keeps following the pointer
+     * unclamped, which is what lets the label pick it up again on the way back in.
+     */
+    function clampDraggedLabels(draggedNodes) {
+        const clampedById = new Map();
+        for (const dragged of draggedNodes) {
+            if (dragged.type !== LABEL_NODE_TYPE) {
+                continue;
+            }
+            const clamped = clampToAnchor(
+                dragged.position,
+                dragged.data.anchorPoint,
+            );
+            if (clamped !== dragged.position) {
+                clampedById.set(dragged.id, clamped);
+            }
+        }
+        if (clampedById.size === 0) {
+            return;
+        }
+        nodes = nodes.map(node =>
+            clampedById.has(node.id)
+                ? { ...node, position: clampedById.get(node.id) }
+                : node,
+        );
+    }
+
+    function handleLabelMove(movedLabelNodes) {
+        const classNodes = new Map(nodes.map(node => [node.id, node]));
+        const movedLabels = [];
+        for (const labelNode of movedLabelNodes) {
+            const anchorClass = classNodes.get(labelNode.data.anchorClassId);
+            if (!anchorClass) {
+                continue;
+            }
+            const offset = offsetFromClass(
+                {
+                    position: clampToAnchor(
+                        labelNode.position,
+                        labelNode.data.anchorPoint,
+                    ),
+                },
+                anchorClass,
+            );
+            labelOffsets.set(labelNode.id, offset);
+            movedLabels.push({
+                identifiedObjectUUID: labelNode.data.identifiedObjectUUID,
+                kind: labelNode.data.kind,
+                xOffset: offset.x,
+                yOffset: offset.y,
+            });
+        }
+        persistLabelPositions(movedLabels);
+    }
+
+    /** Drops the manual placement of every label, so they return to their default placement. */
+    function resetLabelPositions() {
+        const resetLabels = [];
+        for (const { label } of collectLabels(edges)) {
+            if (!effectiveOffset(label, labelOffsets)) {
+                continue;
+            }
+            labelOffsets.set(labelNodeId(label), null);
+            resetLabels.push({
+                identifiedObjectUUID: label.identifiedObjectUUID,
+                kind: label.kind,
+                xOffset: null,
+                yOffset: null,
+            });
+        }
+        persistLabelPositions(resetLabels);
+    }
+
+    function persistLabelPositions(labelPositionDTOList) {
+        const diagramUUID = editorState.selectedDiagram.getProperty("id");
+        if (!diagramUUID || labelPositionDTOList.length === 0) {
+            return;
+        }
+
+        if (editorState.selectedGraph.getValue()) {
+            updateLabelPositions({
+                path: {
+                    datasetName: editorState.selectedWorkspace.getValue(),
+                    graphURI: editorState.selectedGraph.getValue(),
+                    diagramUUID: diagramUUID,
+                },
+                body: labelPositionDTOList,
+            });
+        } else {
+            updateDatasetLabelPositions({
+                path: {
+                    datasetName: editorState.selectedWorkspace.getValue(),
+                    diagramUUID: diagramUUID,
+                },
+                body: labelPositionDTOList,
+            });
+        }
+    }
+
     function handleNodeMove(nodeMoveEvent) {
-        updateNodePositions(nodeMoveEvent.nodes);
+        const movedNodes = nodeMoveEvent.nodes ?? [];
+        const movedLabels = movedNodes.filter(
+            node => node.type === LABEL_NODE_TYPE,
+        );
+        if (movedLabels.length > 0) {
+            handleLabelMove(movedLabels);
+        }
+        updateNodePositions(
+            movedNodes.filter(node => node.type !== LABEL_NODE_TYPE),
+        );
     }
 
     function updateNodePositions(movedNodes) {
@@ -335,7 +518,7 @@
         }
 
         const diagramUUID = editorState.selectedDiagram.getProperty("id");
-        if (!diagramUUID) return;
+        if (!diagramUUID || classPositionDTOList.length === 0) return;
 
         if (editorState.selectedGraph.getValue()) {
             updateClassPositions({
@@ -360,9 +543,12 @@
     export async function applyELKLayout() {
         if (!isLoading) isLoading = true;
         layouted = true;
-        const layoutedNodes = await getLayoutedNodes(nodes, edges);
+        const classNodes = nodes.filter(node => node.type !== LABEL_NODE_TYPE);
+        const layoutedNodes = await getLayoutedNodes(classNodes, edges);
         nodes = [...layoutedNodes];
         updateNodePositions(nodes);
+        resetLabelPositions();
+        syncLabelNodes(nodes, edges);
         await svelteFlowAPI.svelteFlow.fitView();
         isLoading = false;
     }
@@ -388,9 +574,20 @@
         elementsSelectable={true}
         nodesFocusable={false}
         zIndexMode={"manual"}
-        onnodeclick={e => selection.handleNodeClick(e)}
-        onnodecontextmenu={e => contextMenus.handleNodeContextMenu(e)}
-        onpaneclick={() => contextMenus.close()}
+        onnodeclick={e => {
+            if (e.node?.type === LABEL_NODE_TYPE) {
+                return;
+            }
+            selection.handleNodeClick(e);
+        }}
+        onnodecontextmenu={e => {
+            if (e.node?.type !== LABEL_NODE_TYPE) {
+                contextMenus.handleNodeContextMenu(e);
+            }
+        }}
+        onpaneclick={() => {
+            contextMenus.close();
+        }}
         onpanecontextmenu={e => contextMenus.handlePaneContextMenu(e)}
         onedgecontextmenu={e => contextMenus.handleEdgeContextMenu(e)}
         onselectionchange={e => selection.handleSelectionChange(e)}
@@ -402,11 +599,29 @@
             selection.handleSelectionEnd();
             applySelectionZIndices();
         }}
-        onnodedragstart={({ node }) => {
+        onnodedragstart={e => {
+            // Dragging a label makes SvelteFlow clear the selection, because label nodes are not
+            // selectable. Announcing the drag keeps the class selection from following along.
             selection.notifyNodeDragStart();
-            nodeOrderCtrl.bringToFrontTemporarily(node?.id);
+            if (e.targetNode?.type === LABEL_NODE_TYPE) {
+                labelDragActive = true;
+                return;
+            }
+            nodeOrderCtrl.bringToFrontTemporarily(e.targetNode?.id);
+        }}
+        onnodedrag={e => {
+            if (labelDragActive) {
+                clampDraggedLabels(e.nodes ?? []);
+            }
         }}
         onnodedragstop={e => {
+            if (labelDragActive) {
+                labelDragActive = false;
+                selection.notifyNodeDragStop();
+                handleNodeMove(e);
+                syncLabelNodes(nodes, edges);
+                return;
+            }
             selection.notifyNodeDragStop();
             handleNodeMove(e);
         }}
@@ -430,7 +645,7 @@
         lockedWorkspaceName={editorState.selectedWorkspace.getValue()}
         lockedGraphUri={editorState.selectedGraph.getValue()}
         lockedPackage={editorState.selectedDiagram.getProperty("id")}
-        classes={nodes.map(node => ({
+        classes={classNodes.map(node => ({
             id: node.id,
             graphUri: node.data?.graphUri,
         }))}
@@ -444,7 +659,7 @@
         workspaceName={editorState.selectedWorkspace.getValue()}
         graphUri={editorState.selectedGraph.getValue()}
         nodeOrder={nodeOrderCtrl.nodeOrder}
-        nodeCount={nodes.length}
+        nodeCount={classNodes.length}
         onClose={() => contextMenus.close()}
         onMoveClass={e => nodeOrderCtrl.moveClass(e)}
         onSetLayer={e => nodeOrderCtrl.setLayer(e)}

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -25,6 +25,7 @@
         useSvelteFlow,
     } from "@xyflow/svelte";
     import { onDestroy, onMount, tick, untrack } from "svelte";
+    import { SvelteMap } from "svelte/reactivity";
 
     import {
         updateClassPositions,
@@ -124,8 +125,12 @@
     let selectionZFrame = null;
     let boxSelecting = false;
     // Offsets of labels moved in this session, so a drag takes effect without refetching the
-    // diagram. An entry holding null resets that label to its default placement.
-    let labelOffsets = new Map();
+    // diagram. An entry holding null resets that label to its default placement. A SvelteMap so
+    // mutating it alone is enough to re-trigger syncLabelNodes below.
+    let labelOffsets = new SvelteMap();
+    // Memoizes edge-intersection geometry per class pair, so dragging one class does not
+    // recompute the placement of every other edge in the diagram.
+    let labelPlacementCache = new Map();
     let labelDragActive = false;
     let classNodes = $derived(
         nodes.filter(node => node.type !== LABEL_NODE_TYPE),
@@ -288,7 +293,8 @@
     }
 
     function syncDiagramElements() {
-        labelOffsets = new Map();
+        labelOffsets = new SvelteMap();
+        labelPlacementCache = new Map();
         const nextNodes = [...inputNodes];
         const nextHasDefaultLayout = hasDefaultNodeLayout(nextNodes);
 
@@ -357,6 +363,7 @@
             currentNodes,
             currentEdges,
             labelOffsets,
+            labelPlacementCache,
         );
         if (!labelNodesChanged(currentNodes, nextLabelNodes)) {
             return;
@@ -420,11 +427,20 @@
         );
     }
 
+    function toLabelPositionDTO(identifiedObjectUUID, kind, offset) {
+        return {
+            identifiedObjectUUID,
+            kind,
+            xOffset: offset?.x ?? null,
+            yOffset: offset?.y ?? null,
+        };
+    }
+
     function handleLabelMove(movedLabelNodes) {
-        const classNodes = new Map(nodes.map(node => [node.id, node]));
+        const nodesById = new Map(nodes.map(node => [node.id, node]));
         const movedLabels = [];
         for (const labelNode of movedLabelNodes) {
-            const anchorClass = classNodes.get(labelNode.data.anchorClassId);
+            const anchorClass = nodesById.get(labelNode.data.anchorClassId);
             if (!anchorClass) {
                 continue;
             }
@@ -438,12 +454,13 @@
                 anchorClass,
             );
             labelOffsets.set(labelNode.id, offset);
-            movedLabels.push({
-                identifiedObjectUUID: labelNode.data.identifiedObjectUUID,
-                kind: labelNode.data.kind,
-                xOffset: offset.x,
-                yOffset: offset.y,
-            });
+            movedLabels.push(
+                toLabelPositionDTO(
+                    labelNode.data.identifiedObjectUUID,
+                    labelNode.data.kind,
+                    offset,
+                ),
+            );
         }
         persistLabelPositions(movedLabels);
     }
@@ -456,12 +473,13 @@
                 continue;
             }
             labelOffsets.set(labelNodeId(label), null);
-            resetLabels.push({
-                identifiedObjectUUID: label.identifiedObjectUUID,
-                kind: label.kind,
-                xOffset: null,
-                yOffset: null,
-            });
+            resetLabels.push(
+                toLabelPositionDTO(
+                    label.identifiedObjectUUID,
+                    label.kind,
+                    null,
+                ),
+            );
         }
         persistLabelPositions(resetLabels);
     }
@@ -543,7 +561,6 @@
     export async function applyELKLayout() {
         if (!isLoading) isLoading = true;
         layouted = true;
-        const classNodes = nodes.filter(node => node.type !== LABEL_NODE_TYPE);
         const layoutedNodes = await getLayoutedNodes(classNodes, edges);
         nodes = [...layoutedNodes];
         updateNodePositions(nodes);


### PR DESCRIPTION
## Summary

Labels can now be moved inside a defined radius around the association


## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO
