### PR TITLE
fix: offer the whole inheritance chain of a copied class (GH-259)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/CopyClassReference.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/CopyClassReference.java
@@ -34,6 +34,7 @@ public record CopyClassReference(
         URI uri,
         String label,
         Set<URI> dataTypeUris,
+        Set<URI> superClassUris,
         Set<Kind> kinds,
         Map<Kind, Set<Usage>> usedBy) {
 
@@ -43,8 +44,17 @@ public record CopyClassReference(
             URI uri,
             String label,
             Set<URI> dataTypeUris,
+            Set<URI> superClassUris,
             Set<Kind> kinds) {
-        this(sourceGraph, uuid, uri, label, dataTypeUris, kinds, new EnumMap<>(Kind.class));
+        this(
+                sourceGraph,
+                uuid,
+                uri,
+                label,
+                dataTypeUris,
+                superClassUris,
+                kinds,
+                new EnumMap<>(Kind.class));
     }
 
     public CopyClassSource toSource() {

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/CopyClassReferenceResolver.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/CopyClassReferenceResolver.java
@@ -20,6 +20,8 @@ package org.rdfarchitect.services.update.classes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -54,7 +56,14 @@ public class CopyClassReferenceResolver {
 
     private final DatabasePort databasePort;
 
-    public List<CopyClassReference> resolve(List<ResolvedSource> sources) {
+    /**
+     * Resolves the classes the {@code sources} point at, so that a paste can offer them for the
+     * graph they are pasted into. Inheritance is followed all the way up, stopping above every
+     * class {@code targetGraphIdentifier} already defines: such a class is not copied, so a super
+     * class of it would land in the target with nothing inheriting from it.
+     */
+    public List<CopyClassReference> resolve(
+            List<ResolvedSource> sources, GraphIdentifier targetGraphIdentifier) {
 
         var urisByGraph =
                 new LinkedHashMap<GraphIdentifier, Map<CopyClassReference.Kind, Set<URI>>>();
@@ -78,8 +87,72 @@ public class CopyClassReferenceResolver {
         urisByGraph.forEach(
                 (graphIdentifier, urisByKind) ->
                         readReferences(resolved, graphIdentifier, urisByKind));
+        resolveSuperClassesOf(resolved, usedBy, targetGraphIdentifier);
         resolved.forEach((uri, reference) -> reference.usedBy().putAll(usedBy.of(uri)));
         return List.copyOf(resolved.values());
+    }
+
+    /**
+     * Adds the super classes above the ones already resolved, so that a paste offers the whole
+     * inheritance chain of a copied class instead of its direct super class alone. Each of them is
+     * named after the sub class that inherits from it, and classes already resolved as a reference
+     * of another kind only gain the {@link CopyClassReference.Kind#SUPER_CLASS} kind. Walking stops
+     * once a round discovers nothing new, which also ends a cyclic hierarchy.
+     */
+    private void resolveSuperClassesOf(
+            Map<URI, CopyClassReference> resolved,
+            UsagesByReference usedBy,
+            GraphIdentifier targetGraphIdentifier) {
+
+        var frontier =
+                resolved.values().stream()
+                        .filter(
+                                reference ->
+                                        reference
+                                                .kinds()
+                                                .contains(CopyClassReference.Kind.SUPER_CLASS))
+                        .toList();
+        if (frontier.isEmpty()) {
+            return;
+        }
+        var classesInTargetGraph = classUrisOf(targetGraphIdentifier);
+        while (!frontier.isEmpty()) {
+            var urisByGraph = new LinkedHashMap<GraphIdentifier, Set<URI>>();
+            var usages = new LinkedHashMap<URI, Set<CopyClassReference.Usage>>();
+            for (var reference : frontier) {
+                if (reference.superClassUris().isEmpty()
+                        || classesInTargetGraph.contains(reference.uri())) {
+                    continue;
+                }
+                urisByGraph
+                        .computeIfAbsent(
+                                reference.sourceGraph(), graphIdentifier -> new LinkedHashSet<>())
+                        .addAll(reference.superClassUris());
+                reference
+                        .superClassUris()
+                        .forEach(
+                                uri ->
+                                        addUsage(
+                                                usages,
+                                                uri,
+                                                new CopyClassReference.Usage(
+                                                        reference.label(), null)));
+            }
+            usedBy.add(CopyClassReference.Kind.SUPER_CLASS, usages);
+
+            var known = Set.copyOf(resolved.keySet());
+            urisByGraph.forEach(
+                    (graphIdentifier, uris) ->
+                            readReferences(
+                                    resolved,
+                                    graphIdentifier,
+                                    Map.of(CopyClassReference.Kind.SUPER_CLASS, uris)));
+            frontier =
+                    resolved.entrySet().stream()
+                            .filter(entry -> !known.contains(entry.getKey()))
+                            .map(Map.Entry::getValue)
+                            .toList();
+        }
     }
 
     public List<CopyClassReference> resolveDataTypesOf(List<CopyClassReference> copiedReferences) {
@@ -119,6 +192,21 @@ public class CopyClassReferenceResolver {
             frontier = List.copyOf(discovered.values());
         }
         return List.copyOf(resolved.values());
+    }
+
+    /** Reads the class URIs of a graph in a transaction of its own, closed before the walk. */
+    private Set<URI> classUrisOf(GraphIdentifier graphIdentifier) {
+        try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.READ)) {
+            return ctx
+                    .getRdfGraph()
+                    .find(Node.ANY, RDF.type.asNode(), RDFS.Class.asNode())
+                    .toList()
+                    .stream()
+                    .map(Triple::getSubject)
+                    .filter(Node::isURI)
+                    .map(subject -> new URI(subject.getURI()))
+                    .collect(Collectors.toSet());
+        }
     }
 
     public Map<URI, Set<URI>> dataTypeDependenciesOf(List<CopyClassReference> references) {
@@ -205,7 +293,18 @@ public class CopyClassReferenceResolver {
                 referencedClass.getUri(),
                 referencedClass.getLabel().getValue(),
                 dataTypeUris(referencedClass),
+                superClassUris(referencedClass),
                 EnumSet.noneOf(CopyClassReference.Kind.class));
+    }
+
+    private Set<URI> superClassUris(ICIMClass referencedClass) {
+        var uris = new LinkedHashSet<URI>();
+        for (var superClass : referencedClass.getSuperClasses()) {
+            if (superClass.getUri() != null) {
+                uris.add(superClass.getUri());
+            }
+        }
+        return uris;
     }
 
     private Set<URI> dataTypeUris(ICIMClass referencedClass) {

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/CopyClassService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/CopyClassService.java
@@ -113,7 +113,7 @@ public class CopyClassService implements CopyClassUseCase {
                     sources.size());
             return List.of();
         }
-        var references = resolveSelectedReferences(resolvedSources, options);
+        var references = resolveSelectedReferences(resolvedSources, options, targetGraphIdentifier);
         var referencedClasses = readReferencedClasses(references, snapshots);
 
         var cimPackage = options.targetPackage();
@@ -180,12 +180,17 @@ public class CopyClassService implements CopyClassUseCase {
     }
 
     private List<CopyClassReference> resolveSelectedReferences(
-            List<ResolvedSource> sources, CopyClassOptions options) {
+            List<ResolvedSource> sources,
+            CopyClassOptions options,
+            GraphIdentifier targetGraphIdentifier) {
 
         if (options.referencesToCopy().isEmpty()) {
             return List.of();
         }
-        var selected = referenceResolver.resolve(sources).stream().filter(options::copies).toList();
+        var selected =
+                referenceResolver.resolve(sources, targetGraphIdentifier).stream()
+                        .filter(options::copies)
+                        .toList();
         return Stream.concat(
                         selected.stream(), referenceResolver.resolveDataTypesOf(selected).stream())
                 .toList();
@@ -244,9 +249,6 @@ public class CopyClassService implements CopyClassUseCase {
             Graph targetGraph,
             PrefixMapping prefixMapping) {
 
-        var copiedUris =
-                references.stream().map(CopyClassReference::uri).collect(Collectors.toSet());
-
         var messages = new ArrayList<String>();
         for (var reference : references) {
             var sourceClass = referencedClasses.get(reference.uri());
@@ -257,8 +259,7 @@ public class CopyClassService implements CopyClassUseCase {
                             options,
                             cimPackage,
                             targetGraph,
-                            prefixMapping,
-                            copiedUris)) {
+                            prefixMapping)) {
                 messages.add(buildReferenceMessage(reference, options));
             }
         }
@@ -271,8 +272,7 @@ public class CopyClassService implements CopyClassUseCase {
             CopyClassOptions options,
             ICIMClassCategory cimPackage,
             Graph targetGraph,
-            PrefixMapping prefixMapping,
-            Set<URI> copiedUris) {
+            PrefixMapping prefixMapping) {
 
         if (CIMResourceUtils.containsClass(targetGraph, sourceClass.getUri())) {
             return false;
@@ -284,7 +284,7 @@ public class CopyClassService implements CopyClassUseCase {
                         sourceClass.getUri(),
                         sourceClass.getLabel(),
                         sourceClass.getStereotypes(),
-                        resolvableSuperClass(sourceClass, targetGraph, copiedUris),
+                        options.copyInheritance() ? superClassOf(sourceClass) : null,
                         cimPackage);
         if (options.copiesMembersOf(reference)) {
             copyMembers(sourceClass, newCimClass);
@@ -293,19 +293,6 @@ public class CopyClassService implements CopyClassUseCase {
         CIMUpdates.insertUMLAdaptedClass(
                 targetGraph, prefixMapping, newCimClass, newValuesAsBlankNode);
         return true;
-    }
-
-    private RDFSSubClassOf resolvableSuperClass(
-            ICIMClass sourceClass, Graph targetGraph, Set<URI> copiedUris) {
-        var superClass = superClassOf(sourceClass);
-        if (superClass == null) {
-            return null;
-        }
-        if (copiedUris.contains(superClass.getUri())
-                || CIMResourceUtils.containsClass(targetGraph, superClass.getUri())) {
-            return superClass;
-        }
-        return null;
     }
 
     private RDFSSubClassOf superClassOf(ICIMClass sourceClass) {

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/PastePreviewService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/PastePreviewService.java
@@ -60,7 +60,7 @@ public class PastePreviewService implements PastePreviewUseCase {
             return PastePreviewResponseDTO.empty();
         }
 
-        var references = referenceResolver.resolve(resolvedSources);
+        var references = referenceResolver.resolve(resolvedSources, targetGraphIdentifier);
         var pastedUris =
                 resolvedSources.stream()
                         .map(resolvedSource -> resolvedSource.cimClass().getUri())

--- a/backend/src/test/java/org/rdfarchitect/services/update/CopyClassServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/CopyClassServiceTest.java
@@ -83,6 +83,7 @@ class CopyClassServiceTest {
     private static final String OTHER_DATA_TYPE_URI = PREFIX + "OtherDataType";
     private static final String ASSOCIATION_TARGET_URI = PREFIX + "associatedClass";
     private static final String SUPER_CLASS_URI = PREFIX + "BaseClass";
+    private static final String ROOT_CLASS_URI = PREFIX + "RootClass";
     private static final String VALUE_TYPE_URI = PREFIX + "ValueType";
     private static final String DEEP_TYPE_URI = PREFIX + "DeepType";
 
@@ -249,6 +250,43 @@ class CopyClassServiceTest {
                                             CIMS.stereotype.asNode(),
                                             CIMStereotypes.concrete.asNode()))
                     .isFalse();
+        }
+    }
+
+    @Test
+    void copyClass_selectedInheritanceChain_copiesEveryAncestorAsStub() {
+        setUpReferenceGraphs();
+
+        var request = referenceRequest(SUPER_CLASS_URI, ROOT_CLASS_URI);
+
+        copyClassService.copyClasses(request, targetGraphIdentifier);
+
+        try (var ctx =
+                databasePort.getGraphWithContext(targetGraphIdentifier).begin(ReadWrite.READ)) {
+            var graph = ctx.getRdfGraph();
+            assertThat(containsClass(graph, SUPER_CLASS_URI)).isTrue();
+            assertThat(containsClass(graph, ROOT_CLASS_URI)).isTrue();
+            assertThat(superClassOf(graph, PREFIX + "oldLabel"))
+                    .isEqualTo(NodeFactory.createURI(SUPER_CLASS_URI));
+            assertThat(superClassOf(graph, SUPER_CLASS_URI))
+                    .isEqualTo(NodeFactory.createURI(ROOT_CLASS_URI));
+        }
+    }
+
+    @Test
+    void copyClass_ancestorLeftBehind_keepsItAsAReferenceOfTheCopiedStub() {
+        setUpReferenceGraphs();
+
+        var request = referenceRequest(SUPER_CLASS_URI);
+
+        copyClassService.copyClasses(request, targetGraphIdentifier);
+
+        try (var ctx =
+                databasePort.getGraphWithContext(targetGraphIdentifier).begin(ReadWrite.READ)) {
+            var graph = ctx.getRdfGraph();
+            assertThat(containsClass(graph, ROOT_CLASS_URI)).isFalse();
+            assertThat(superClassOf(graph, SUPER_CLASS_URI))
+                    .isEqualTo(NodeFactory.createURI(ROOT_CLASS_URI));
         }
     }
 
@@ -856,6 +894,13 @@ class CopyClassServiceTest {
             ctx.getRdfGraph().remove(NodeFactory.createURI(subjectUri), predicate, object);
             ctx.commit("Removed a triple for the test.");
         }
+    }
+
+    private Node superClassOf(Graph graph, String classUri) {
+        var superClasses =
+                graph.find(NodeFactory.createURI(classUri), RDFS.subClassOf.asNode(), Node.ANY)
+                        .toList();
+        return superClasses.isEmpty() ? null : superClasses.getFirst().getObject();
     }
 
     private boolean containsClass(Graph graph, String classUri) {

--- a/backend/src/test/java/org/rdfarchitect/services/update/PastePreviewServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/PastePreviewServiceTest.java
@@ -25,6 +25,7 @@ import static utils.TestUtils.readMultipartFileFromFile;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,7 @@ class PastePreviewServiceTest {
     private static final String DERIVED_CLASS_UUID = "3c7d0e55-4f5a-4b72-8c83-9d4e5f6a7b14";
     private static final String ASSOCIATED_CLASS_UUID = "4e6d5c33-8b69-4d74-a1f2-8a3e9b4d5c67";
     private static final String UNKNOWN_CLASS_UUID = "0f0e0d0c-0b0a-4988-8766-554433221100";
+    private static final String CYCLIC_CLASS_UUID = "1b2c3d4e-5f60-4a71-8b82-9c0d1e2f3a51";
 
     @BeforeEach
     void setUp() {
@@ -88,6 +90,15 @@ class PastePreviewServiceTest {
                         .build();
         databasePort.createGraph(sourceGraphIdentifier, graphSource.graph());
         databasePort.createGraph(targetGraphIdentifier, GraphFactory.createDefaultGraph());
+    }
+
+    private void addClassToTargetGraph(String classUri) {
+        try (var ctx =
+                databasePort.getGraphWithContext(targetGraphIdentifier).begin(ReadWrite.WRITE)) {
+            ctx.getRdfGraph()
+                    .add(NodeFactory.createURI(classUri), RDF.type.asNode(), RDFS.Class.asNode());
+            ctx.commit("Added a class");
+        }
     }
 
     private PasteSourceClassDTO source(String classUUID) {
@@ -121,7 +132,7 @@ class PastePreviewServiceTest {
                 .containsExactly("associatedClass");
         assertThat(missing(preview, Kind.SUPER_CLASS))
                 .extracting(PasteReferenceDTO::label)
-                .containsExactly("BaseClass");
+                .containsExactly("BaseClass", "RootClass");
         assertThat(missing(preview, Kind.DATA_TYPE).get(0).uri())
                 .isEqualTo(new URI("http://example.org#MyDataType"));
     }
@@ -146,7 +157,42 @@ class PastePreviewServiceTest {
                 .containsExactly(List.of(new PasteUsageDTO("oldLabel", "associatedClass")));
         assertThat(missing(preview, Kind.SUPER_CLASS))
                 .extracting(PasteReferenceDTO::usedBy)
-                .containsExactly(List.of(new PasteUsageDTO("oldLabel", null)));
+                .containsExactly(
+                        List.of(new PasteUsageDTO("oldLabel", null)),
+                        List.of(new PasteUsageDTO("BaseClass", null)));
+    }
+
+    @Test
+    void previewPaste_superClassHasSuperClassesOfItsOwn_namesTheWholeChain() {
+        var preview =
+                pastePreviewService.previewPaste(previewRequest(CLASS_UUID), targetGraphIdentifier);
+
+        assertThat(missing(preview, Kind.SUPER_CLASS))
+                .extracting(PasteReferenceDTO::label, PasteReferenceDTO::uri)
+                .containsExactly(
+                        tuple("BaseClass", new URI("http://example.org#BaseClass")),
+                        tuple("RootClass", new URI("http://example.org#RootClass")));
+    }
+
+    @Test
+    void previewPaste_targetGraphDefinesTheSuperClass_endsTheChainThere() {
+        addClassToTargetGraph("http://example.org#BaseClass");
+
+        var preview =
+                pastePreviewService.previewPaste(previewRequest(CLASS_UUID), targetGraphIdentifier);
+
+        assertThat(missing(preview, Kind.SUPER_CLASS)).isEmpty();
+    }
+
+    @Test
+    void previewPaste_cyclicInheritance_namesEveryClassOfTheCycleOnce() {
+        var preview =
+                pastePreviewService.previewPaste(
+                        previewRequest(CYCLIC_CLASS_UUID), targetGraphIdentifier);
+
+        assertThat(missing(preview, Kind.SUPER_CLASS))
+                .extracting(PasteReferenceDTO::label)
+                .containsExactly("cyclicSuperClass");
     }
 
     @Test

--- a/backend/src/test/java/org/rdfarchitect/services/update/class-with-references.ttl
+++ b/backend/src/test/java/org/rdfarchitect/services/update/class-with-references.ttl
@@ -15,7 +15,13 @@ ex:class
 ex:BaseClass
     rdf:type                  rdfs:Class ;
     rdfs:label                "BaseClass"@en ;
+    rdfs:subClassOf           ex:RootClass ;
     <http://example.org#uuid> "8c1b2a77-4f6d-4e18-95c7-2a3b4c5d6e70" .
+
+ex:RootClass
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "RootClass"@en ;
+    <http://example.org#uuid> "0a1b2c3d-4e5f-4a60-8b71-9c8d7e6f5a40" .
 
 ex:BaseClass.attribute
     rdf:type                  rdf:Property ;
@@ -175,3 +181,15 @@ ex:newPackage
     rdf:type                  cims:ClassCategory ;
     rdfs:label                "newPackage"@en ;
     <http://example.org#uuid> "75844dc0-d937-4184-bf6b-d35d8ca6d92a" .
+
+ex:cyclicClass
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "cyclicClass"@en ;
+    rdfs:subClassOf           ex:cyclicSuperClass ;
+    <http://example.org#uuid> "1b2c3d4e-5f60-4a71-8b82-9c0d1e2f3a51" .
+
+ex:cyclicSuperClass
+    rdf:type                  rdfs:Class ;
+    rdfs:label                "cyclicSuperClass"@en ;
+    rdfs:subClassOf           ex:cyclicClass ;
+    <http://example.org#uuid> "2c3d4e5f-6a71-4b82-8c93-0d1e2f3a4b62" .

--- a/docs/content/user-guide/organising-schemas.md
+++ b/docs/content/user-guide/organising-schemas.md
@@ -45,9 +45,11 @@ A paste is all or nothing. If one of the copied classes is gone by the time it i
 
 A class usually refers to other classes: the data types of its attributes, the target classes of its associations, and its super class. When the target schema does not contain some of them, a dialog lists what is missing before the paste runs, grouped by kind and with the attribute or class that uses it. Everything is preselected — clear whatever should stay out.
 
+Inheritance is followed all the way up: the list names the whole chain of super classes, not just the direct one, each with the sub class it belongs to — for `GeneratingUnit` that is `Equipment`, then `PowerSystemResource`, then `IdentifiedObject`. The chain stops where the target schema already defines a class of it.
+
 Association targets and super classes are copied as stubs: label and URI only, without attributes or associations. Data types are copied with their attributes, including the data types those attributes need in turn; such a follow-up data type is checked and locked in the list, labelled with the entry that requires it.
 
-The dialog only covers what the chosen variant actually copies — after **Paste without Associations** it never asks about association targets, and **Paste Bare** never opens it at all. A super class that is left behind stays on the pasted class as a reference: the class editor shows it under **Derived from** even though the schema does not define it.
+The dialog only covers what the chosen variant actually copies — after **Paste without Associations** it never asks about association targets, and **Paste Bare** never opens it at all. A super class that is left behind stays on the class below it as a reference: the class editor shows it under **Derived from** even though the schema does not define it.
 
 ## Deleting
 


### PR DESCRIPTION
## Summary

CopyClassReferenceResolver walked each copied class exactly once, so it only ever saw the direct super class. Copying GeneratingUnit out of an SSH schema therefore listed Equipment alone, while PowerSystemResource and IdentifiedObject above it were never discovered - not even the client could ask for them, because CopyClassService filters the resolver's output by URI, so a class the resolver never returned cannot be selected. Only data types were resolved transitively, because they are copied with their attributes.

The pasted Equipment stub then lost its own super class as well: resolvableSuperClass dropped the link whenever the grandparent was neither copied nor already in the target, which severed the hierarchy instead of truncating it - and contradicted the top-level class, which keeps a left-behind super class as a reference.

- resolve() now follows inheritance up to the root, naming every ancestor after the sub class that inherits from it, so the dialog reads "Equipment -> PowerSystemResource"
- the walk stops above a class the target graph already defines: that class is not copied, so its super class would land in the target with nothing inheriting from it
- a round that discovers nothing new ends the walk, which also terminates a cyclic hierarchy
- a copied stub keeps its super class like the pasted class does, dangling as a reference when the ancestor stays behind, and drops it when the paste asks for no inheritance
- the target graph is read only when there is a chain to walk at all

## Related Issues

Closes #259

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
