### PR TITLE
fix: keep UUIDs out of the changelog (GH-173)

### DIFF
--- a/backend/src/main/java/org/rdfarchitect/services/diagrams/CustomDiagramService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/diagrams/CustomDiagramService.java
@@ -19,7 +19,9 @@ package org.rdfarchitect.services.diagrams;
 
 import lombok.RequiredArgsConstructor;
 
+import org.apache.jena.graph.Graph;
 import org.apache.jena.query.ReadWrite;
+import org.apache.jena.vocabulary.RDFS;
 import org.rdfarchitect.api.dto.CustomDiagramDTO;
 import org.rdfarchitect.api.dto.cross_profile_diagram.ClassSourceDTO;
 import org.rdfarchitect.api.dto.cross_profile_diagram.CrossProfileDiagramColorDataDTO;
@@ -31,6 +33,7 @@ import org.rdfarchitect.database.inmemory.diagrams.CustomDiagram;
 import org.rdfarchitect.dl.data.dto.DiagramObject;
 import org.rdfarchitect.dl.data.dto.relations.MRID;
 import org.rdfarchitect.dl.queries.select.DLObjectFetcher;
+import org.rdfarchitect.models.cim.relations.model.CIMResourceUtils;
 import org.rdfarchitect.rdf.graph.wrapper.DiagramLayout;
 import org.rdfarchitect.services.dl.update.DiagramLayoutServiceUtils;
 import org.rdfarchitect.services.rendering.CIMProfileModel;
@@ -209,8 +212,8 @@ public class CustomDiagramService
     @Override
     public void deleteCustomGraphDiagram(GraphIdentifier graphIdentifier, String diagramId) {
         try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
-            ctx.getCustomDiagrams().remove(UUID.fromString(diagramId));
-            ctx.commit("deleted diagram %s".formatted(diagramId));
+            var diagram = ctx.getCustomDiagrams().remove(UUID.fromString(diagramId));
+            ctx.commit("deleted diagram%s".formatted(quoted(nameOf(diagram))));
         }
     }
 
@@ -234,7 +237,7 @@ public class CustomDiagramService
                             diagramDTO.getName(),
                             diagramDTO.getClasses());
             ctx.getCustomDiagrams().put(UUID.fromString(diagramId), diagram);
-            ctx.commit("replaced diagram %s".formatted(diagramId));
+            ctx.commit("replaced diagram%s".formatted(quoted(diagram.getName())));
         }
     }
 
@@ -242,19 +245,23 @@ public class CustomDiagramService
     public void removeFromCustomGraphDiagram(
             GraphIdentifier graphIdentifier, String diagramId, UUID classId) {
         try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
+            var classLabel = findClassLabel(ctx.getRdfGraph(), classId);
             var diagram = ctx.getCustomDiagrams().get(UUID.fromString(diagramId));
             if (diagram != null) {
                 var classes = diagram.getClasses();
                 classes.removeIf(c -> c.getUuid().equals(classId));
                 diagram.setClasses(classes);
             }
-            ctx.commit("removed class %s from diagram %s".formatted(classId, diagramId));
+            ctx.commit(
+                    "removed class%s from diagram%s"
+                            .formatted(quoted(classLabel), quoted(nameOf(diagram))));
         }
     }
 
     @Override
     public void removeFromAllDiagrams(GraphIdentifier graphIdentifier, UUID classId) {
         try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
+            var classLabel = findClassLabel(ctx.getRdfGraph(), classId);
             for (var diagram : ctx.getCustomDiagrams().values()) {
                 var classes = diagram.getClasses();
                 classes.removeIf(c -> c.getUuid().equals(classId));
@@ -266,7 +273,7 @@ public class CustomDiagramService
                 classes.removeIf(c -> c.getUuid().equals(classId));
                 diagram.setClasses(classes);
             }
-            ctx.commit("removed class %s from all diagrams".formatted(classId));
+            ctx.commit("removed class%s from all diagrams".formatted(quoted(classLabel)));
         }
     }
 
@@ -292,5 +299,33 @@ public class CustomDiagramService
                         .setColor(graphUri, dto.getGraphColors().get(graphUri));
             }
         }
+    }
+
+    /**
+     * Labels a class for the changelog message. Diagrams only reference classes by UUID, so the
+     * label is looked up in the RDF graph. A class that is no longer in the graph - it may have
+     * just been deleted, which is what removed it from the diagrams - stays unlabelled.
+     */
+    private String findClassLabel(Graph graph, UUID classId) {
+        try {
+            var resource = CIMResourceUtils.findResourceForUuid(graph, classId);
+            return resource.hasProperty(RDFS.label)
+                    ? CIMResourceUtils.findLabelForResource(resource)
+                    : "";
+        } catch (IllegalStateException e) {
+            return "";
+        }
+    }
+
+    private String nameOf(CustomDiagram diagram) {
+        return diagram == null ? "" : diagram.getName();
+    }
+
+    /**
+     * Renders a name as {@code "name"} for the changelog message, including the separating space.
+     * An unknown name is left out entirely rather than exposing the UUID behind it.
+     */
+    private String quoted(String name) {
+        return name == null || name.isEmpty() ? "" : " \"%s\"".formatted(name);
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/UpdateClassService.java
@@ -103,8 +103,7 @@ public class UpdateClassService
                             databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                             cimClass,
                             newValuesAsBlankNode);
-            ctx.commit(
-                    "Updated class \"%s\" (%s)".formatted(newClass.getLabel(), newClass.getUuid()));
+            ctx.commit("Updated class \"%s\"".formatted(newClass.getLabel()));
         }
 
         if (releasedUuid != null) {
@@ -142,7 +141,7 @@ public class UpdateClassService
                             graph,
                             databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                             newClass);
-            ctx.commit("Added class \"%s\" (%s)".formatted(newClass.getLabel(), newClassUUID));
+            ctx.commit("Added class \"%s\"".formatted(newClass.getLabel().getValue()));
         }
 
         createClassLayoutDataUseCase.createClassLayoutData(
@@ -186,7 +185,7 @@ public class UpdateClassService
                     ctx.getRdfGraph(),
                     databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                     classUUID);
-            ctx.commit("Deleted class \"%s\" (%s)".formatted(classLabel, classUUID));
+            ctx.commit("Deleted class \"%s\"".formatted(classLabel));
         }
 
         deleteClassLayoutDataUseCase.deleteClassLayoutData(graphIdentifier, classUUID);

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/associations/AssociationsService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/associations/AssociationsService.java
@@ -114,9 +114,7 @@ public class AssociationsService implements CreateAssociationUseCase, UpdateAsso
 
             UpdateAction.execute(new UpdateRequest().add(update.build()), ctx.getRdfGraph());
 
-            ctx.commit(
-                    "Replaced all associations for class \"%s\" (%s)"
-                            .formatted(classLabel, classUUID));
+            ctx.commit("Replaced all associations for class \"%s\"".formatted(classLabel));
         }
     }
 
@@ -135,14 +133,12 @@ public class AssociationsService implements CreateAssociationUseCase, UpdateAsso
                 CIMResourceUtils.findLabelForResource(
                         CIMResourceUtils.findResourceForUri(
                                 session.getRdfGraph(), dto.getTo().getDomain()));
-        return "%s association \"%s.%s\" (%s) → \"%s.%s\" (%s)"
+        return "%s association \"%s.%s\" → \"%s.%s\""
                 .formatted(
                         action,
                         fromClassLabel,
                         from.getLabel().getValue(),
-                        from.getUuid(),
                         toClassLabel,
-                        to.getLabel().getValue(),
-                        to.getUuid());
+                        to.getLabel().getValue());
     }
 }

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/attributes/AttributesService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/attributes/AttributesService.java
@@ -79,9 +79,8 @@ public class AttributesService implements CreateAttributeUseCase, UpdateAttribut
                     .execute();
             var classLabel = findClassLabel(graph, attributeDTO.getDomain());
             ctx.commit(
-                    "Created attribute \"%s.%s\" (%s)"
-                            .formatted(
-                                    classLabel, cimAttribute.getLabel(), cimAttribute.getUuid()));
+                    "Created attribute \"%s.%s\""
+                            .formatted(classLabel, cimAttribute.getLabel().getValue()));
         }
         return cimAttribute.getUuid();
     }
@@ -101,11 +100,8 @@ public class AttributesService implements CreateAttributeUseCase, UpdateAttribut
                     .execute();
             var classLabel = findClassLabel(graph, attributeDTO.getDomain());
             ctx.commit(
-                    "Replaced attribute \"%s.%s\" (%s)"
-                            .formatted(
-                                    classLabel,
-                                    cimAttribute.getLabel().getValue(),
-                                    cimAttribute.getUuid()));
+                    "Replaced attribute \"%s.%s\""
+                            .formatted(classLabel, cimAttribute.getLabel().getValue()));
         }
         return cimAttribute.getUuid();
     }
@@ -131,9 +127,7 @@ public class AttributesService implements CreateAttributeUseCase, UpdateAttribut
                     .execute();
             var classResource = CIMResourceUtils.findResourceForUuid(graph, classUUID);
             var classLabel = CIMResourceUtils.findLabelForResource(classResource);
-            ctx.commit(
-                    "Replaced all attributes for class \"%s\" (%s)"
-                            .formatted(classLabel, classUUID));
+            ctx.commit("Replaced all attributes for class \"%s\"".formatted(classLabel));
         }
     }
 

--- a/backend/src/main/java/org/rdfarchitect/services/update/classes/enumentries/UpdateEnumEntriesService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/classes/enumentries/UpdateEnumEntriesService.java
@@ -56,7 +56,7 @@ public class UpdateEnumEntriesService implements ReplaceOrCreateEnumEntryUseCase
                         graph,
                         databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                         cimEnumEntry);
-                message = "Created enum entry \"%s\" (%s)".formatted(cimEnumEntry.getLabel(), uuid);
+                message = "Created enum entry \"%s\"".formatted(cimEnumEntry.getLabel().getValue());
             } else {
                 uuid = enumEntryDTO.getUuid();
                 CIMUpdates.replaceEnumEntry(
@@ -64,7 +64,7 @@ public class UpdateEnumEntriesService implements ReplaceOrCreateEnumEntryUseCase
                         databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                         cimEnumEntry);
                 message =
-                        "Replaced enum entry \"%s\" (%s)".formatted(cimEnumEntry.getLabel(), uuid);
+                        "Replaced enum entry \"%s\"".formatted(cimEnumEntry.getLabel().getValue());
             }
 
             ctx.commit(message);

--- a/backend/src/main/java/org/rdfarchitect/services/update/packages/UpdatePackageService.java
+++ b/backend/src/main/java/org/rdfarchitect/services/update/packages/UpdatePackageService.java
@@ -23,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.query.ReadWrite;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDFS;
 import org.rdfarchitect.api.dto.packages.PackageDTO;
 import org.rdfarchitect.api.dto.packages.PackageMapper;
 import org.rdfarchitect.database.DatabasePort;
@@ -91,7 +93,7 @@ public class UpdatePackageService
                     graph,
                     databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                     newPackage);
-            ctx.commit("Replaced package " + packageDTO.getUuid());
+            ctx.commit("Replaced package " + packageDTO.getLabel());
         }
 
         replaceDiagramUseCase.replaceDiagram(
@@ -101,14 +103,33 @@ public class UpdatePackageService
     @Override
     public void deletePackage(GraphIdentifier graphIdentifier, UUID packageUUID) {
         try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {
+            var packageName = findPackageName(ctx.getRdfGraph(), packageUUID);
             CIMUpdates.deletePackage(
                     ctx.getRdfGraph(),
                     databasePort.getPrefixMapping(graphIdentifier.datasetName()),
                     packageUUID);
-            ctx.commit("Deleted package " + packageUUID);
+            ctx.commit(
+                    packageName.isEmpty() ? "Deleted package" : "Deleted package " + packageName);
         }
 
         deletePackageLayoutDataUseCase.deletePackageLayoutData(graphIdentifier, packageUUID);
+    }
+
+    /**
+     * Names a package for the changelog message: its label, or its IRI when it carries no label (as
+     * referenced-only packages do). Returns an empty name when the package is not part of the
+     * graph, so that naming it never fails the deletion itself.
+     */
+    private String findPackageName(Graph graph, UUID packageUUID) {
+        Resource resource;
+        try {
+            resource = CIMResourceUtils.findResourceForUuid(graph, packageUUID);
+        } catch (IllegalStateException e) {
+            return "";
+        }
+        return resource.hasProperty(RDFS.label)
+                ? CIMResourceUtils.findLabelForResource(resource)
+                : resource.getURI();
     }
 
     private void assertNoClassWithSameIri(Graph graph, CIMPackage newPackage) {

--- a/backend/src/test/java/org/rdfarchitect/services/diagrams/CustomDiagramsServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/diagrams/CustomDiagramsServiceTest.java
@@ -20,7 +20,11 @@ package org.rdfarchitect.services.diagrams;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ReadWrite;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.jena.vocabulary.RDFS;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rdfarchitect.api.dto.CustomDiagramDTO;
@@ -30,6 +34,7 @@ import org.rdfarchitect.database.GraphIdentifier;
 import org.rdfarchitect.database.inmemory.diagrams.ClassInDiagram;
 import org.rdfarchitect.database.inmemory.diagrams.CustomDiagram;
 import org.rdfarchitect.models.cim.data.dto.relations.uri.URI;
+import org.rdfarchitect.models.cim.rdf.resources.RDFA;
 import org.rdfarchitect.services.select.ListGraphsUseCase;
 
 import java.util.ArrayList;
@@ -222,10 +227,68 @@ class CustomDiagramsServiceTest {
         assertThat(datasetDiagram.getClasses()).isEmpty();
     }
 
+    @Test
+    void removeFromGraphDiagram_namesClassAndDiagramInTheChangeLogWithoutUuids() {
+        var classId = UUID.randomUUID();
+        var diagramId = UUID.randomUUID();
+        var diagram = new CustomDiagram(diagramId, "Overview", new ArrayList<>());
+        var map = new ConcurrentHashMap<UUID, CustomDiagram>();
+        map.put(diagramId, diagram);
+
+        var graph = mockGraph(map, graphWithClass(classId, "Breaker"));
+        when(databasePort.getGraphWithContext(graphIdentifier)).thenReturn(graph);
+
+        service.removeFromCustomGraphDiagram(graphIdentifier, diagramId.toString(), classId);
+
+        verify(graph).commit("removed class \"Breaker\" from diagram \"Overview\"");
+    }
+
+    @Test
+    void removeFromAllDiagrams_classAlreadyGone_leavesItUnnamedInTheChangeLog() {
+        var classId = UUID.randomUUID();
+        var graph = mockGraph(new ConcurrentHashMap<>());
+        when(databasePort.getGraphWithContext(graphIdentifier)).thenReturn(graph);
+        when(databasePort.getDatasetDiagrams("dataset")).thenReturn(new ConcurrentHashMap<>());
+
+        service.removeFromAllDiagrams(graphIdentifier, classId);
+
+        verify(graph).commit("removed class from all diagrams");
+    }
+
+    @Test
+    void deleteCustomGraphDiagram_namesTheDiagramInTheChangeLogWithoutItsUuid() {
+        var diagramId = UUID.randomUUID();
+        var map = new ConcurrentHashMap<UUID, CustomDiagram>();
+        map.put(diagramId, new CustomDiagram(diagramId, "Overview", new ArrayList<>()));
+
+        var graph = mockGraph(map);
+        when(databasePort.getGraphWithContext(graphIdentifier)).thenReturn(graph);
+
+        service.deleteCustomGraphDiagram(graphIdentifier, diagramId.toString());
+
+        verify(graph).commit("deleted diagram \"Overview\"");
+    }
+
     private GraphContext mockGraph(ConcurrentHashMap<UUID, CustomDiagram> diagrams) {
+        return mockGraph(diagrams, GraphFactory.createDefaultGraph());
+    }
+
+    private GraphContext mockGraph(
+            ConcurrentHashMap<UUID, CustomDiagram> diagrams, Graph rdfGraph) {
         GraphContext graph = mock(GraphContext.class);
         when(graph.begin(any(ReadWrite.class))).thenReturn(graph);
         when(graph.getCustomDiagrams()).thenReturn(diagrams);
+        when(graph.getRdfGraph()).thenReturn(rdfGraph);
         return graph;
+    }
+
+    /** A graph holding a single labelled class, the way the changelog messages look it up. */
+    private Graph graphWithClass(UUID classId, String label) {
+        var rdfGraph = GraphFactory.createDefaultGraph();
+        var classNode = NodeFactory.createURI("http://example.org#" + label);
+        rdfGraph.add(classNode, RDFS.label.asNode(), NodeFactory.createLiteralString(label));
+        rdfGraph.add(
+                classNode, RDFA.uuid.asNode(), NodeFactory.createLiteralString(classId.toString()));
+        return rdfGraph;
     }
 }

--- a/backend/src/test/java/org/rdfarchitect/services/update/UpdateClassServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/UpdateClassServiceTest.java
@@ -286,6 +286,47 @@ class UpdateClassServiceTest {
                 .removeFromAllDiagrams(any(GraphIdentifier.class), any(UUID.class));
     }
 
+    @Test
+    void addClass_namesTheClassInTheChangeLogWithoutItsUuid() {
+        var packageDTO =
+                PackageDTO.builder()
+                        .uuid(UUID.randomUUID())
+                        .prefix(PREFIX)
+                        .label("default")
+                        .build();
+
+        updateClassService.addClass(graphIdentifier, packageDTO, PREFIX, "newClass", null);
+
+        assertThat(latestChangeMessage()).isEqualTo("Added class \"newClass\"");
+    }
+
+    @Test
+    void replaceClass_namesTheClassInTheChangeLogWithoutItsUuid() {
+        var newClass =
+                ClassUMLAdaptedDTO.builder()
+                        .uuid(UUID.fromString(CLASS_UUID))
+                        .prefix(PREFIX)
+                        .label("newClass")
+                        .build();
+
+        updateClassService.replaceClass(graphIdentifier, newClass);
+
+        assertThat(latestChangeMessage()).isEqualTo("Updated class \"newClass\"");
+    }
+
+    @Test
+    void deleteClass_namesTheClassInTheChangeLogWithoutItsUuid() {
+        updateClassService.deleteClass(graphIdentifier, UUID.fromString(CLASS_UUID));
+
+        assertThat(latestChangeMessage()).isEqualTo("Deleted class \"oldLabel\"");
+    }
+
+    private String latestChangeMessage() {
+        try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.READ)) {
+            return ctx.getChangeLog().getUndoHistory().getFirst().getMessage();
+        }
+    }
+
     /** Referencing a uri that nothing defines makes it a referenced only resource with a uuid. */
     private UUID addReferencedOnlyResource(String label) {
         try (var ctx = databasePort.getGraphWithContext(graphIdentifier).begin(ReadWrite.WRITE)) {

--- a/backend/src/test/java/org/rdfarchitect/services/update/UpdatePackageServiceTest.java
+++ b/backend/src/test/java/org/rdfarchitect/services/update/UpdatePackageServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ReadWrite;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
@@ -41,6 +42,7 @@ import org.rdfarchitect.models.cim.data.dto.relations.RDFSComment;
 import org.rdfarchitect.models.cim.data.dto.relations.RDFSLabel;
 import org.rdfarchitect.models.cim.data.dto.relations.uri.URI;
 import org.rdfarchitect.models.cim.queries.update.CIMUpdates;
+import org.rdfarchitect.models.cim.relations.model.CIMResourceUtils;
 import org.rdfarchitect.rdf.graph.DeltaCompressible;
 import org.rdfarchitect.rdf.graph.wrapper.GraphRewindable;
 import org.rdfarchitect.services.dl.update.packagelayout.UpdatePackageLayoutService;
@@ -196,18 +198,44 @@ class UpdatePackageServiceTest {
     }
 
     @Test
-    void deletePackage_validUuid_deletesPackageAndRecordsChange() {
+    void deletePackage_validUuid_deletesPackageAndRecordsChangeWithLabel() {
         var graphIdentifier = new GraphIdentifier("default", "test");
         UUID packageUuid = UUID.randomUUID();
 
-        try (MockedStatic<CIMUpdates> mockedStatic = mockStatic(CIMUpdates.class)) {
+        try (MockedStatic<CIMUpdates> mockedStatic = mockStatic(CIMUpdates.class);
+                MockedStatic<CIMResourceUtils> mockedResourceUtils =
+                        mockStatic(CIMResourceUtils.class)) {
+            stubPackageLabel(mockedResourceUtils, packageUuid, "somePackage");
+
             service.deletePackage(graphIdentifier, packageUuid);
 
             mockedStatic.verify(
                     () -> CIMUpdates.deletePackage(eq(mockGraph), any(), eq(packageUuid)));
         }
 
-        verify(mockGraphWithContext).commit("Deleted package " + packageUuid);
+        verify(mockGraphWithContext).commit("Deleted package somePackage");
+        verify(mockGraphWithContext).close();
+    }
+
+    @Test
+    void deletePackage_packageNotInGraph_recordsChangeWithoutName() {
+        var graphIdentifier = new GraphIdentifier("default", "test");
+        UUID packageUuid = UUID.randomUUID();
+
+        try (MockedStatic<CIMUpdates> mockedStatic = mockStatic(CIMUpdates.class);
+                MockedStatic<CIMResourceUtils> mockedResourceUtils =
+                        mockStatic(CIMResourceUtils.class)) {
+            mockedResourceUtils
+                    .when(() -> CIMResourceUtils.findResourceForUuid(mockGraph, packageUuid))
+                    .thenThrow(new IllegalStateException("no resource"));
+
+            service.deletePackage(graphIdentifier, packageUuid);
+
+            mockedStatic.verify(
+                    () -> CIMUpdates.deletePackage(eq(mockGraph), any(), eq(packageUuid)));
+        }
+
+        verify(mockGraphWithContext).commit("Deleted package");
         verify(mockGraphWithContext).close();
     }
 
@@ -216,7 +244,10 @@ class UpdatePackageServiceTest {
         var graphIdentifier = new GraphIdentifier("default", "test");
         UUID packageUuid = UUID.randomUUID();
 
-        try (MockedStatic<CIMUpdates> mockedStatic = mockStatic(CIMUpdates.class)) {
+        try (MockedStatic<CIMUpdates> mockedStatic = mockStatic(CIMUpdates.class);
+                MockedStatic<CIMResourceUtils> mockedResourceUtils =
+                        mockStatic(CIMResourceUtils.class)) {
+            stubPackageLabel(mockedResourceUtils, packageUuid, "somePackage");
             mockedStatic
                     .when(() -> CIMUpdates.deletePackage(any(), any(), any(UUID.class)))
                     .thenThrow(new RuntimeException("boom"));
@@ -226,5 +257,17 @@ class UpdatePackageServiceTest {
 
             verify(mockGraphWithContext).close();
         }
+    }
+
+    private void stubPackageLabel(
+            MockedStatic<CIMResourceUtils> mockedResourceUtils, UUID packageUuid, String label) {
+        var packageResource = mock(Resource.class);
+        when(packageResource.hasProperty(RDFS.label)).thenReturn(true);
+        mockedResourceUtils
+                .when(() -> CIMResourceUtils.findResourceForUuid(mockGraph, packageUuid))
+                .thenReturn(packageResource);
+        mockedResourceUtils
+                .when(() -> CIMResourceUtils.findLabelForResource(packageResource))
+                .thenReturn(label);
     }
 }


### PR DESCRIPTION
## Summary

Every commit message that named a resource appended its UUID, and the changelog shows those messages verbatim - editing a class produced entries like Updated class "Breaker" (0f0e9b1c-...). Packages and custom diagrams were worse: they were identified by UUID alone.

Resources now appear by label, which is what the user recognises:

- classes, attributes, associations and enum entries drop the trailing UUID
- a replaced package is named by its label instead of its UUID
- a deleted package is looked up before the delete, so its label survives into the message; a package that is not in the graph is left unnamed rather than failing the deletion
- diagrams are named by their name, and the classes removed from them by their label, looked up in the RDF graph since ClassInDiagram only holds a UUID. A class that is already gone - deleting it is what removes it from every diagram
  - stays unnamed

Two messages passed the RDFSLabel object where the format string expected text, so "Added class" and "Created attribute" rendered the whole Lombok toString. They use the label value now.

## Related Issues

Closes #173

## Checklist

- [x] Tests added or updated (or not applicable)
- [x] Documentation updated (or not applicable)
- [x] No breaking changes introduced (or described in the summary above)
- [x] Commits are signed off (`git commit -s`) for DCO

## Testing Notes

<!-- Describe what you tested manually and which areas you covered.
     See the [feature checklist](.github/FEATURE_CHECKLIST.md) for reference. -->
