### PR TITLE
fix: show association labels in diagrams (GH-232, RDFA-719)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/DiagramObjectStyle.java
+++ b/backend/src/main/java/org/rdfarchitect/dl/data/dto/relations/DiagramObjectStyle.java
@@ -29,7 +29,8 @@ import java.util.UUID;
  */
 public enum DiagramObjectStyle {
     CLASS("class"),
-    MULTIPLICITY("multiplicity");
+    MULTIPLICITY("multiplicity"),
+    ASSOCIATION_LABEL("associationLabel");
 
     private final String styleName;
     private final MRID mRID;

--- a/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/CIMResource.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/CIMResource.java
@@ -98,6 +98,22 @@ abstract class CIMResource implements ICIMResource {
             throw new IllegalStateException(
                     "Label for resource with UUID " + uuid + " is not a literal.");
         }
+        return asLabel(node);
+    }
+
+    /**
+     * The label of this resource, or null when the model holds none. For the places a label is nice
+     * to have rather than required, such as a diagram label that is simply left out when the
+     * resource has none.
+     *
+     * @return the label of this resource, or null
+     */
+    public RDFSLabel getLabelOrNull() {
+        var node = getUniqueJenaPropertyNode(RDFS.label);
+        return node != null && node.isLiteral() ? asLabel(node) : null;
+    }
+
+    private RDFSLabel asLabel(RDFNode node) {
         var langLiteral = node.asLiteral();
         return new RDFSLabel(langLiteral.getString(), langLiteral.getLanguage());
     }

--- a/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/ICIMAssociation.java
+++ b/backend/src/main/java/org/rdfarchitect/models/cim/data/dto/facade/ICIMAssociation.java
@@ -19,6 +19,7 @@ package org.rdfarchitect.models.cim.data.dto.facade;
 
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSAssociationUsed;
 import org.rdfarchitect.models.cim.data.dto.relations.CIMSMultiplicity;
+import org.rdfarchitect.models.cim.data.dto.relations.RDFSLabel;
 
 public interface ICIMAssociation extends ICIMResource {
 
@@ -38,4 +39,13 @@ public interface ICIMAssociation extends ICIMResource {
     boolean isRenderable();
 
     CIMSAssociationUsed getAssociationUsed();
+
+    /**
+     * The label of this association end, or null when the model holds none. Unlike {@link
+     * #getLabel()} this does not throw, so an association without a label still renders, just
+     * without its label.
+     *
+     * @return the label of this association end, or null
+     */
+    RDFSLabel getLabelOrNull();
 }

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMCollectionSvelteFlowService.java
@@ -341,11 +341,7 @@ public class RenderCIMCollectionSvelteFlowService implements RenderCIMCollection
                 EdgeDataDTO.builder()
                         .labels(
                                 SvelteFlowLabels.forAssociation(
-                                        to.getUuid(),
-                                        extractMultiplicityString(to.getMultiplicity()),
-                                        from.getUuid(),
-                                        extractMultiplicityString(from.getMultiplicity()),
-                                        layoutData))
+                                        associationEnd(to), associationEnd(from), layoutData))
                         .useToAssociation(useToAssociation)
                         .useFromAssociation(useFromAssociation)
                         .build();
@@ -357,6 +353,19 @@ public class RenderCIMCollectionSvelteFlowService implements RenderCIMCollection
                 .target(targetUUID)
                 .data(edgeDataDTO)
                 .build();
+    }
+
+    /**
+     * The labels of one association end, which are drawn at the class the association points to.
+     *
+     * @param association the association end
+     * @return the end together with the texts of its labels
+     */
+    private SvelteFlowLabels.AssociationEnd associationEnd(CIMAssociation association) {
+        return new SvelteFlowLabels.AssociationEnd(
+                association.getUuid(),
+                extractMultiplicityString(association.getMultiplicity()),
+                association.getLabel() == null ? null : association.getLabel().getValue());
     }
 
     /**

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/RenderCIMFacadeCollectionSvelteFlowService.java
@@ -381,14 +381,16 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                             EdgeDataDTO.builder()
                                     .labels(
                                             SvelteFlowLabels.forAssociation(
-                                                    CrossProfileUtils.mergedUuid(
-                                                            inverse.getUri().toString()),
-                                                    extractMultiplicityString(
-                                                            inverse.getMultiplicity()),
-                                                    CrossProfileUtils.mergedUuid(
-                                                            association.getUri().toString()),
-                                                    extractMultiplicityString(
-                                                            association.getMultiplicity()),
+                                                    associationEnd(
+                                                            CrossProfileUtils.mergedUuid(
+                                                                    inverse.getUri().toString()),
+                                                            inverse),
+                                                    associationEnd(
+                                                            CrossProfileUtils.mergedUuid(
+                                                                    association
+                                                                            .getUri()
+                                                                            .toString()),
+                                                            association),
                                                     layoutData))
                                     .useToAssociation(
                                             getAssociationUsedValue(
@@ -770,10 +772,8 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                 EdgeDataDTO.builder()
                         .labels(
                                 SvelteFlowLabels.forAssociation(
-                                        to.getUuid(),
-                                        extractMultiplicityString(to.getMultiplicity()),
-                                        from.getUuid(),
-                                        extractMultiplicityString(from.getMultiplicity()),
+                                        associationEnd(to.getUuid(), to),
+                                        associationEnd(from.getUuid(), from),
                                         layoutData))
                         .useToAssociation(getAssociationUsedValue(from.getAssociationUsed()))
                         .useFromAssociation(getAssociationUsedValue(to.getAssociationUsed()))
@@ -786,6 +786,24 @@ public class RenderCIMFacadeCollectionSvelteFlowService
                 .target(from.getRange().getUuid())
                 .data(edgeDataDTO)
                 .build();
+    }
+
+    /**
+     * The labels of one association end, which are drawn at the class the association points to.
+     * The label is read leniently, because an association end without one is still rendered, just
+     * without its label.
+     *
+     * @param uuid the UUID the labels of this end are stored under, which is the merged UUID in a
+     *     merged diagram rather than the UUID of the association end itself
+     * @param association the association end
+     * @return the end together with the texts of its labels
+     */
+    private SvelteFlowLabels.AssociationEnd associationEnd(UUID uuid, ICIMAssociation association) {
+        var label = association.getLabelOrNull();
+        return new SvelteFlowLabels.AssociationEnd(
+                uuid,
+                extractMultiplicityString(association.getMultiplicity()),
+                label == null ? null : label.getValue());
     }
 
     private String extractMultiplicityString(CIMSMultiplicity multiplicity) {

--- a/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/SvelteFlowLabels.java
+++ b/backend/src/main/java/org/rdfarchitect/services/rendering/svelteflow/SvelteFlowLabels.java
@@ -31,58 +31,82 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Assembles the movable labels of an association end. A label is identified by the CIM resource it
- * belongs to plus its kind, which is what lets further kinds (role names, association names) be
- * added here without touching the layout storage.
+ * Assembles the movable labels of an association edge, a multiplicity and an association label per
+ * end. A label is identified by the CIM resource it belongs to plus its kind, which is what lets
+ * further kinds be added here without touching the layout storage.
  */
 @UtilityClass
 public class SvelteFlowLabels {
 
     /**
-     * Builds the labels of an association edge. A multiplicity is rendered at the class its
-     * association points to, so the multiplicity of the association leaving the source class ends
-     * up at the target end and vice versa.
+     * One end of an association edge: the association end whose labels are drawn at that class,
+     * together with the texts of those labels. Both the multiplicity and the label of an
+     * association end are drawn at the class its association points to, so the end at the source
+     * class carries the association leaving the target class and vice versa.
      *
-     * @param sourceAssociation the UUID of the association end whose multiplicity sits at the
-     *     source class
-     * @param sourceMultiplicity the multiplicity text at the source class
-     * @param targetAssociation the UUID of the association end whose multiplicity sits at the
-     *     target class
-     * @param targetMultiplicity the multiplicity text at the target class
+     * @param association the UUID of the association end
+     * @param multiplicity the multiplicity text, may be null
+     * @param label the label of the association end, may be null
+     */
+    public record AssociationEnd(UUID association, String multiplicity, String label) {}
+
+    /**
+     * Builds the labels of an association edge.
+     *
+     * @param source the association end whose labels sit at the source class
+     * @param target the association end whose labels sit at the target class
      * @param layoutData the layout data holding manually placed label positions, may be null
      * @return the labels of the edge
      */
     public List<EdgeLabelDTO> forAssociation(
-            UUID sourceAssociation,
-            String sourceMultiplicity,
-            UUID targetAssociation,
-            String targetMultiplicity,
-            RenderingLayoutData layoutData) {
+            AssociationEnd source, AssociationEnd target, RenderingLayoutData layoutData) {
         var labels = new ArrayList<EdgeLabelDTO>();
-        addMultiplicity(labels, Anchor.SOURCE, sourceAssociation, sourceMultiplicity, layoutData);
-        addMultiplicity(labels, Anchor.TARGET, targetAssociation, targetMultiplicity, layoutData);
+        addEndLabels(labels, Anchor.SOURCE, source, layoutData);
+        addEndLabels(labels, Anchor.TARGET, target, layoutData);
         return labels;
     }
 
-    private void addMultiplicity(
+    private void addEndLabels(
+            List<EdgeLabelDTO> labels,
+            Anchor anchor,
+            AssociationEnd end,
+            RenderingLayoutData layoutData) {
+        if (end == null || end.association() == null) {
+            return;
+        }
+        addLabel(
+                labels,
+                anchor,
+                end.association(),
+                DiagramObjectStyle.MULTIPLICITY,
+                end.multiplicity(),
+                layoutData);
+        addLabel(
+                labels,
+                anchor,
+                end.association(),
+                DiagramObjectStyle.ASSOCIATION_LABEL,
+                end.label(),
+                layoutData);
+    }
+
+    private void addLabel(
             List<EdgeLabelDTO> labels,
             Anchor anchor,
             UUID association,
-            String multiplicity,
+            DiagramObjectStyle style,
+            String text,
             RenderingLayoutData layoutData) {
-        if (association == null || multiplicity == null || multiplicity.isBlank()) {
+        if (text == null || text.isBlank()) {
             return;
         }
         labels.add(
                 EdgeLabelDTO.builder()
                         .anchor(anchor)
                         .identifiedObjectUUID(association)
-                        .kind(DiagramObjectStyle.MULTIPLICITY.getStyleName())
-                        .text(multiplicity)
-                        .offset(
-                                offsetFor(
-                                        layoutData,
-                                        new LabelKey(association, DiagramObjectStyle.MULTIPLICITY)))
+                        .kind(style.getStyleName())
+                        .text(text)
+                        .offset(offsetFor(layoutData, new LabelKey(association, style)))
                         .build());
     }
 

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMCollectionSvelteFlowServiceTest.java
@@ -193,8 +193,12 @@ class RenderCIMCollectionSvelteFlowServiceTest extends RenderCIMCollectionTestBa
         var associationEdgeDTO = result.getEdges().getFirst();
         assertThat(result.getEdges()).hasSize(1);
         assertThat(associationEdgeDTO.getData().getLabels())
-                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getText)
-                .containsExactly(tuple(Anchor.SOURCE, "1...1"), tuple(Anchor.TARGET, "0...n"));
+                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getKind, EdgeLabelDTO::getText)
+                .containsExactly(
+                        tuple(Anchor.SOURCE, "multiplicity", "1...1"),
+                        tuple(Anchor.SOURCE, "associationLabel", "class2.class1"),
+                        tuple(Anchor.TARGET, "multiplicity", "0...n"),
+                        tuple(Anchor.TARGET, "associationLabel", "class1.class2"));
         assertThat(associationEdgeDTO.getData().isUseFromAssociation()).isFalse();
         assertThat(associationEdgeDTO.getData().isUseToAssociation()).isTrue();
     }

--- a/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/rendering/RenderCIMFacadeCollectionSvelteFlowServiceTest.java
@@ -350,10 +350,36 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
         assertThat(edge.getSource()).isEqualTo(CHILD_UUID);
         assertThat(edge.getTarget()).isEqualTo(TERMINAL_UUID);
         assertThat(edge.getData().getLabels())
-                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getText)
-                .containsExactly(tuple(Anchor.SOURCE, "1..1"), tuple(Anchor.TARGET, "0..n"));
+                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getKind, EdgeLabelDTO::getText)
+                .containsExactly(
+                        tuple(Anchor.SOURCE, "multiplicity", "1..1"),
+                        tuple(Anchor.SOURCE, "associationLabel", "Child"),
+                        tuple(Anchor.TARGET, "multiplicity", "0..n"),
+                        tuple(Anchor.TARGET, "associationLabel", "Terminals"));
         assertThat(edge.getData().isUseToAssociation()).isTrue();
         assertThat(edge.getData().isUseFromAssociation()).isFalse();
+    }
+
+    @Test
+    @DisplayName("renders an association end without a label as its multiplicity alone")
+    void rendersAssociationEndWithoutLabel() {
+        model.getResource(NS + "Terminal.Child").removeAll(RDFS.label);
+
+        var result =
+                (SvelteFlowDTO)
+                        renderer.renderUML(facade, coreFilter(), null, List.of(), null, null);
+
+        var edge =
+                result.getEdges().stream()
+                        .filter(candidate -> candidate.getType().equals("association"))
+                        .findFirst()
+                        .orElseThrow();
+        assertThat(edge.getData().getLabels())
+                .extracting(EdgeLabelDTO::getAnchor, EdgeLabelDTO::getText)
+                .containsExactly(
+                        tuple(Anchor.SOURCE, "1..1"),
+                        tuple(Anchor.TARGET, "0..n"),
+                        tuple(Anchor.TARGET, "Terminals"));
     }
 
     @Test
@@ -972,7 +998,10 @@ class RenderCIMFacadeCollectionSvelteFlowServiceTest {
     }
 
     private List<String> multiplicityTexts(EdgeDTO edge) {
-        return edge.getData().getLabels().stream().map(EdgeLabelDTO::getText).toList();
+        return edge.getData().getLabels().stream()
+                .filter(label -> label.getKind().equals("multiplicity"))
+                .map(EdgeLabelDTO::getText)
+                .toList();
     }
 
     private List<EdgeDTO> mergedAssociationEdges(List<CIMProfileModel> profiles) {

--- a/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
+++ b/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
@@ -30,7 +30,20 @@ const LABEL_MAX_DISTANCE = 120;
 
 const SELF_LOOP_LABEL_OFFSET = { x: 12, y: -30 };
 
+/**
+ * The vertical distance between the two labels of an edge end. Kept vertical whatever way the
+ * edge runs, because a label is at most a line high but can be arbitrarily wide.
+ */
+const LABEL_STACK_SPACING = 24;
+
 const SOURCE_ANCHOR = "SOURCE";
+
+/**
+ * The kinds of label an association edge carries at each of its ends, named after the diagram
+ * object styles they are stored under.
+ */
+const MULTIPLICITY_KIND = "multiplicity";
+const ASSOCIATION_LABEL_KIND = "associationLabel";
 
 export function labelNodeId(label) {
     return `${label.identifiedObjectUUID}:${label.kind}`;
@@ -132,7 +145,7 @@ function buildLabelNode(
               x: anchorClass.position.x + offset.x,
               y: anchorClass.position.y + offset.y,
           }
-        : placement.defaultCenter;
+        : defaultCenter(placement, label.kind);
 
     return {
         id,
@@ -210,49 +223,78 @@ function samePlacementInputs(cached, source, target) {
 
 /**
  * Anchor points and default label placements of both edge ends. The anchor point is where the
- * edge meets the class; the default placement is the one the labels had before they became
- * movable.
+ * edge meets the class; the default placement of the multiplicity is the one it had before an
+ * edge end carried more than one label.
  */
 function edgePlacements(source, target) {
     if (source.id === target.id) {
         const position = source.position;
         const width = source.measured.width ?? 100;
+        // Stacked upwards, into the loop the edge draws above the class, rather than downwards
+        // onto the class itself.
+        const stacked = { x: 0, y: -LABEL_STACK_SPACING };
         return {
             source: placement(
                 position.x + width * 0.25,
                 position.y,
-                -SELF_LOOP_LABEL_OFFSET.x,
-                SELF_LOOP_LABEL_OFFSET.y,
+                { x: -SELF_LOOP_LABEL_OFFSET.x, y: SELF_LOOP_LABEL_OFFSET.y },
+                stacked,
             ),
             target: placement(
                 position.x + width * 0.75,
                 position.y,
-                SELF_LOOP_LABEL_OFFSET.x,
-                SELF_LOOP_LABEL_OFFSET.y,
+                { x: SELF_LOOP_LABEL_OFFSET.x, y: SELF_LOOP_LABEL_OFFSET.y },
+                stacked,
             ),
         };
     }
 
     const edgeParams = getEdgeParams(source, target);
+    const stacked = { x: 0, y: LABEL_STACK_SPACING };
     return {
         source: placement(
             edgeParams.sx,
             edgeParams.sy,
-            edgeParams.startX,
-            edgeParams.startY,
+            { x: edgeParams.startX, y: edgeParams.startY },
+            stacked,
         ),
         target: placement(
             edgeParams.tx,
             edgeParams.ty,
-            edgeParams.endX,
-            edgeParams.endY,
+            { x: edgeParams.endX, y: edgeParams.endY },
+            stacked,
         ),
     };
 }
 
-function placement(anchorX, anchorY, offsetX, offsetY) {
+/**
+ * The anchor point of an edge end together with the default placement of each label drawn there.
+ *
+ * @param offset where the multiplicity sits relative to the anchor point
+ * @param associationLabelShift how far the association label sits from the multiplicity, so that
+ *     the two labels of an edge end do not cover each other
+ */
+function placement(anchorX, anchorY, offset, associationLabelShift) {
+    const multiplicityCenter = {
+        x: anchorX + offset.x,
+        y: anchorY + offset.y,
+    };
     return {
         anchor: { x: anchorX, y: anchorY },
-        defaultCenter: { x: anchorX + offsetX, y: anchorY + offsetY },
+        defaultCenters: {
+            [MULTIPLICITY_KIND]: multiplicityCenter,
+            [ASSOCIATION_LABEL_KIND]: {
+                x: multiplicityCenter.x + associationLabelShift.x,
+                y: multiplicityCenter.y + associationLabelShift.y,
+            },
+        },
     };
+}
+
+/** The default placement of a label kind, falling back to the one of the multiplicity. */
+function defaultCenter(placement, kind) {
+    return (
+        placement.defaultCenters[kind] ??
+        placement.defaultCenters[MULTIPLICITY_KIND]
+    );
 }

--- a/frontend/tests/rendering/labelNodes.test.js
+++ b/frontend/tests/rendering/labelNodes.test.js
@@ -1,0 +1,127 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { buildLabelNodes } from "$lib/rendering/svelteflow/diagram/labelNodes.js";
+
+const CLASS_SIZE = { width: 100, height: 50 };
+
+function classNode(id, x, y) {
+    return {
+        id,
+        type: "class",
+        position: { x, y },
+        measured: CLASS_SIZE,
+    };
+}
+
+function label(anchor, uuid, kind, text, offset = null) {
+    return { anchor, identifiedObjectUUID: uuid, kind, text, offset };
+}
+
+function associationEdge(source, target, labels) {
+    return {
+        id: "edge",
+        type: "association",
+        source,
+        target,
+        data: { labels },
+    };
+}
+
+function nodeById(nodes, id) {
+    return nodes.find(node => node.id === id);
+}
+
+describe("buildLabelNodes", () => {
+    test.each([
+        ["a horizontal edge", classNode("target", 300, 0)],
+        ["a vertical edge", classNode("target", 0, 300)],
+        ["a diagonal edge", classNode("target", 300, 300)],
+    ])("stacks the two labels of an edge end of %s", (_, target) => {
+        const nodes = [classNode("source", 0, 0), target];
+        const edges = [
+            associationEdge("source", "target", [
+                label("SOURCE", "from", "multiplicity", "1..1"),
+                label("SOURCE", "from", "associationLabel", "Child"),
+                label("TARGET", "to", "multiplicity", "0..n"),
+                label("TARGET", "to", "associationLabel", "Terminals"),
+            ]),
+        ];
+
+        const labelNodes = buildLabelNodes(nodes, edges);
+
+        expect(labelNodes.map(node => node.id)).toEqual([
+            "from:multiplicity",
+            "from:associationLabel",
+            "to:multiplicity",
+            "to:associationLabel",
+        ]);
+        for (const uuid of ["from", "to"]) {
+            const multiplicity = nodeById(labelNodes, `${uuid}:multiplicity`);
+            const associationLabel = nodeById(
+                labelNodes,
+                `${uuid}:associationLabel`,
+            );
+
+            // Whatever way the edge runs, the association label sits a line below the
+            // multiplicity, which is the one direction a label of any width clears the other in.
+            expect(associationLabel.position.x).toBe(multiplicity.position.x);
+            expect(
+                associationLabel.position.y - multiplicity.position.y,
+            ).toBeGreaterThanOrEqual(20);
+        }
+    });
+
+    test("stacks the labels of a self loop into its arc", () => {
+        const nodes = [classNode("class", 0, 0)];
+        const edges = [
+            associationEdge("class", "class", [
+                label("SOURCE", "from", "multiplicity", "1..1"),
+                label("SOURCE", "from", "associationLabel", "Parent"),
+            ]),
+        ];
+
+        const labelNodes = buildLabelNodes(nodes, edges);
+
+        const multiplicity = nodeById(labelNodes, "from:multiplicity");
+        const associationLabel = nodeById(labelNodes, "from:associationLabel");
+        expect(associationLabel.position.x).toBe(multiplicity.position.x);
+        expect(multiplicity.position.y - associationLabel.position.y).toBe(24);
+    });
+
+    test("keeps a manually placed association label at its stored offset", () => {
+        const nodes = [
+            classNode("source", 10, 20),
+            classNode("target", 300, 0),
+        ];
+        const edges = [
+            associationEdge("source", "target", [
+                label("SOURCE", "from", "associationLabel", "Child", {
+                    x: 40,
+                    y: -60,
+                }),
+            ]),
+        ];
+
+        const labelNodes = buildLabelNodes(nodes, edges);
+
+        expect(labelNodes).toHaveLength(1);
+        expect(labelNodes[0].position).toEqual({ x: 50, y: -40 });
+    });
+});


### PR DESCRIPTION
## Summary

- both ends of an association edge now carry the label of their association end next to the multiplicity, stacked a line below it so that neither label covers the other whatever way the edge runs
- association labels are moved, reset and stored like multiplicity labels, under a diagram object style of their own
- an association end without a label keeps rendering, just without the label

## Related Issues

Closes #232

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
