### PR TITLE
fix: keep the diagram from freezing on an unlaid-out layout (GH-256)

### DIFF
--- a/frontend/src/lib/rendering/svelteflow/components/edgeUtils.ts
+++ b/frontend/src/lib/rendering/svelteflow/components/edgeUtils.ts
@@ -49,6 +49,14 @@ function getNodeIntersection(
     const x1 = targetPos.x + (targetNode.measured.width ?? 0) / 2;
     const y1 = targetPos.y + (targetNode.measured.height ?? 0) / 2 + offsetY;
 
+    // Two classes share a centre for as long as a diagram has not been laid out, where every
+    // class still sits at (0,0), and again whenever one is dropped on top of another. There is
+    // no border intersection to compute then, and the formula below would turn 0 * Infinity
+    // into NaN — which travels on into the edge path and the placement of its labels.
+    if (w === 0 || h === 0 || (x1 === x2 && y1 === y2)) {
+        return { x: x2, y: y2 };
+    }
+
     const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
     const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);
 

--- a/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
+++ b/frontend/src/lib/rendering/svelteflow/diagram/labelNodes.js
@@ -105,6 +105,34 @@ export function buildLabelNodes(
     return labelNodes;
 }
 
+/**
+ * Whether a rebuild differs from the label nodes a diagram currently holds.
+ *
+ * Coordinates are compared with `Object.is`, so that one which is not a number still compares
+ * equal to itself. The label nodes are kept in sync by an effect that writes the nodes it reads,
+ * so a `NaN !== NaN` reporting a change on every rebuild would keep that effect running forever.
+ */
+export function labelNodesChanged(currentNodes, nextLabelNodes) {
+    const current = currentNodes.filter(node => node.type === LABEL_NODE_TYPE);
+    if (current.length !== nextLabelNodes.length) {
+        return true;
+    }
+    const currentById = new Map(current.map(node => [node.id, node]));
+    return nextLabelNodes.some(next => {
+        const node = currentById.get(next.id);
+        return (
+            !node ||
+            node.data.text !== next.data.text ||
+            !samePoint(node.position, next.position) ||
+            !samePoint(node.data.anchorPoint, next.data.anchorPoint)
+        );
+    });
+}
+
+function samePoint(one, other) {
+    return Object.is(one.x, other.x) && Object.is(one.y, other.y);
+}
+
 /** The offset a label at the given position has relative to the class it is anchored to. */
 export function offsetFromClass(labelNode, anchorClass) {
     return {

--- a/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
+++ b/frontend/src/lib/rendering/svelteflow/svelteFlowWrapper.svelte
@@ -34,6 +34,7 @@
         updateLabelPositions,
     } from "$lib/api/generated/index.ts";
     import { eventStack } from "$lib/eventhandling/closeEventManager.svelte.js";
+    import { toastStore } from "$lib/eventhandling/toastStore.svelte.js";
     import {
         editorState,
         forceReloadTrigger,
@@ -59,6 +60,7 @@
         effectiveOffset,
         LABEL_NODE_TYPE,
         labelNodeId,
+        labelNodesChanged,
         offsetFromClass,
     } from "./diagram/labelNodes.js";
     import { ContextMenuController } from "./interaction/contextMenus.svelte.js";
@@ -374,27 +376,6 @@
         ];
     }
 
-    function labelNodesChanged(currentNodes, nextLabelNodes) {
-        const current = currentNodes.filter(
-            node => node.type === LABEL_NODE_TYPE,
-        );
-        if (current.length !== nextLabelNodes.length) {
-            return true;
-        }
-        const currentById = new Map(current.map(node => [node.id, node]));
-        return nextLabelNodes.some(next => {
-            const node = currentById.get(next.id);
-            return (
-                !node ||
-                node.data.text !== next.data.text ||
-                node.position.x !== next.position.x ||
-                node.position.y !== next.position.y ||
-                node.data.anchorPoint.x !== next.data.anchorPoint.x ||
-                node.data.anchorPoint.y !== next.data.anchorPoint.y
-            );
-        });
-    }
-
     /**
      * Holds a dragged label within its maximum distance from the anchor point. SvelteFlow can only
      * constrain a node to a rectangle, so the radial limit is applied per drag event instead.
@@ -561,13 +542,24 @@
     export async function applyELKLayout() {
         if (!isLoading) isLoading = true;
         layouted = true;
-        const layoutedNodes = await getLayoutedNodes(classNodes, edges);
-        nodes = [...layoutedNodes];
-        updateNodePositions(nodes);
-        resetLabelPositions();
-        syncLabelNodes(nodes, edges);
-        await svelteFlowAPI.svelteFlow.fitView();
-        isLoading = false;
+        try {
+            const layoutedNodes = await getLayoutedNodes(classNodes, edges);
+            nodes = [...layoutedNodes];
+            updateNodePositions(nodes);
+            resetLabelPositions();
+            syncLabelNodes(nodes, edges);
+            await svelteFlowAPI.svelteFlow.fitView();
+        } catch (error) {
+            // The diagram keeps the positions it has; leaving the spinner up would only look
+            // like a layout that never finishes.
+            console.error("Laying out the diagram failed:", error);
+            toastStore.error(
+                "Layout failed",
+                "The diagram could not be laid out automatically.",
+            );
+        } finally {
+            isLoading = false;
+        }
     }
 </script>
 

--- a/frontend/tests/rendering/labelPlacement.test.js
+++ b/frontend/tests/rendering/labelPlacement.test.js
@@ -1,0 +1,141 @@
+/*
+ *    Copyright (c) 2024-2026 SOPTIM AG
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { getEdgeParams } from "$lib/rendering/svelteflow/components/edgeUtils.ts";
+import {
+    buildLabelNodes,
+    labelNodesChanged,
+    LABEL_NODE_TYPE,
+} from "$lib/rendering/svelteflow/diagram/labelNodes.js";
+
+/** A class node as it arrives before a diagram has been laid out: every class sits at (0,0). */
+function classNode(
+    id,
+    size = { width: 180, height: 88 },
+    position = { x: 0, y: 0 },
+) {
+    return { id, type: "class", position, measured: size };
+}
+
+function associationEdge(source, target) {
+    return {
+        id: `${source}->${target}`,
+        type: "association",
+        source,
+        target,
+        data: {
+            labels: [
+                {
+                    anchor: "SOURCE",
+                    identifiedObjectUUID: `${source}-end`,
+                    kind: "multiplicity",
+                    text: "0..1",
+                    offset: null,
+                },
+                {
+                    anchor: "TARGET",
+                    identifiedObjectUUID: `${target}-end`,
+                    kind: "multiplicity",
+                    text: "1..n",
+                    offset: null,
+                },
+            ],
+        },
+    };
+}
+
+describe("edge geometry", () => {
+    test("stays finite for two equally sized classes sharing a position", () => {
+        const params = getEdgeParams(classNode("a"), classNode("b"));
+
+        for (const [key, value] of Object.entries(params)) {
+            expect(`${key}=${value}`).toBe(`${key}=${Number(value)}`);
+            expect(Number.isFinite(value), key).toBe(true);
+        }
+    });
+
+    test("puts both ends on the shared centre when there is no intersection", () => {
+        const params = getEdgeParams(classNode("a"), classNode("b"));
+
+        expect([params.sx, params.sy]).toEqual([90, 44]);
+        expect([params.tx, params.ty]).toEqual([90, 44]);
+    });
+
+    test("still intersects the border of classes that do have a distance", () => {
+        const params = getEdgeParams(
+            classNode("a"),
+            classNode("b", undefined, { x: 400, y: 0 }),
+        );
+
+        expect(params.sx).toBeGreaterThan(params.tx - 400);
+        expect(Number.isFinite(params.startX)).toBe(true);
+    });
+});
+
+describe("label nodes", () => {
+    const nodes = [classNode("a"), classNode("b")];
+    const edges = [associationEdge("a", "b")];
+
+    test("are placed at a real position even before the diagram is laid out", () => {
+        for (const label of buildLabelNodes(nodes, edges)) {
+            expect(Number.isFinite(label.position.x), label.id).toBe(true);
+            expect(Number.isFinite(label.position.y), label.id).toBe(true);
+        }
+    });
+
+    test("a rebuild of an unchanged diagram reports no change", () => {
+        const built = buildLabelNodes(nodes, edges);
+        const withLabels = [...nodes, ...built];
+
+        expect(labelNodesChanged(withLabels, built)).toBe(false);
+        expect(
+            labelNodesChanged(withLabels, buildLabelNodes(withLabels, edges)),
+        ).toBe(false);
+    });
+
+    test("a label that cannot be placed does not report a change forever", () => {
+        const notANumber = buildLabelNodes(nodes, edges).map(label => ({
+            ...label,
+            position: { x: NaN, y: NaN },
+        }));
+
+        expect(labelNodesChanged([...nodes, ...notANumber], notANumber)).toBe(
+            false,
+        );
+    });
+
+    test("a moved class does report a change", () => {
+        const built = buildLabelNodes(nodes, edges);
+        const moved = [
+            classNode("a"),
+            classNode("b", undefined, { x: 400, y: 120 }),
+            ...built,
+        ];
+
+        expect(labelNodesChanged(moved, buildLabelNodes(moved, edges))).toBe(
+            true,
+        );
+    });
+
+    test("only label nodes are compared", () => {
+        const built = buildLabelNodes(nodes, edges);
+        expect(built.every(node => node.type === LABEL_NODE_TYPE)).toBe(true);
+        expect(labelNodesChanged([...nodes, ...built], built)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Every class of a diagram without a stored layout sits at (0,0), so any two of the same measured size share a centre. getNodeIntersection had no border intersection to compute there and turned 0 * Infinity into NaN, for the edge path and for the placement of its labels alike.

That was fatal in syncLabelNodes, whose effect writes the nodes it reads and compared positions with !==: NaN !== NaN reported a change on every rebuild, so the effect never settled. Svelte aborted the batch with effect_update_depth_exceeded and the main thread stayed busy, which left the app unresponsive and the loading spinner up for good - the ELK layout that would have separated the classes could no longer be delivered.

- an edge between two classes on the same spot now ends on their shared centre
- labelNodesChanged moved next to buildLabelNodes and compares coordinates with Object.is, so a coordinate that is not a number can no longer keep a self-writing effect running
- a failing ELK layout clears the loading state and says so, rather than leaving the user watching the spinner

## Related Issues

Closes #256

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
