### PR TITLE
fix: restore share snapshot (RDFA-710)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -104,7 +104,9 @@
     async function loadSnapshot() {
         const base64Param = page.url.searchParams.get("snapshot");
         if (base64Param) {
-            const { error } = await loadSnapshotAPI({ path: { base64Param } });
+            const { error } = await loadSnapshotAPI({
+                path: { base64Token: base64Param },
+            });
             if (!error) {
                 await goto("/mainpage");
                 toastStore.success(

--- a/frontend/src/routes/SnapshotDialog.svelte
+++ b/frontend/src/routes/SnapshotDialog.svelte
@@ -34,7 +34,7 @@
     const workspaceSelectId = `workspaceSelect-${uuidv4()}`;
 
     let workspaceName = $state(null);
-    let workspaces = $state();
+    let workspaces = $state([]);
     let base64Token = $state();
 
     const workspaceSelectionLocked = $derived(!!lockedWorkspaceName);
@@ -42,12 +42,17 @@
     async function onOpen() {
         workspaceName =
             lockedWorkspaceName ?? editorState.selectedWorkspace.getValue();
-        workspaces = await workspaceStore.getWorkspaces();
+        workspaces = (await workspaceStore.getWorkspaces()) ?? [];
     }
 
     async function snapshotWorkspace() {
+        // The endpoint takes the workspace name as a raw request body: the
+        // backend reads it verbatim, so the default JSON serializer would send
+        // it quoted and the workspace would not be found.
         const { data, error } = await createSnapshot({
-            path: { datasetName: workspaceName },
+            body: workspaceName,
+            bodySerializer: null,
+            headers: { "Content-Type": "text/plain" },
         });
         if (!error) {
             base64Token = data;

--- a/frontend/tests/routes/snapshotDialog.test.js
+++ b/frontend/tests/routes/snapshotDialog.test.js
@@ -1,0 +1,121 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { mount, unmount } from "svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import SnapshotDialog from "../../src/routes/SnapshotDialog.svelte";
+
+const WORKSPACES = vi.hoisted(() => [
+    { label: "cgmes", readOnly: false, prefixes: [] },
+    { label: "nc", readOnly: false, prefixes: [] },
+]);
+
+const createSnapshot = vi.hoisted(() => vi.fn());
+const getWorkspaces = vi.hoisted(() => vi.fn());
+
+let mounted = null;
+let target = null;
+
+function dialog() {
+    return document.querySelector("[role='dialog']");
+}
+
+function workspaceSelect() {
+    return dialog().querySelector("select");
+}
+
+function primaryButton() {
+    return [...dialog().querySelectorAll("button")].find(
+        button => button.textContent.trim() === "Share Snapshot",
+    );
+}
+
+async function render(props = {}) {
+    target = document.createElement("div");
+    document.body.appendChild(target);
+    mounted = mount(SnapshotDialog, {
+        target,
+        props: { showDialog: true, ...props },
+    });
+    await vi.waitFor(() => expect(dialog()).not.toBeNull());
+    return target;
+}
+
+vi.mock("$lib/api/generated/index.ts", () => ({ createSnapshot }));
+
+vi.mock("$lib/stores/workspaceStore.ts", () => ({
+    workspaceStore: { getWorkspaces },
+}));
+
+beforeEach(() => {
+    createSnapshot.mockResolvedValue({ data: "a-token", error: undefined });
+    getWorkspaces.mockResolvedValue(WORKSPACES);
+});
+
+afterEach(() => {
+    if (mounted) unmount(mounted);
+    target?.remove();
+    mounted = null;
+    target = null;
+    vi.clearAllMocks();
+});
+
+describe("SnapshotDialog", () => {
+    test("offers the known workspaces when none is locked", async () => {
+        await render();
+
+        await vi.waitFor(() =>
+            expect(workspaceSelect().options).toHaveLength(
+                WORKSPACES.length + 1,
+            ),
+        );
+        expect(
+            [...workspaceSelect().options].slice(1).map(o => o.value),
+        ).toEqual(["cgmes", "nc"]);
+    });
+
+    test("stays usable when the workspaces cannot be loaded", async () => {
+        getWorkspaces.mockResolvedValue(null);
+
+        await render();
+
+        await vi.waitFor(() => expect(workspaceSelect()).not.toBeNull());
+        expect(workspaceSelect().disabled).toBe(true);
+    });
+
+    test("sends the workspace name as an unquoted request body", async () => {
+        await render({ lockedWorkspaceName: "cgmes" });
+
+        primaryButton().click();
+
+        await vi.waitFor(() => expect(createSnapshot).toHaveBeenCalledTimes(1));
+        const options = createSnapshot.mock.calls[0][0];
+        expect(options.body).toBe("cgmes");
+        expect(options.bodySerializer).toBeNull();
+    });
+
+    test("builds the share link from the returned token", async () => {
+        await render({ lockedWorkspaceName: "cgmes" });
+
+        primaryButton().click();
+
+        await vi.waitFor(() =>
+            expect(dialog().textContent).toContain("?snapshot=a-token"),
+        );
+    });
+});


### PR DESCRIPTION
## Summary

The client migration in 64d25ac1 broke every step of the snapshot flow:

- SnapshotDialog left `workspaces` undefined until the store answered, so opening the dialog from the File menu threw on `workspaces.length` before it rendered. Only the workspace tab context menu still worked, because it locks the workspace and hides the select.
- createSnapshot passed the workspace name as a path parameter. The endpoint takes it as a raw request body that the backend reads verbatim, so it has to be sent unserialized instead of as a quoted JSON string.
- loadSnapshot passed the token as `base64Param`, while the path placeholder is `base64Token`, so a shared link requested a literal /api/snapshots/{base64Token}.

## Related Issues

Closes #246

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

Tested Share Snapshot dialog functionality and opening snapshots.